### PR TITLE
fix wallet password

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -52,6 +52,12 @@ data class LoginResponse(
 )
 
 @Serializable
+data class WalletAuthResponse(
+  val message: String,
+  val walletTokenExpiresAt: Long,
+)
+
+@Serializable
 data class User(
   val id: String? = null,
   val name: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TokenService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TokenService.kt
@@ -56,7 +56,7 @@ class TokenService(environment: ApplicationEnvironment, private val connection: 
   .withClaim("scope", "wallet_access")
   .withClaim("userId", userId)
   .withClaim("realm", "Ambrosia-Server")
-  .withExpiresAt(Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(2)))
+  .withExpiresAt(Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(8)))
   .sign(algorithm)
 
   fun validateRefreshToken(refreshToken: String): Boolean {


### PR DESCRIPTION
This pull request enhances the wallet authentication flow by improving how client and server handle wallet session expiry. The server now issues wallet access tokens with a longer validity period and communicates the exact expiry timestamp to the client, which uses this to manage session state more reliably. The client restores sessions based on persisted expiry and proactively manages re-authentication before expiry. 

**Wallet session expiry improvements:**

* Server-side wallet access tokens now expire after 8 hours instead of 2 minutes, by updating the expiry duration in `TokenService.generateWalletAccessToken`.
* The `/wallet/auth` endpoint now returns a `WalletAuthResponse` that includes both a message and the token's expiry timestamp (`walletTokenExpiresAt`), and sets the cookie expiry to match the token. [[1]](diffhunk://#diff-6cb7d8b06aa87f6a0453d81985dd67e8f66a928fc196a1729b294877b958f7f2R47-R66) [[2]](diffhunk://#diff-bcea94bd86d271d7c2d0eee3706cb79f1092a37643f91727fdc5d675df7c3ff7R54-R59)

**Client-side session management:**

* The client restores wallet sessions on page load if the local expiry timestamp is still valid, allowing for persistent authentication across reloads.
* The client tracks session expiry using the server-provided timestamp when available, or falls back to 8 hours, and proactively triggers re-authentication slightly before expiry. [[1]](diffhunk://#diff-ebe2712d7f15d9197f7e1d50765f929151629f3c54546a8cebdcb25fec3d2017R38-R39) [[2]](diffhunk://#diff-ebe2712d7f15d9197f7e1d50765f929151629f3c54546a8cebdcb25fec3d2017R92-R119)

**Security enhancements:**

* The server now sets the wallet access cookie as `secure` if the request is made over HTTPS, improving cookie security.