### PR TITLE
fix: update phoenixd volume path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     expose:
       - "9740"
     volumes:
-      - phoenixd_datadir:/root/.phoenix  # Mount to default $HOME/.phoenix for auto-generation
+      - phoenixd_datadir:/phoenix/.phoenix  # Mount to default $HOME/.phoenix for auto-generation
 
   ambrosia:
     build: server/


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file, specifically adjusting the mount path for the `phoenixd` service's volume. The path has been changed to ensure the `.phoenix` data directory is mounted at `/phoenix/.phoenix` instead of `/root/.phoenix`, to match changes in the container's expected home directory or to improve clarity.