### PR TITLE
set stock input default and max limit

### DIFF
--- a/client/src/components/pages/Store/Products/AddProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/AddProductsModal.jsx
@@ -186,8 +186,9 @@ export function AddProductsModal({
               <NumberInput
                 label={t("modal.productStockLabel")}
                 placeholder={t("modal.productStockPlaceholder")}
+                defaultValue={1}
                 minValue={0}
-                value={data.productStock}
+                maxValue={1000000}
                 isRequired
                 errorMessage={t("modal.errorMsgInputFieldEmpty")}
                 onValueChange={(value) => {

--- a/client/src/components/pages/Store/Products/EditProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/EditProductsModal.jsx
@@ -193,6 +193,7 @@ export function EditProductsModal({
                 isRequired
                 errorMessage={t("modal.errorMsgInputFieldEmpty")}
                 minValue={0}
+                maxValue={1000000}
                 value={data.productStock}
                 onValueChange={(value) => {
                   const numeric = value === null ? "" : Number(value);


### PR DESCRIPTION
This pull request introduces validation improvements to the product stock input fields in both the Add and Edit product modals. The main changes set reasonable default and maximum values to prevent invalid or excessive stock entries.

**Input validation improvements:**

* Added a `defaultValue` of 1 and a `maxValue` of 1,000,000 to the `productStock` field in the `AddProductsModal`, ensuring a sensible default and preventing excessively large stock values.
* Added a `maxValue` of 1,000,000 to the `productStock` field in the `EditProductsModal` to enforce the same upper limit when editing products.