### PR TITLE
make client image smaller

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,15 @@
-FROM node:22
+# Build stage
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY . .
+RUN NO_ZIP=1 ./package-client.sh
+
+# Runtime stage
+FROM node:22-slim AS runtime
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
-COPY . .
 ENV NODE_ENV=production
-RUN npm run build
+RUN npm i --omit=dev && npm cache clean --force
+COPY --from=builder /tmp/ambrosia-client-dist/ .
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/client/package-client.sh
+++ b/client/package-client.sh
@@ -2,8 +2,6 @@
 set -e
 
 TAG="0.1.2-alpha"
-# Navigate to the client directory
-cd "$(dirname "$0")/../client"
 
 echo "=== Packaging Next.js application for distribution ==="
 
@@ -35,19 +33,17 @@ cp generate-env.cjs "/tmp/$PACKAGE_NAME/"
 
 # 4. Copy installation script
 echo "Copying installation script..."
-cp ../scripts/install-client.sh "/tmp/$PACKAGE_NAME/"
 
-# 5. Create compressed file
-DIST_FILE="ambrosia-client-$TAG.tar.gz"
-echo "Creating distribution file: $DIST_FILE..."
-cd /tmp
-tar -czf "$DIST_FILE" "$PACKAGE_NAME"
-cd -
-
-mv "/tmp/$DIST_FILE" ./dist/
-
-# 6. Clean up
-rm -rf "/tmp/$PACKAGE_NAME"
+# 5. Create compressed file if not NO_ZIP=1
+if [ "${NO_ZIP:-0}" != "1" ]; then
+  DIST_FILE="ambrosia-client-$TAG.tar.gz"
+  echo "Creating distribution file: $DIST_FILE..."
+  cd /tmp
+  tar -czf "$DIST_FILE" "$PACKAGE_NAME"
+  cd -
+  # 6. Clean up
+  mv "/tmp/$DIST_FILE" ./dist/
+fi
 
 echo ""
 echo "✅ Packaging complete!"


### PR DESCRIPTION
This shrinks the client image from 2.36GB to 1.2GB

The client build is now multistage to minimize runtime image size.

We move scripts/package-client.sh to client/package-client.sh (to be able to use in the docker build) and add a `NO_ZIP` env var to tell the script to just leave the dist folder in /tmp without deleting it, so we can copy it from the build stage into the run stage. 