### PR TITLE
Persistant items on cart

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -1,5 +1,4 @@
 "use client";
-import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { StoreLayout } from "../StoreLayout";
 import { SearchProducts } from "./SearchProducts";
@@ -7,17 +6,19 @@ import { Summary } from "./Summary";
 import { useProducts } from "../hooks/useProducts.jsx"
 import { useCategories } from "../hooks/useCategories.jsx"
 import { useCartPayment } from "./hooks/useCartPayment";
+import { usePersistentCart } from "./hooks/usePersistentCart";
 
 export function Cart() {
   const t = useTranslations("cart");
-  const [cart, setCart] = useState([]);
-  const [discount, setDiscount] = useState(0);
+  const {
+    cart,
+    setCart,
+    discount,
+    setDiscount,
+    resetCartState,
+  } = usePersistentCart();
   const { products } = useProducts();
   const { categories } = useCategories();
-  const resetCartState = () => {
-    setCart([]);
-    setDiscount(0);
-  };
 
   const {
     handlePay,

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -4,6 +4,7 @@ import * as useModulesHook from "../../../../../hooks/useModules";
 import * as useAuthHook from "../../../../../modules/auth/useAuth";
 import * as configurationsProvider from "../../../../../providers/configurations/configurationsProvider";
 import { Cart } from "../Cart";
+import { CART_STORAGE_KEY } from "../hooks/usePersistentCart";
 import { PRODUCTS, CART_ITEMS } from "./__mocks__/mocks";
 
 function renderCart() {
@@ -31,6 +32,7 @@ const mockConfig = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   console.warn = (...args) => {
     if (
       typeof args[0] === "string" &&
@@ -119,4 +121,14 @@ describe("Cart page", () => {
     expect(screen.getAllByLabelText("Remove Product")).toHaveLength(1);
   });
 
+  it("hydrates cart from localStorage", async () => {
+    localStorage.setItem(
+      CART_STORAGE_KEY,
+      JSON.stringify({ items: CART_ITEMS, discount: 10 }),
+    );
+    await act(async () => {
+      renderCart();
+    });
+    expect(screen.getAllByLabelText("Remove Product")).toHaveLength(CART_ITEMS.length);
+  });
 });

--- a/client/src/components/pages/Store/Cart/hooks/usePersistentCart.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/usePersistentCart.jsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export const CART_STORAGE_KEY = "store-cart";
+
+export function usePersistentCart() {
+  const [cart, setCart] = useState([]);
+  const [discount, setDiscount] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const saved = window.localStorage.getItem(CART_STORAGE_KEY);
+      if (!saved) return;
+
+      const parsed = JSON.parse(saved);
+      if (Array.isArray(parsed?.items)) {
+        setCart(parsed.items);
+      }
+      const storedDiscount = Number(parsed?.discount);
+      if (Number.isFinite(storedDiscount)) {
+        setDiscount(storedDiscount);
+      }
+    } catch (err) {
+      console.error("Error loading cart from storage", err);
+    } finally {
+      setHydrated(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        CART_STORAGE_KEY,
+        JSON.stringify({ items: cart, discount }),
+      );
+    } catch (err) {
+      console.error("Error saving cart to storage", err);
+    }
+  }, [cart, discount, hydrated]);
+
+  const resetCartState = useCallback(() => {
+    setCart([]);
+    setDiscount(0);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(CART_STORAGE_KEY);
+    } catch (err) {
+      console.error("Error clearing cart storage", err);
+    }
+  }, []);
+
+  return {
+    cart,
+    setCart,
+    discount,
+    setDiscount,
+    resetCartState,
+  };
+}


### PR DESCRIPTION
This pull request introduces persistent cart functionality to the store's cart page, ensuring that cart items and discounts are saved to and loaded from localStorage. This improves the user experience by retaining cart state across page reloads and sessions. The main changes include implementing a new custom hook for cart persistence, updating the cart component to use this hook, and adding related test coverage.

**Persistent cart functionality:**

* Added a new custom hook `usePersistentCart` in `usePersistentCart.jsx` to manage cart state and discount, automatically syncing with `localStorage` and providing a reset method.
* Updated `Cart.jsx` to use `usePersistentCart` instead of local state, enabling cart persistence and simplifying state management in the component.

**Testing and reliability improvements:**

* Added a test to verify that the cart hydrates correctly from `localStorage` when present, ensuring reliability of the persistence feature.
* Ensured `localStorage` is cleared before each test in `Cart.test.jsx` to prevent test pollution and improve test accuracy.
* Imported the `CART_STORAGE_KEY` constant in `Cart.test.jsx` to maintain consistency and avoid magic strings in tests.