### PR TITLE
(fix): fix dir for npm and node #150

### DIFF
--- a/scripts/install-client.sh
+++ b/scripts/install-client.sh
@@ -98,13 +98,16 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 fi
 
 NPM_EXEC_PATH=$(which npm)
+NPM_DIR=$(dirname "$NPM_EXEC_PATH")
+NODE_EXEC_PATH=$(which node)
+NODE_DIR=$(dirname "$NODE_EXEC_PATH")
+
 if [ -z "$NPM_EXEC_PATH" ]; then
     echo "❌ Could not find npm executable."
     exit 1
 fi
 
 echo "Creating systemd service file at $SERVICE_FILE..."
-
 sudo tee "$SERVICE_FILE" > /dev/null << EOF
 [Unit]
 Description=Ambrosia POS Client (Next.js)
@@ -113,6 +116,8 @@ After=network.target
 [Service]
 User=$USER
 WorkingDirectory=$INSTALL_DIR
+Environment=PATH=$NPM_DIR:$NODE_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NODE_ENV=production
 ExecStart=$NPM_EXEC_PATH start
 Restart=always
 RestartSec=10


### PR DESCRIPTION
#150
This pull request updates the `scripts/install-client.sh` installation script to improve how the systemd service for the Ambrosia POS Client is configured. The main changes focus on ensuring the correct environment variables are set for the service, which helps guarantee that the service uses the appropriate `npm` and `node` executables and runs in production mode.

**Systemd service environment improvements:**

* Added logic to determine the directory paths for both the `npm` and `node` executables, storing them in `NPM_DIR` and `NODE_DIR` respectively.
* Updated the systemd service file to set the `PATH` environment variable to include the directories for `npm` and `node`, ensuring the service can reliably find these executables.
* Added the `NODE_ENV=production` environment variable to the systemd service configuration, so the client runs in production mode.