### PR TITLE
make server docker image smaller

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /build
-COPY . .
+COPY ./app/build/libs/ambrosia-0.1.2-alpha.jar ./app/build/libs/ambrosia-0.1.2-alpha.jar
 
 # comment this line for faster builds, requires the user to manually invoke `./gradlew jar` outside docker build
 # conversely, uncomment if you just want to do `docker build` without using `make run` or `make run-rebuild`


### PR DESCRIPTION
This makes the server image `ambrosia` smaller.

It was 1.21GB, now it is 266MB.

```
2025-09-18 18:25:27 cguida@cg-carbon:~/code/Ambrosia-POS$ docker images
REPOSITORY                        TAG                                                IMAGE ID       CREATED              SIZE
ambrosia                          latest                                             73dc09e4e14a   About a minute ago   266MB
<none>                            <none>                                             1e89c3a6941d   About an hour ago    1.21GB
```