### PR TITLE
fix port

### DIFF
--- a/client/src/hooks/usePaymentWebsocket.js
+++ b/client/src/hooks/usePaymentWebsocket.js
@@ -33,8 +33,7 @@ export function usePaymentWebsocket() {
       if (apiUrl) return `${apiUrl.replace(/^http/i, "ws")}/ws/payments`;
 
       const host = window.location.hostname;
-      const port =
-        process.env.NEXT_PUBLIC_PORT_API || window.location.port || "9154";
+      const port = process.env.NEXT_PUBLIC_PORT_API || "9154";
       const protocol = window.location.protocol === "https:" ? "wss" : "ws";
       return `${protocol}://${host}${port ? `:${port}` : ""}/ws/payments`;
     };


### PR DESCRIPTION
This pull request makes a small change to the logic that constructs the WebSocket URL in the `usePaymentWebsocket` hook. The change ensures that the port used for the WebSocket connection defaults to `process.env.NEXT_PUBLIC_PORT_API` or `"9154"`, instead of falling back to `window.location.port`.

([client/src/hooks/usePaymentWebsocket.jsL36-R36](diffhunk://#diff-a90bf6248e33e08f203aa4cdb81482553fa311dcec2bee5a3a59957c19829696L36-R36))