### PR TITLE
Fix/store printer

### DIFF
--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
@@ -47,6 +47,8 @@ jest.mock("../../../hooks/useTickets", () => ({
 jest.mock("../../../hooks/usePrinter", () => ({
   usePrinters: () => ({
     printTicket: jest.fn(() => Promise.resolve()),
+    printerConfigs: [{ id: "cfg-1", printerType: "CUSTOMER", enabled: true }],
+    loadingConfigs: false,
   }),
 }));
 

--- a/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
@@ -60,8 +60,7 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
   const hasCustomerPrinter = useMemo(() => {
     if (!Array.isArray(printerConfigs)) return false;
     return printerConfigs.some(
-      (config) =>
-        config?.printerType === "CUSTOMER" && config?.enabled !== false,
+      (config) => config?.printerType === "CUSTOMER" && config?.enabled !== false,
     );
   }, [printerConfigs]);
 

--- a/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
@@ -37,7 +37,7 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
   const t = useTranslations("cart.payment");
   const { user } = useAuth();
   const { currency, formatAmount } = useCurrency();
-  const { printTicket } = usePrinters();
+  const { printTicket, printerConfigs, loadingConfigs } = usePrinters();
   const { paymentMethods } = usePaymentMethods();
   const { createOrder, updateOrder } = useOrders();
   const { createPayment, linkPaymentToTicket, getPaymentCurrencyById } = usePayments();
@@ -57,8 +57,17 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
   const paymentMethodMap = useMemo(
     () => (paymentMethods || []).reduce((acc, method) => { acc[method.id] = method; return acc; }, {}), [paymentMethods]);
 
+  const hasCustomerPrinter = useMemo(() => {
+    if (!Array.isArray(printerConfigs)) return false;
+    return printerConfigs.some(
+      (config) =>
+        config?.printerType === "CUSTOMER" && config?.enabled !== false,
+    );
+  }, [printerConfigs]);
+
   const printCustomerReceipt = useCallback(
     async ({ items, totalCents, ticketId, invoice }) => {
+      if (loadingConfigs || !hasCustomerPrinter) return;
       const ticketData = {
         ticketId: ticketId?.toString() || "",
         tableName: t("receipt.tableName"),
@@ -88,7 +97,7 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
         });
       }
     },
-    [printTicket, t],
+    [hasCustomerPrinter, loadingConfigs, printTicket, t],
   );
 
   const handlePay = useMemo(

--- a/client/src/components/pages/Store/Settings/PrinterSettings/PrinterAddForm.jsx
+++ b/client/src/components/pages/Store/Settings/PrinterSettings/PrinterAddForm.jsx
@@ -34,7 +34,7 @@ export function PrinterAddForm({
         </p>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-[160px_1fr_1fr_auto] lg:items-end">
+      <div className="grid gap-4 lg:grid-cols-3 lg:items-end">
         <Select
           label={t("cardPrinters.typeLabel")}
           value={printerType}
@@ -81,7 +81,7 @@ export function PrinterAddForm({
             ))}
         </Select>
 
-        <div className="flex flex-wrap items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4 lg:col-span-3 lg:justify-end">
           <Switch
             size="sm"
             isSelected={isDefault}

--- a/client/src/components/pages/Store/Settings/PrinterSettings/PrinterConfigRow.jsx
+++ b/client/src/components/pages/Store/Settings/PrinterSettings/PrinterConfigRow.jsx
@@ -56,7 +56,7 @@ export function PrinterConfigRow({
         </Select>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3 lg:min-w-[240px]">
         <Switch
           size="sm"
           isSelected={config.isDefault}

--- a/client/src/components/pages/Store/Settings/PrinterSettings/PrinterSettingsCard.jsx
+++ b/client/src/components/pages/Store/Settings/PrinterSettings/PrinterSettingsCard.jsx
@@ -21,6 +21,7 @@ export function PrinterSettingsCard({
   updatePrinterConfig,
   deletePrinterConfig,
   setDefaultPrinterConfig,
+  onTemplatesRefresh,
   t,
 }) {
   const [printerType, setPrinterType] = useState("KITCHEN");
@@ -71,6 +72,11 @@ export function PrinterSettingsCard({
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleTemplatesClose = () => {
+    setTemplatesModalOpen(false);
+    onTemplatesRefresh?.();
   };
 
   return (
@@ -163,7 +169,7 @@ export function PrinterSettingsCard({
       {templatesModalOpen && (
         <TicketTemplatesModal
           isOpen={templatesModalOpen}
-          onClose={() => setTemplatesModalOpen(false)}
+          onClose={handleTemplatesClose}
         />
       )}
     </>

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -34,7 +34,7 @@ export function Settings() {
     deletePrinterConfig,
     setDefaultPrinterConfig,
   } = usePrinters();
-  const { templates, loading: loadingTemplates } = useTemplates();
+  const { templates, loading: loadingTemplates, refetch: refetchTemplates } = useTemplates();
   const [data, setData] = useState(config);
   const [editSettingsShowModal, setEditSettingsShowModal] = useState(false);
   const t = useTranslations("settings");
@@ -178,6 +178,7 @@ export function Settings() {
             updatePrinterConfig={updatePrinterConfig}
             deletePrinterConfig={deletePrinterConfig}
             setDefaultPrinterConfig={setDefaultPrinterConfig}
+            onTemplatesRefresh={refetchTemplates}
             t={t}
           />
 


### PR DESCRIPTION
This pull request introduces enhancements to the printer configuration and payment flow in the store's cart and settings pages. The main changes improve how customer receipt printing is handled, update UI layouts for printer settings, and ensure ticket templates are refreshed when relevant modals are closed.

**Printer Configuration and Payment Logic:**

- Added logic in `useCartPayment` to check for enabled customer printers (`printerConfigs`) before attempting to print customer receipts, preventing unnecessary print attempts when no suitable printer is available. Also, now considers loading state for printer configs. [[1]](diffhunk://#diff-9d3ae3562d06ee2b2edb78e818466879aa11b1e288472cb9bf2ad3725a27a1bdL40-R40) [[2]](diffhunk://#diff-9d3ae3562d06ee2b2edb78e818466879aa11b1e288472cb9bf2ad3725a27a1bdR60-R70) [[3]](diffhunk://#diff-9d3ae3562d06ee2b2edb78e818466879aa11b1e288472cb9bf2ad3725a27a1bdL91-R100) [[4]](diffhunk://#diff-0a8f37d3c0da605f3c6b84e82cacecd3029df51ef27827c549109494348748f2R50-R51)

**Printer Settings UI Improvements:**

- Updated grid layouts in `PrinterAddForm` and `PrinterConfigRow` to improve responsiveness and alignment, particularly for controls and switches in the printer settings UI. [[1]](diffhunk://#diff-0ad2866e775244c459df41f7157842f220c945c3bda5de86cb52d0ddc5ab461dL37-R37) [[2]](diffhunk://#diff-0ad2866e775244c459df41f7157842f220c945c3bda5de86cb52d0ddc5ab461dL84-R84) [[3]](diffhunk://#diff-75830fdd16c70f6d795c955b13df73abf5a6293a4ca0ccafca02d94916d76cc4L59-R59)

**Ticket Template Refresh Handling:**

- Modified `PrinterSettingsCard` and `Settings` to trigger a refresh of ticket templates (`refetchTemplates`) whenever the ticket templates modal is closed, ensuring the latest templates are always displayed after edits. [[1]](diffhunk://#diff-459f2aa6295623f356173cd3df7feabded4a3645c2f73ece0b1d3d879b83cd50R24) [[2]](diffhunk://#diff-459f2aa6295623f356173cd3df7feabded4a3645c2f73ece0b1d3d879b83cd50R77-R81) [[3]](diffhunk://#diff-459f2aa6295623f356173cd3df7feabded4a3645c2f73ece0b1d3d879b83cd50L166-R172) [[4]](diffhunk://#diff-e9f5464c4b4764c51c3c74604fd4973495ecf94d3d6e8c6dcba9a81aaca55dc5L37-R37) [[5]](diffhunk://#diff-e9f5464c4b4764c51c3c74604fd4973495ecf94d3d6e8c6dcba9a81aaca55dc5R181)