### PR TITLE
change symbol Mex$ for 'MXN' to $

### DIFF
--- a/server/app/src/main/resources/db/migration/V16__normalize_mxn_symbol.sql
+++ b/server/app/src/main/resources/db/migration/V16__normalize_mxn_symbol.sql
@@ -1,0 +1,5 @@
+PRAGMA foreign_keys = ON;
+
+UPDATE currency
+SET symbol = '$'
+WHERE acronym = 'MXN' AND symbol = 'Mex$';


### PR DESCRIPTION
This pull request includes a small database migration to normalize the currency symbol for the Mexican Peso. The change updates the symbol for `MXN` from `Mex to the standard `.

* Database migration: Updates the `currency` table to set the symbol for `MXN` to ` where it was previously `Mex (`server/app/src/main/resources/db/migration/V16__normalize_mxn_symbol.sql`).