### PR TITLE
remove other types for add or edit printers

### DIFF
--- a/client/src/components/pages/Store/Settings/PrinterSettings/PrinterAddForm.jsx
+++ b/client/src/components/pages/Store/Settings/PrinterSettings/PrinterAddForm.jsx
@@ -2,7 +2,7 @@
 
 import { Button, Select, SelectItem, Switch } from "@heroui/react";
 
-const PRINTER_TYPES = ["KITCHEN", "CUSTOMER", "BAR"];
+const PRINTER_TYPES = ["CUSTOMER"];
 
 export function PrinterAddForm({
   printerType,

--- a/client/src/components/pages/Store/Settings/PrinterSettings/PrinterSettingsCard.jsx
+++ b/client/src/components/pages/Store/Settings/PrinterSettings/PrinterSettingsCard.jsx
@@ -24,7 +24,7 @@ export function PrinterSettingsCard({
   onTemplatesRefresh,
   t,
 }) {
-  const [printerType, setPrinterType] = useState("KITCHEN");
+  const [printerType, setPrinterType] = useState("CUSTOMER");
   const [printerName, setPrinterName] = useState("");
   const [templateName, setTemplateName] = useState("");
   const [isDefault, setIsDefault] = useState(false);

--- a/client/src/components/pages/Store/Settings/TicketTemplate/TicketTemplatesModal.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplate/TicketTemplatesModal.jsx
@@ -15,7 +15,7 @@ import { TicketTemplatesEditor } from "./TicketTemplatesEditor";
 import { TicketTemplatesFooter } from "./TicketTemplatesFooter";
 import { useTicketTemplatePreviewElements } from "./useTicketTemplatePreviewElements";
 
-const PRINTER_TYPES = ["KITCHEN", "CUSTOMER", "BAR"];
+const PRINTER_TYPES = ["CUSTOMER"];
 
 export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }) {
   const t = useTranslations("settings");
@@ -33,7 +33,7 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [printing, setPrinting] = useState(false);
-  const [printerType, setPrinterType] = useState("KITCHEN");
+  const [printerType, setPrinterType] = useState("CUSTOMER");
 
   const previewElements = useTicketTemplatePreviewElements(elements);
 

--- a/client/src/components/pages/Store/Settings/__tests__/PrinterAddForm.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/PrinterAddForm.test.jsx
@@ -53,7 +53,7 @@ describe("PrinterAddForm", () => {
 
     render(
       <PrinterAddForm
-        printerType="KITCHEN"
+        printerType="CUSTOMER"
         printerName=""
         templateName=""
         isDefault={false}
@@ -74,9 +74,9 @@ describe("PrinterAddForm", () => {
     );
 
     fireEvent.change(screen.getByLabelText("cardPrinters.typeLabel"), {
-      target: { value: "BAR" },
+      target: { value: "CUSTOMER" },
     });
-    expect(onPrinterTypeChange).toHaveBeenCalledWith("BAR");
+    expect(onPrinterTypeChange).toHaveBeenCalledWith("CUSTOMER");
 
     fireEvent.change(screen.getByLabelText("cardPrinters.nameLabel"), {
       target: { value: "Printer A" },
@@ -103,7 +103,7 @@ describe("PrinterAddForm", () => {
 
     render(
       <PrinterAddForm
-        printerType="KITCHEN"
+        printerType="CUSTOMER"
         printerName="Printer A"
         templateName="Template A"
         isDefault={false}

--- a/client/src/components/pages/Store/Settings/__tests__/PrinterSettingsCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/PrinterSettingsCard.test.jsx
@@ -91,7 +91,7 @@ describe("PrinterSettingsCard", () => {
     fireEvent.click(screen.getByText("add-form-submit"));
 
     await waitFor(() => expect(createPrinterConfig).toHaveBeenCalledWith({
-      printerType: "KITCHEN",
+      printerType: "CUSTOMER",
       printerName: "Printer A",
       templateName: "Template A",
       isDefault: false,

--- a/client/src/components/pages/Store/Settings/__tests__/TemplatePreview.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/TemplatePreview.test.jsx
@@ -23,9 +23,9 @@ const t = (key) => key;
 
 const defaultProps = {
   previewElements: [],
-  printerType: "KITCHEN",
+  printerType: "CUSTOMER",
   onPrinterTypeChange: jest.fn(),
-  printerTypes: ["KITCHEN", "CUSTOMER", "BAR"],
+  printerTypes: ["CUSTOMER"],
   onPrintTest: jest.fn(),
   printing: false,
   templateExists: false,

--- a/client/src/components/pages/Store/Settings/__tests__/TicketTemplatesModal.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/TicketTemplatesModal.test.jsx
@@ -149,7 +149,7 @@ describe("TicketTemplatesModal", () => {
     await waitFor(() => expect(printTicket).toHaveBeenCalledWith(
       expect.objectContaining({
         templateName: "Menu",
-        printerType: "KITCHEN",
+        printerType: "CUSTOMER",
         broadcast: false,
         forceTemplateName: true,
       }),
@@ -230,10 +230,10 @@ describe("TicketTemplatesModal", () => {
     fireEvent.click(screen.getByText("templates.addElement"));
 
     fireEvent.change(screen.getByLabelText("templates.printTypeLabel"), {
-      target: { value: "BAR" },
+      target: { value: "CUSTOMER" },
     });
 
-    expect(screen.getByText("cardPrinters.types.BAR")).toBeInTheDocument();
+    expect(screen.getByText("cardPrinters.types.CUSTOMER")).toBeInTheDocument();
   });
 
   it("opens with empty form when no initialTemplate is provided", () => {


### PR DESCRIPTION
This pull request restricts the available printer types in the store settings and ticket template management UI to only "CUSTOMER" printers. All references to other printer types such as "KITCHEN" and "BAR" have been removed or replaced, and the default selected printer type is now "CUSTOMER" throughout the application. Corresponding tests have also been updated to reflect these changes.

**Printer Type Restriction and UI Updates:**
* Limited the `PRINTER_TYPES` array to only include "CUSTOMER" in both `PrinterAddForm.jsx` and `TicketTemplatesModal.jsx`, removing "KITCHEN" and "BAR" as options. [[1]](diffhunk://#diff-0ad2866e775244c459df41f7157842f220c945c3bda5de86cb52d0ddc5ab461dL5-R5) [[2]](diffhunk://#diff-0436bc5319a747346b3daadbef686fd2a6c802ed80e766d35897322accc09056L18-R18)
* Updated the default `printerType` state to "CUSTOMER" in both `PrinterSettingsCard.jsx` and `TicketTemplatesModal.jsx`. [[1]](diffhunk://#diff-459f2aa6295623f356173cd3df7feabded4a3645c2f73ece0b1d3d879b83cd50L27-R27) [[2]](diffhunk://#diff-0436bc5319a747346b3daadbef686fd2a6c802ed80e766d35897322accc09056L36-R36)

**Test Updates:**
* Modified tests in `PrinterAddForm.test.jsx`, `PrinterSettingsCard.test.jsx`, `TemplatePreview.test.jsx`, and `TicketTemplatesModal.test.jsx` to use "CUSTOMER" as the printer type and to expect only "CUSTOMER" as a valid value. [[1]](diffhunk://#diff-ad6d9e9e2e567161458e372d9cb3f36529649a1543562779fcc8a1177c76ad95L56-R56) [[2]](diffhunk://#diff-ad6d9e9e2e567161458e372d9cb3f36529649a1543562779fcc8a1177c76ad95L77-R79) [[3]](diffhunk://#diff-ad6d9e9e2e567161458e372d9cb3f36529649a1543562779fcc8a1177c76ad95L106-R106) [[4]](diffhunk://#diff-1e2c4ec474faf513f639d0139ba7c71c2b8fb208adaaf3fd8ef952a637d06b97L94-R94) [[5]](diffhunk://#diff-77ac4e7edef480c1413568eb42af2e0442e9f18965e402b31b8cb02d97011fd2L26-R28) [[6]](diffhunk://#diff-4547b0c956fe845f239eef70dfcf23b906e38fb742c53c3939c86f27d2cd9d3dL152-R152) [[7]](diffhunk://#diff-4547b0c956fe845f239eef70dfcf23b906e38fb742c53c3939c86f27d2cd9d3dL233-R236)