### PR TITLE
add missing locale for printer card settings

### DIFF
--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -225,6 +225,8 @@ const storeEn = {
       addButton: "Add",
       manageTemplates: "Manage templates",
       addTitle: "Add printer",
+      addDescription:
+        "Choose a type, select the system printer, and attach a template.",
       listTitle: "Configured printers",
       listHint: "Each printer can have its own template and default status.",
       defaultLabel: "Default printer",

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -223,6 +223,8 @@ const storeEs = {
       templateLabel: "Plantilla",
       templateNone: "Sin plantilla",
       addButton: "Agregar",
+      addDescription:
+        "Elige el tipo, la impresora del sistema y asigna una plantilla.",
       manageTemplates: "Administrar plantillas",
       addTitle: "Agregar impresora",
       listTitle: "Impresoras configuradas",


### PR DESCRIPTION
This pull request adds a helpful description to the "Add printer" dialog in both the English and Spanish language files, improving clarity for users during printer setup.

Localization improvements:

* Added an `addDescription` field to the English store page localization (`storeEn` in `client/src/components/pages/Store/locales/en.js`) to guide users through the printer addition process.
* Added an `addDescription` field to the Spanish store page localization (`storeEs` in `client/src/components/pages/Store/locales/es.js`) with equivalent guidance.