### PR TITLE
Refactor authenticateAdmin

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/util/AuthUtils.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/AuthUtils.kt
@@ -31,20 +31,11 @@ fun ApplicationCall.getCurrentUser(): UserInfo? {
 /**
  * Función de extensión para crear rutas que requieren autenticación y privilegios de administrador
  */
-val AdminOnlyPlugin = createRouteScopedPlugin("AdminOnlyPlugin") {
-    onCall { call ->
-        // La lógica que antes estaba en el interceptor ahora vive aquí.
-        call.requireAdmin()
-    }
-}
-
-/** Función de extensión para crear rutas que requieren autenticación y privilegios de administrador */
 fun Route.authenticateAdmin(name: String = "auth-jwt", build: Route.() -> Unit): Route {
-    return authenticate(name) {
-        // 2. Instalamos el plugin en el bloque de la ruta autenticada.
-        install(AdminOnlyPlugin)
-        build()
-    }
+  return authenticate(name) {
+    intercept(ApplicationCallPipeline.Call) { call.requireAdmin() }
+    build()
+  }
 }
 
 /** Data class para representar información básica del usuario */


### PR DESCRIPTION
This pull request refactors the way admin-only route protection is implemented in the authentication utilities. The main change is the removal of the custom `AdminOnlyPlugin` in favor of directly intercepting the call pipeline to enforce admin privileges.

Authentication and route protection:

* Removed the `AdminOnlyPlugin` and replaced its usage in the `authenticateAdmin` route extension with a direct call to `intercept(ApplicationCallPipeline.Call) { call.requireAdmin() }`, simplifying the admin authentication logic.