### PR TITLE
(feat): Change HttpOnly for accesToken

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -48,9 +48,9 @@ fun Route.auth(userService: UsersService, tokenService: TokenService) {
                     name = "accessToken",
                     value = accessTokenResponse,
                     maxAge = 15 * 60, // 15 minutos en segundos
-                    httpOnly = true, // No accesible desde JavaScript
+                    httpOnly = false, // No accesible desde JavaScript
                     secure = false, // Cambiar a true en producción con HTTPS
-                    path = "/"
+                    path = "/",
             )
     )
 
@@ -61,7 +61,7 @@ fun Route.auth(userService: UsersService, tokenService: TokenService) {
                     maxAge = 30 * 24 * 60 * 60, // 30 días en segundos
                     httpOnly = true, // No accesible desde JavaScript
                     secure = false, // Cambiar a true en producción con HTTPS
-                    path = "/"
+                    path = "/",
             )
     )
 
@@ -98,7 +98,7 @@ fun Route.auth(userService: UsersService, tokenService: TokenService) {
                       name = "accessToken",
                       value = newAccessToken,
                       maxAge = 15 * 60, // 15 minutos
-                      httpOnly = true,
+                      httpOnly = false,
                       secure = false, // Cambiar a true en producción
                       path = "/"
               )


### PR DESCRIPTION
This pull request modifies cookie settings in the `auth` function of `Authorize.kt`. The changes primarily affect the `httpOnly` attribute and formatting of the `path` attribute in cookie definitions.

Cookie attribute adjustments:

* Updated `httpOnly` attribute from `true` to `false` for the `accessToken` cookie, making it accessible from JavaScript. [[1]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL51-R53) [[2]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL101-R101)

Formatting changes:

* Added a trailing comma to the `path` attribute in multiple cookie definitions for consistency. [[1]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL51-R53) [[2]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL64-R64)