### PR TITLE
update logic for stock statuses

### DIFF
--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -18,17 +18,13 @@ export function ProductList({ products, onAddProduct, categories }) {
     const numeric = Number(value ?? fallback);
     return Number.isFinite(numeric) ? numeric : fallback;
   };
-  const normalizeThreshold = (value, fallback) => {
-    const numeric = normalizeNumber(value, fallback);
-    return numeric > 0 ? numeric : fallback;
-  };
 
   const stockStatus = (product) => {
-    const min = normalizeThreshold(product.min_stock_threshold, defaultMinStock);
-    const max = normalizeThreshold(product.max_stock_threshold, defaultMaxStock);
+    const min = defaultMinStock;
+    const max = defaultMaxStock;
     const quantity = normalizeNumber(product.quantity);
 
-    if (quantity <= min) {
+    if (quantity <= 0) {
       return "out";
     }
     if (quantity < max) {

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -6,7 +6,6 @@ import { useCurrency } from "@/components/hooks/useCurrency";
 export function ProductList({ products, onAddProduct, categories }) {
   const t = useTranslations("cart");
   const { formatAmount } = useCurrency();
-  const defaultMinStock = 5;
   const defaultMaxStock = 11;
 
   const getCategoryName = (categoryId) => {
@@ -20,7 +19,6 @@ export function ProductList({ products, onAddProduct, categories }) {
   };
 
   const stockStatus = (product) => {
-    const min = defaultMinStock;
     const max = defaultMaxStock;
     const quantity = normalizeNumber(product.quantity);
 

--- a/client/src/components/pages/Store/Products/ProductsTable.jsx
+++ b/client/src/components/pages/Store/Products/ProductsTable.jsx
@@ -21,7 +21,6 @@ import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 export function ProductsTable({ products, categories = [], onEditProduct, onDeleteProduct }) {
   const t = useTranslations("products");
   const { formatAmount } = useCurrency();
-  const defaultMinStock = 5;
   const defaultMaxStock = 11;
   const categoryNameById = useMemo(() => categories.reduce((map, category) => {
     const categoryId = String(category.id);
@@ -34,7 +33,6 @@ export function ProductsTable({ products, categories = [], onEditProduct, onDele
     return Number.isFinite(numeric) ? numeric : fallback;
   };
   const stockStatus = (product) => {
-    const min = defaultMinStock;
     const max = defaultMaxStock;
     const quantity = normalizeNumber(
       product.quantity ?? product.productStock,

--- a/client/src/components/pages/Store/Products/ProductsTable.jsx
+++ b/client/src/components/pages/Store/Products/ProductsTable.jsx
@@ -33,24 +33,14 @@ export function ProductsTable({ products, categories = [], onEditProduct, onDele
     const numeric = Number(value ?? fallback);
     return Number.isFinite(numeric) ? numeric : fallback;
   };
-  const normalizeThreshold = (value, fallback) => {
-    const numeric = normalizeNumber(value, fallback);
-    return numeric > 0 ? numeric : fallback;
-  };
   const stockStatus = (product) => {
-    const min = normalizeThreshold(
-      product.min_stock_threshold ?? product.productMinStock,
-      defaultMinStock,
-    );
-    const max = normalizeThreshold(
-      product.max_stock_threshold ?? product.productMaxStock,
-      defaultMaxStock,
-    );
+    const min = defaultMinStock;
+    const max = defaultMaxStock;
     const quantity = normalizeNumber(
       product.quantity ?? product.productStock,
     );
 
-    if (quantity <= min) {
+    if (quantity <= 0) {
       return "out";
     }
     if (quantity < max) {


### PR DESCRIPTION
This pull request updates how stock status is determined in both the product list and products table components. The main change is that product-specific stock thresholds are no longer used; instead, default minimum and maximum stock values are applied universally. Additionally, items are considered "out" of stock if their quantity is zero or less, rather than if they are below the minimum threshold.

Stock status calculation changes:

* Removed the use of per-product minimum and maximum stock thresholds in `ProductList.jsx` and `ProductsTable.jsx`; now both use default values for all products. [[1]](diffhunk://#diff-d803cbc0bf31e4eade9bbe49a30845fc86e109b9a04bd9d70acea67209d5dfcdL21-R27) [[2]](diffhunk://#diff-e176aaa69cbbcbdd1e0f8b98a9d00164fa9af764fa3e78431fa72f6462d8dbb4L36-R43)
* Changed the "out of stock" condition to trigger when quantity is zero or less, instead of when quantity is less than or equal to the minimum threshold. [[1]](diffhunk://#diff-d803cbc0bf31e4eade9bbe49a30845fc86e109b9a04bd9d70acea67209d5dfcdL21-R27) [[2]](diffhunk://#diff-e176aaa69cbbcbdd1e0f8b98a9d00164fa9af764fa3e78431fa72f6462d8dbb4L36-R43)