### PR TITLE
feat: Add endpoint to retrieve tables by space ID

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Tables.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Tables.kt
@@ -31,6 +31,19 @@ fun Route.tables(tableService: TableService) {
         }
         call.respond(HttpStatusCode.OK, tables)
     }
+    get("/by-space/{id}") {
+        val id = call.parameters["id"]
+        if (id != null) {
+            val tables = tableService.getTablesBySpace(spaceId = id)
+            if (tables.isNotEmpty()) {
+                call.respond(HttpStatusCode.OK, tables)
+            } else {
+                call.respond(HttpStatusCode.NoContent, "No tables found for space ID: $id")
+            }
+        } else {
+            call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+        }
+    }
     get("/{id}") {
         val id = call.parameters["id"]
         if (id != null) {


### PR DESCRIPTION
This pull request adds a new endpoint to the `Tables` API to retrieve tables by space ID, improving the API's functionality for space-specific queries.

New API functionality:

* [`server/app/src/main/kotlin/pos/ambrosia/api/Tables.kt`](diffhunk://#diff-8d8c8c496439eb425f96e136825054b30d189b4ae83acec6b31b21e04f84b944R34-R46): Added a `GET /by-space/{id}` endpoint to fetch tables associated with a specific space ID. The endpoint handles cases where the ID is missing, malformed, or returns no results, responding with appropriate HTTP status codes (`BadRequest`, `NoContent`, or `OK`).