### PR TITLE
change description to disappear when client pay the invoice

### DIFF
--- a/client/src/components/pages/Store/Cart/BitcoinPaymentModal.jsx
+++ b/client/src/components/pages/Store/Cart/BitcoinPaymentModal.jsx
@@ -77,13 +77,6 @@ export function BitcoinPaymentModal({
     onClose?.();
   };
 
-  const handleComplete = () => {
-    if (!invoice || completedRef.current) return;
-    completedRef.current = true;
-    setPaymentReceived(true);
-    onComplete?.({ invoice, satoshis: satsAmount, paymentId });
-  };
-
   return (
     <Modal isOpen={isOpen} onClose={handleClose} size="lg">
       <ModalContent>
@@ -91,9 +84,11 @@ export function BitcoinPaymentModal({
           <span className="text-base font-semibold text-green-900">
             {t("title")}
           </span>
-          <span className="text-sm text-gray-600">
-            {t("subtitle")}
-          </span>
+          {!paymentReceived &&
+            <span className="text-sm text-gray-600">
+              {t("subtitle")}
+            </span>
+          }
         </ModalHeader>
         <ModalBody className="space-y-4">
           {loading && !paymentReceived && (
@@ -159,15 +154,12 @@ export function BitcoinPaymentModal({
           )}
         </ModalBody>
         <ModalFooter className="flex gap-2">
-          <Button variant="flat" onPress={handleClose}>
-            {t("cancel")}
-          </Button>
           <Button
             color={paymentReceived ? "success" : "primary"}
             isDisabled={loading}
-            onPress={paymentReceived ? handleClose : handleComplete}
+            onPress={handleClose}
           >
-            {paymentReceived ? t("close") : t("confirm")}
+            {paymentReceived ? t("close") : t("cancel")}
           </Button>
         </ModalFooter>
       </ModalContent>


### PR DESCRIPTION
This pull request makes a small update to the `BitcoinPaymentModal` component to simplify its payment confirmation logic and improve the user interface. The main change is the removal of the `handleComplete` function, which previously handled payment confirmation, and the adjustment of modal actions and text to better reflect the payment state.

User interface and logic simplification:

* Removed the `handleComplete` function and updated the button logic to use only `handleClose`, streamlining the modal's behavior for payment confirmation and cancellation.
* Updated the modal footer button text to display "cancel" instead of "confirm" when payment has not been received, and ensured the button always triggers `handleClose`.
* Adjusted the subtitle display so it only appears when payment has not been received, improving clarity for users.