### PR TITLE
fix SSL Problem with phoenix.conf and phoenixd

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -97,7 +97,7 @@ class Ambrosia : CliktCommand() {
         help = "webhook URL to register in phoenix.conf (webhook=<url>)"
       )
         .defaultLazy {
-          val value = "https://${httpBindIp}:9443/webhook/phoenixd"
+          val value = "http://${httpBindIp}:9154/webhook/phoenixd"
           value
         }
   }


### PR DESCRIPTION
This pull request updates the default webhook URL configuration in the `Ambrosia` command. The change switches the protocol from HTTPS to HTTP and updates the port number from 9443 to 9154.

Configuration update:

* Changed the default webhook URL in the `Ambrosia` command to use HTTP protocol and port 9154 instead of HTTPS and port 9443 (`Ambrosia.kt`).