### PR TITLE
Use multi-stage build for self-contained server image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,11 +1,32 @@
-FROM eclipse-temurin:21-jre-alpine
+# Build stage - compiles the JAR using Gradle
+FROM eclipse-temurin:21-jdk-alpine AS builder
 
 WORKDIR /build
-COPY ./app/build/libs/ambrosia-0.3.0-alpha.jar ./app/build/libs/ambrosia-0.3.0-alpha.jar
 
-# comment this line for faster builds, requires the user to manually invoke `./gradlew jar` outside docker build
-# conversely, uncomment if you just want to do `docker build` without using `make run` or `make run-rebuild`
-# RUN ./gradlew jar
+# Copy Gradle wrapper and build files first (better layer caching)
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts settings.gradle.kts
+COPY gradle.properties gradle.properties
+COPY app/build.gradle.kts app/build.gradle.kts
+
+# Download dependencies (cached unless build files change)
+RUN ./gradlew dependencies --no-daemon || true
+
+# Copy source code
+COPY app/src app/src
+
+# Build the JAR
+RUN ./gradlew jar --no-daemon
+
+# Runtime stage - slim image with only JRE
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# Copy the built JAR from builder stage
+COPY --from=builder /build/app/build/libs/ambrosia-*.jar ./ambrosia.jar
+
 EXPOSE 9154
 
-ENTRYPOINT ["java", "-jar", "app/build/libs/ambrosia-0.3.0-alpha.jar", "--phoenixd-url=http://phoenixd:9740", "--http-bind-ip=0.0.0.0"]
+ENTRYPOINT ["java", "-jar", "ambrosia.jar", "--phoenixd-url=http://phoenixd:9740", "--http-bind-ip=0.0.0.0"]


### PR DESCRIPTION
This Dockerfile allows to:
* Build the JAR inside Docker (no JDK needed on host)
* Work on a fresh clone (no pre-built JAR required)
* Only needs Docker installed

Once merged you should be able to just run:

```bash
git clone https://github.com/olympus-btc/ambrosia
cd ambrosia
docker-compose up -d
```
then 

```bash
open http://localhost:3000
```

Build time: ~6-7 minutes (downloads JDK, Gradle, dependencies)