### PR TITLE
add new sku when product has eliminated

### DIFF
--- a/server/app/src/main/resources/db/migration/V17__update_deleted_product_sku.sql
+++ b/server/app/src/main/resources/db/migration/V17__update_deleted_product_sku.sql
@@ -1,0 +1,4 @@
+UPDATE products
+SET SKU = 'DELETED-' || CAST(id AS TEXT)
+WHERE is_deleted = 1
+  AND SKU NOT LIKE 'DELETED-%';

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ProductServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ProductServiceTest.kt
@@ -326,6 +326,8 @@ class ProductServiceTest {
             val service = ProductService(mockConnection) // Arrange
             val result = service.deleteProduct("p-1") // Act
             assertTrue(result) // Assert
+            verify(deleteStatement).setString(1, "DELETED-p-1") // Assert
+            verify(deleteStatement).setString(2, "p-1") // Assert
         }
     }
 
@@ -338,6 +340,8 @@ class ProductServiceTest {
             val service = ProductService(mockConnection) // Arrange
             val result = service.deleteProduct("not-found") // Act
             assertFalse(result) // Assert
+            verify(deleteStatement).setString(1, "DELETED-not-found") // Assert
+            verify(deleteStatement).setString(2, "not-found") // Assert
         }
     }
 


### PR DESCRIPTION
This pull request updates the product deletion logic to ensure that when a product is deleted, its SKU is also updated to a unique "DELETED-<id>" format. This prevents potential SKU conflicts with future products and improves data consistency. Corresponding changes have been made to the SQL, service class, and tests.

**Product deletion logic:**

* Modified the `DELETE_PRODUCT` SQL statement in `ProductService` to update both the `is_deleted` flag and the SKU to "DELETED-<id>" when deleting a product.
* Updated the `deleteProduct` method in `ProductService` to generate the new SKU and set both parameters in the prepared statement. Added a helper function `deletedSku` for this purpose.

**Database migration:**

* Added a migration script (`V17__update_deleted_product_sku.sql`) to retroactively update SKUs for products already marked as deleted, ensuring all deleted products have the new SKU format.

**Testing:**

* Enhanced `ProductServiceTest` to verify that the SKU is updated correctly when a product is deleted, checking the correct parameters are set in the prepared statement for both successful and unsuccessful deletions. [[1]](diffhunk://#diff-74ab6c7556dbe98c82dafb98087fc00f20b4d3f2ac62832c24baa907e82e3d34R329-R330) [[2]](diffhunk://#diff-74ab6c7556dbe98c82dafb98087fc00f20b4d3f2ac62832c24baa907e82e3d34R343-R344)