### PR TITLE
fix lost items, and acces denied without accesstoken

### DIFF
--- a/client/src/modules/auth/AuthProvider.jsx
+++ b/client/src/modules/auth/AuthProvider.jsx
@@ -18,7 +18,7 @@ export function AuthProvider({ children }) {
     try {
       setIsLoading(true)
 
-      const data = await apiClient("/users/me", { skipRefresh: true, silentAuth: true })
+      const data = await apiClient("/users/me", { silentAuth: true })
 
       setPermissions(data.perms);
       setUser(data.user);


### PR DESCRIPTION
This pull request improves security for authentication cookies by ensuring they are only set with the `secure` flag when the incoming request is made over HTTPS. This change is applied consistently across both the frontend (Next.js API route) and backend (Ktor server) codebases, replacing previous logic that relied solely on environment variables or hardcoded values.

**Frontend (Next.js API route) security improvements:**

- Added a new `isSecureRequest` function in `client/src/app/api/auth/refresh/route.js` to determine if the request is HTTPS, using either the `x-forwarded-proto` header or the request URL protocol. Cookie options now use this function to set the `secure` flag.
- Updated cookie setting logic for both `accessToken` and `refreshToken` in the refresh endpoint to use `useSecureCookies` instead of relying on `process.env.NODE_ENV`. [[1]](diffhunk://#diff-f1836503f5e845a475e242ff2009638c96902f034cf5adfca3214f704d7af234L55-R63) [[2]](diffhunk://#diff-f1836503f5e845a475e242ff2009638c96902f034cf5adfca3214f704d7af234L70-R78)

**Backend (Ktor server) security improvements:**

- Added logic in `server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt` to detect secure requests using the request scheme and `X-Forwarded-Proto` header, and applied this to the `secure` attribute of authentication cookies. [[1]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cR46-R47) [[2]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL65-R68) [[3]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL76-R79) [[4]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cR102-R103) [[5]](diffhunk://#diff-068f77c99fca209df7358f72f6297ec855b362829ba57d6b900dcce26708131cL120-R125)

**Minor cleanup:**

- Removed the unused `skipRefresh` option from the `apiClient` call in `AuthProvider.jsx`.