### PR TITLE
refactor: remove unused import for authenticateWallet in Wallet.kt

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -18,7 +18,6 @@ import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.AuthService
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.authenticateAdmin
-import pos.ambrosia.utils.authenticateWallet
 import pos.ambrosia.utils.getCurrentUser
 import pos.ambrosia.models.RolePassword
 


### PR DESCRIPTION
This pull request makes a minor update to the import statements in `server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt`. The change removes an unused import, helping to keep the code clean and maintainable. 

* Removed the unused `authenticateWallet` import from `pos.ambrosia.utils` in `Wallet.kt`.