### PR TITLE
Docker support

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -74,6 +74,25 @@ curl -fsSL https://raw.githubusercontent.com/btcgdl/Ambrosia-POS/master/scripts/
 ```
 
 ## Development Scripts
+
+### docker-compose with all 3 images (phoenixd, ambrosia, and ambrosia-client)
+To set up the entire docker-compose environment (including installing dependencies if not already installed):
+
+This command will optionally build the client and server docker images (required on first run)
+```sh
+make run-rebuild
+```
+
+This command will only rebuild the server jar and restart any containers whose images have been rebuilt:
+```sh
+make run
+```
+
+Command for rebuilding the server image without rebuilding the other containers (useful for rapid development on the server Kotlin code):
+```sh
+cd server/ && ./gradlew jar && cd .. && docker-compose build ambrosia && make run
+```
+
 ### Server (Backend - Kotlin/Gradle)
 
 To run the server in development mode, go to the `server/` directory and run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-jdk install-docker install-docker-compose build-jar up run run-rebuild
+.PHONY: install-jdk install-docker install-docker-compose build-jar up run run-rebuild create-secrets
 
 install-jdk:
 	@if ! command -v java > /dev/null 2>&1 || ! java -version 2>&1 | grep -q "21"; then \
@@ -39,10 +39,14 @@ install-docker-compose:
 build-jar:
 	cd server && ./gradlew jar
 
+create-secrets:
+	mkdir -p ~/.phoenix
+	touch ~/.phoenix/seed.dat
+
 up:
 	docker-compose up $(if $(REBUILD),--build)
 
-run: install-jdk install-docker install-docker-compose build-jar up
+run: install-jdk install-docker install-docker-compose build-jar create-secrets up
 
 run-rebuild: REBUILD=1
 run-rebuild: run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: install-jdk install-docker install-docker-compose build-jar up run
+
+install-jdk:
+	@if ! command -v java > /dev/null 2>&1 || ! java -version 2>&1 | grep -q "21"; then \
+		echo "Installing OpenJDK 21..."; \
+		sudo apt update; \
+		sudo apt install -y openjdk-21-jdk; \
+		echo "OpenJDK 21 installed."; \
+	else \
+		echo "OpenJDK 21 already available."; \
+	fi
+
+install-docker:
+	@if ! command -v docker > /dev/null 2>&1; then \
+		echo "Installing Docker..."; \
+		sudo apt update; \
+		sudo apt install -y docker.io; \
+		sudo systemctl start docker; \
+		sudo systemctl enable docker; \
+		echo "Docker installed and started."; \
+	else \
+		echo "Docker already available."; \
+	fi
+
+install-docker-compose:
+	@if ! command -v docker-compose > /dev/null 2>&1; then \
+		echo "Installing docker-compose..."; \
+		sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$$(uname -s)-$$(uname -m)" -o /usr/local/bin/docker-compose; \
+		sudo chmod +x /usr/local/bin/docker-compose; \
+		echo "docker-compose installed."; \
+	else \
+		echo "docker-compose already installed."; \
+	fi
+
+build-jar:
+	cd server && ./gradlew jar
+
+up:
+	docker-compose up
+
+run: install-jdk install-docker install-docker-compose build-jar up

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+ENV NODE_ENV=production
+RUN npm run build
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,21 @@ services:
       - phoenixd_datadir:/root/.phoenix
     depends_on:
       - phoenixd
-    # command: ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar"]
+  ambrosia-client:
+    build: client/
+    image: ambrosia-client
+    container_name: ambrosia-client
+    restart: unless-stopped
+    networks:
+      - default
+    volumes:
+      - ambrosia_datadir:/root/.Ambrosia-POS
+    depends_on:
+      - ambrosia
+    ports:
+      - "3000:3000"
+    environment:
+        NEXT_PUBLIC_API_URL: http://ambrosia:9154
 volumes:
   phoenixd_datadir:
   ambrosia_datadir:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  phoenixd:
+    image: acinq/phoenixd:latest
+    container_name: phoenixd
+    restart: unless-stopped
+    networks:
+      - default
+    command: "--seed-path=/run/secrets/phoenixd_seed"
+    expose:
+      - "9740"
+    volumes:
+      - "phoenixd_datadir:/phoenix/.phoenix"
+    secrets:
+      - phoenixd_seed
+  ambrosia:
+    build: server/
+    image: ambrosia
+    container_name: ambrosia
+    restart: unless-stopped
+    networks:
+      - default
+    volumes:
+      - ambrosia_datadir:/root/.Ambrosia-POS
+      - phoenixd_datadir:/root/.phoenix
+    depends_on:
+      - phoenixd
+    # command: ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar"]
+volumes:
+  phoenixd_datadir:
+  ambrosia_datadir:
+secrets:
+  phoenixd_seed:
+    file: ~/.phoenix/seed.dat
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,13 @@ services:
     restart: unless-stopped
     networks:
       - default
-    command: "--seed-path=/run/secrets/phoenixd_seed"
+    # Removed: command (let it use default seed path)
+    # Removed: secrets
     expose:
       - "9740"
     volumes:
-      - "phoenixd_datadir:/phoenix/.phoenix"
-    secrets:
-      - phoenixd_seed
+      - phoenixd_datadir:/root/.phoenix  # Mount to default $HOME/.phoenix for auto-generation
+
   ambrosia:
     build: server/
     image: ambrosia
@@ -21,9 +21,10 @@ services:
       - default
     volumes:
       - ambrosia_datadir:/root/.Ambrosia-POS
-      - phoenixd_datadir:/root/.phoenix
+      - phoenixd_datadir:/root/.phoenix  # Shares the persisted phoenix dir (incl. seed)
     depends_on:
       - phoenixd
+
   ambrosia-client:
     build: client/
     image: ambrosia-client
@@ -38,11 +39,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-        NEXT_PUBLIC_API_URL: http://ambrosia:9154
-volumes:
-  phoenixd_datadir:
-  ambrosia_datadir:
-secrets:
-  phoenixd_seed:
-    file: ~/.phoenix/seed.dat
+      NEXT_PUBLIC_API_URL: http://ambrosia:9154
 
+volumes:
+  phoenixd_datadir:  # Docker-managed; auto-creates on first run
+  ambrosia_datadir:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,8 +3,8 @@ FROM openjdk:21-jdk-slim
 WORKDIR /build
 COPY . .
 
-RUN mkdir /root/.Ambrosia-POS && echo 'http-bind-ip=0.0.0.0' >> /root/.Ambrosia-POS/ambrosia.conf
+# comment this line for faster builds, requires the user to manually invoke `./gradlew jar` outside docker build
 RUN ./gradlew jar
 EXPOSE 9154
 
-ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar"]
+ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar", "--phoenixd-url=http://phoenixd:9740", "--http-bind-ip=0.0.0.0"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /build
 COPY . .
 
 # comment this line for faster builds, requires the user to manually invoke `./gradlew jar` outside docker build
-RUN ./gradlew jar
+# conversely, uncomment if you just want to do `docker build` without using `make run` or `make run-rebuild`
+# RUN ./gradlew jar
 EXPOSE 9154
 
 ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar", "--phoenixd-url=http://phoenixd:9740", "--http-bind-ip=0.0.0.0"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,12 +1,10 @@
 FROM openjdk:21-jdk-slim
 
-RUN apt update && apt install net-tools
-
 WORKDIR /build
 COPY . .
 
 RUN mkdir /root/.Ambrosia-POS && echo 'http-bind-ip=0.0.0.0' >> /root/.Ambrosia-POS/ambrosia.conf
-# RUN ./gradlew jar
+RUN ./gradlew jar
 EXPOSE 9154
 
 ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:21-jdk-slim
+
+RUN apt update && apt install net-tools
+
+WORKDIR /build
+COPY . .
+
+RUN mkdir /root/.Ambrosia-POS && echo 'http-bind-ip=0.0.0.0' >> /root/.Ambrosia-POS/ambrosia.conf
+# RUN ./gradlew jar
+EXPOSE 9154
+
+ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.1.2-alpha.jar"]

--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -31,8 +31,6 @@ class Api() {
   }
 
   fun Application.module() {
-
-    AppConfig.loadConfig() // Load custom config
     blockingAddUser() // Add default user if there are no users
     // Configure the application
     val config = this.environment.config

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -23,7 +23,7 @@ import pos.ambrosia.models.RolePassword
 
 fun Application.configureWallet() {
   val connection: Connection = DatabaseConnection.getConnection()
-  val phoenixService = PhoenixService()
+  val phoenixService = PhoenixService(environment)
   val authService = AuthService(connection)
   val tokenService = TokenService(environment, connection)
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -17,7 +17,7 @@ import pos.ambrosia.models.Phoenix.*
 import pos.ambrosia.utils.*
 
 /** Service for interacting with Phoenix Lightning node */
-class PhoenixService(private val phoenixUrl: String = "http://localhost:9740") {
+class PhoenixService(private val phoenixUrl: String = "http://phoenixd:9740") {
   private val httpClient =
           HttpClient(CIO) {
             install(Auth) {


### PR DESCRIPTION
Adds support for docker

Todo:

- [x] Dockerfile for client + add client to docker-compose
- [x] Ability to set phoenixd-url programmatically rather than hardcode
- [x] Precompile client so it's ready for use rather than compiling on-the-fly
- [x] Add `make run` and `make run-rebuild` to install all the dependencies for docker-compose and optionally build all the images, then run them with `docker-compose up` or `docker-compose up --build`
- [x] Add documentation for `make run` 

For later:
- [ ] Multiarchitecture docker image for optimal image size
- [ ] Cache server image gradle build so we don't recompile from scratch every time