### PR TITLE
add test for useOrders

### DIFF
--- a/client/src/components/pages/Store/hooks/__tests__/useOrders.nonArray.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useOrders.nonArray.test.jsx
@@ -1,0 +1,89 @@
+import { act, useEffect } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+
+import { apiClient } from "@/services/apiClient";
+
+import { useOrders } from "../useOrders";
+
+let mockLastSetOrdersResult = null;
+let mockStateCall = 0;
+
+jest.mock("react", () => {
+  const actual = jest.requireActual("react");
+  return {
+    ...actual,
+    useState: (initial) => {
+      mockStateCall += 1;
+      if (mockStateCall === 1) {
+        const setOrdersMock = (updater) => {
+          if (typeof updater === "function") {
+            mockLastSetOrdersResult = updater(null);
+          } else {
+            mockLastSetOrdersResult = updater;
+          }
+        };
+        return [null, setOrdersMock];
+      }
+      return [initial, () => {}];
+    },
+    __resetStateCall: () => {
+      mockStateCall = 0;
+    },
+  };
+});
+
+jest.mock("@/services/apiClient", () => ({
+  apiClient: jest.fn(),
+}));
+
+const handlers = {};
+
+function TestComponent() {
+  const { createOrder, updateOrder } = useOrders();
+
+  useEffect(() => {
+    handlers.createOrder = createOrder;
+    handlers.updateOrder = updateOrder;
+  }, [createOrder, updateOrder]);
+
+  return <div data-testid="ready">ok</div>;
+}
+
+describe("useOrders with non-array previous state", () => {
+  beforeEach(() => {
+    React.__resetStateCall();
+    mockLastSetOrdersResult = null;
+    jest.clearAllMocks();
+  });
+
+  it("uses fallback array when createOrder runs with non-array previous state", async () => {
+    apiClient.mockResolvedValueOnce([]);
+    apiClient.mockResolvedValueOnce({ id: 5, status: "new" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("ready")).toHaveTextContent("ok"));
+
+    await act(async () => {
+      await handlers.createOrder({ note: "test" });
+    });
+
+    expect(mockLastSetOrdersResult).toEqual([{ id: 5, status: "new" }]);
+  });
+
+  it("uses fallback array when updateOrder runs with non-array previous state", async () => {
+    apiClient.mockResolvedValueOnce([]);
+    apiClient.mockResolvedValueOnce({ id: 3, status: "paid" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("ready")).toHaveTextContent("ok"));
+
+    await act(async () => {
+      await handlers.updateOrder(3, { status: "paid" });
+    });
+
+    expect(mockLastSetOrdersResult).toEqual([{ id: 3, status: "paid" }]);
+  });
+});

--- a/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
@@ -1,0 +1,140 @@
+import { act, useEffect } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { apiClient } from "@/services/apiClient";
+
+import { useOrders } from "../useOrders";
+
+jest.mock("@/services/apiClient", () => ({
+  apiClient: jest.fn(),
+}));
+
+const handlers = {};
+
+function TestComponent() {
+  const { orders, loading, error, createOrder, updateOrder } = useOrders();
+
+  useEffect(() => {
+    handlers.createOrder = createOrder;
+    handlers.updateOrder = updateOrder;
+  }, [createOrder, updateOrder]);
+
+  return (
+    <div>
+      <span data-testid="loading">{loading ? "yes" : "no"}</span>
+      <span data-testid="count">{orders.length}</span>
+      <span data-testid="first-status">{orders[0]?.status ?? ""}</span>
+      <span data-testid="error">{error ? "yes" : "no"}</span>
+    </div>
+  );
+}
+
+describe("useOrders", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads orders on mount", async () => {
+    apiClient.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+    expect(screen.getByTestId("error")).toHaveTextContent("no");
+  });
+
+  it("sets error when fetching orders fails", async () => {
+    apiClient.mockRejectedValueOnce(new Error("fetch-fail"));
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("error")).toHaveTextContent("yes");
+  });
+
+  it("sets empty orders when apiClient returns non-array", async () => {
+    apiClient.mockResolvedValueOnce({ data: [] });
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("appends created orders to state", async () => {
+    apiClient.mockResolvedValueOnce([{ id: 1 }]);
+    apiClient.mockResolvedValueOnce({ id: 2 });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await act(async () => {
+      await handlers.createOrder({ note: "test" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("2"));
+  });
+
+  it("does not append when createOrder returns without id", async () => {
+    apiClient.mockResolvedValueOnce([{ id: 1 }]);
+    apiClient.mockResolvedValueOnce({ status: "ok" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await act(async () => {
+      await handlers.createOrder({ note: "test" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+  });
+
+  it("sets error when createOrder fails", async () => {
+    apiClient.mockResolvedValueOnce([]);
+    apiClient.mockRejectedValueOnce(new Error("create-fail"));
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+
+    await expect(handlers.createOrder({ note: "test" })).rejects.toThrow("create-fail");
+    await waitFor(() => expect(screen.getByTestId("error")).toHaveTextContent("yes"));
+  });
+
+  it("updates an order when updateOrder succeeds", async () => {
+    apiClient.mockResolvedValueOnce([{ id: 1, status: "open" }, { id: 2 }]);
+    apiClient.mockResolvedValueOnce({ id: 1, status: "paid" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("2"));
+
+    await act(async () => {
+      await handlers.updateOrder(1, { status: "paid" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("first-status")).toHaveTextContent("paid"));
+  });
+
+  it("sets error when updateOrder fails", async () => {
+    apiClient.mockResolvedValueOnce([{ id: 1, status: "open" }]);
+    apiClient.mockRejectedValueOnce(new Error("update-fail"));
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await expect(handlers.updateOrder(1, { status: "paid" })).rejects.toThrow("update-fail");
+    await waitFor(() => expect(screen.getByTestId("error")).toHaveTextContent("yes"));
+  });
+
+  it("throws when updateOrder is called without an orderId", async () => {
+    apiClient.mockResolvedValueOnce([]);
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+
+    await expect(handlers.updateOrder()).rejects.toThrow("orderId is required");
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `useOrders` hook in the store page, ensuring its correct behavior in both normal and edge cases. The new tests cover the hook’s data fetching, error handling, and state updates, including scenarios where the previous state is not an array.

**Testing for normal and edge cases:**

* Added a new test suite in `useOrders.test.jsx` to verify `useOrders` behavior for standard scenarios, including loading orders, handling API errors, appending and updating orders, and validating error handling for missing or malformed data.
* Added a separate test suite in `useOrders.nonArray.test.jsx` specifically to ensure `useOrders` can recover gracefully when the previous state is not an array, confirming the use of a fallback array in such cases.