### PR TITLE
fix docker with websocket/hook and fix toast in unauth

### DIFF
--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -135,12 +135,6 @@ async function performTokenRefresh() {
       await performLogout();
       dispatchAuthEvent("auth:expired");
 
-      addToast({
-        color: "warning",
-        title: "Session Expired",
-        description: "Please log in again.",
-      });
-
       return false;
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,10 @@ services:
     restart: unless-stopped
     networks:
       - default
-    # Removed: command (let it use default seed path)
-    # Removed: secrets
     expose:
       - "9740"
     volumes:
-      - phoenixd_datadir:/phoenix/.phoenix  # Mount to default $HOME/.phoenix for auto-generation
+      - phoenixd_datadir:/phoenix/.phoenix 
 
   ambrosia:
     build: server/
@@ -19,9 +17,12 @@ services:
     restart: unless-stopped
     networks:
       - default
+    ports:
+      - "9154:9154"
+      - "9443:9443"
     volumes:
       - ambrosia_datadir:/root/.Ambrosia-POS
-      - phoenixd_datadir:/root/.phoenix  # Shares the persisted phoenix dir (incl. seed)
+      - phoenixd_datadir:/root/.phoenix  
     depends_on:
       - phoenixd
 
@@ -40,7 +41,8 @@ services:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://ambrosia:9154
+      NEXT_PUBLIC_WS_URL: ws://localhost:9154/ws/payments
 
 volumes:
-  phoenixd_datadir:  # Docker-managed; auto-creates on first run
+  phoenixd_datadir: 
   ambrosia_datadir:


### PR DESCRIPTION
This pull request introduces several improvements to configuration and environment handling for the Ambrosia POS system, focusing on better defaults, easier Docker setup, and more robust webhook configuration. The changes streamline the Docker Compose setup, enhance webhook URL resolution, and improve how the Phoenix daemon webhook is managed.

**Docker Compose and Environment Configuration:**

* Added explicit port mappings for the `ambrosia` service and removed commented-out configuration for the `phoenixd` service to simplify setup. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R11) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R20-R25)
* Set the `NEXT_PUBLIC_WS_URL` environment variable for the frontend to enable WebSocket connections to payments.

**Ambrosia POS Webhook Handling:**

* Improved webhook URL defaulting: now uses a helper method to resolve the host based on environment variables or bind IP, preferring the Docker service name `ambrosia` when binding to all interfaces. [[1]](diffhunk://#diff-5a7ccdb98f53f8360c0448d075cfc523bd94ed6eae5a8c559765c97431de8e26L99-R99) [[2]](diffhunk://#diff-5a7ccdb98f53f8360c0448d075cfc523bd94ed6eae5a8c559765c97431de8e26R174-R217)
* Enhanced webhook configuration logic: instead of appending duplicate entries, the code now updates or replaces the `webhook` line in `phoenix.conf`, ensuring only one correct entry is present.

**Frontend Session Handling:**

* Removed the toast notification on session expiration to streamline user experience and avoid redundant alerts.