### PR TITLE
Fix: Role password encrption on update

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -60,7 +60,7 @@ fun Route.roles(roleService: RolesService) {
       }
 
       val updatedRole = call.receive<Role>()
-      val isUpdated = roleService.updateRole(updatedRole.copy(id = id))
+      val isUpdated = roleService.updateRole(id, updatedRole)
       logger.info(isUpdated.toString())
 
       if (!isUpdated) {

--- a/server/app/src/main/kotlin/pos/ambrosia/util/PinHasher.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/PinHasher.kt
@@ -24,14 +24,14 @@ object SecurePinProcessor {
   private const val ITERATION_COUNT = 10000
   private const val KEY_LENGTH = 256
 
-  fun hashPinForStorage(pin: CharArray, userName: String): ByteArray {
+  fun hashPinForStorage(pin: CharArray, id: String): ByteArray {
     try {
       val appMasterKey = getAppMasterKey()
       if (appMasterKey.isEmpty()) {
         throw IllegalStateException("App Master Key no cargada o está vacía.")
       }
 
-      val combinedSalt = (appMasterKey.plus(userName.toByteArray(Charsets.UTF_8)))
+      val combinedSalt = (appMasterKey.plus(id.toByteArray(Charsets.UTF_8)))
 
       val spec = PBEKeySpec(pin, combinedSalt, ITERATION_COUNT, KEY_LENGTH)
       val factory = SecretKeyFactory.getInstance(HASH_ALGORITHM)


### PR DESCRIPTION
This pull request updates the role management logic to improve consistency in how role IDs are handled and enhances password encryption by ensuring the correct identifier is used as a salt. The main changes affect the `RolesService` and related API routes, focusing on how roles are updated and how PINs are hashed for secure storage.

**Role update logic and API changes:**

* The `updateRole` method in `RolesService` now takes both `id` and `role` as parameters, ensuring the correct ID is used during updates and preventing updates if the ID is missing. The API route is updated accordingly to pass the ID explicitly. [[1]](diffhunk://#diff-1946076addf9ae68ee30fb137228c8cf84daf5458745964cc0ef6628f6093717L63-R63) [[2]](diffhunk://#diff-34781a5e38813e2d33fed590bb0b27c941f0995414bd4527623775ab8ba536dbL96-R113)

**Password encryption improvements:**

* The PIN hashing logic in `SecurePinProcessor.hashPinForStorage` now uses the role's ID as the salt instead of the role name, improving security and consistency. All related calls in the service are updated to use the ID. [[1]](diffhunk://#diff-17cfc50da4020e281bfa5040777a62004bc4c35c2bbd217e8880922cbfa40cbfL27-R34) [[2]](diffhunk://#diff-34781a5e38813e2d33fed590bb0b27c941f0995414bd4527623775ab8ba536dbL35-R35) [[3]](diffhunk://#diff-34781a5e38813e2d33fed590bb0b27c941f0995414bd4527623775ab8ba536dbL96-R113)

**General code improvements:**

* The API and service code now consistently use base64-encoded encrypted PINs for storage, ensuring secure handling of sensitive data.