### PR TITLE
clear cart when user logout or unauthorized

### DIFF
--- a/client/src/modules/auth/AuthProvider.jsx
+++ b/client/src/modules/auth/AuthProvider.jsx
@@ -1,8 +1,9 @@
-﻿"use client";
+"use client";
 import { createContext, useEffect, useState } from "react";
 import { loginFromService, logoutFromService } from "./authService";
 import { apiClient } from "../../services/apiClient";
 import { useRouter } from "next/navigation";
+import { CART_STORAGE_KEY } from "../../components/pages/Store/Cart/hooks/usePersistentCart";
 
 export const AuthContext = createContext();
 
@@ -13,6 +14,15 @@ export function AuthProvider({ children }) {
   const [isLoading, setIsLoading] = useState(true)
 
   const router = useRouter();
+
+  const clearCartStorage = () => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(CART_STORAGE_KEY);
+    } catch (error) {
+      console.error("Error clearing cart storage on logout", error);
+    }
+  };
 
   const fetchUser = async () => {
     try {
@@ -50,6 +60,7 @@ export function AuthProvider({ children }) {
   }
   const logout = async () => {
     await logoutFromService();
+    clearCartStorage();
     setUser(null);
     setPermissions(null)
     setIsAuth(false);
@@ -59,6 +70,7 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     fetchUser();
     const handleExpired = () => {
+      clearCartStorage();
       setUser(null)
       setPermissions(null)
       setIsAuth(false);
@@ -66,7 +78,6 @@ export function AuthProvider({ children }) {
       router.push("/auth")
     };
     const handleForbidden = () => {
-      // No cerramos sesión; solo redirigimos a unauthorized
       router.push("/unauthorized");
     };
 

--- a/client/src/modules/auth/AuthProvider.jsx
+++ b/client/src/modules/auth/AuthProvider.jsx
@@ -1,9 +1,9 @@
 "use client";
 import { createContext, useEffect, useState } from "react";
 import { loginFromService, logoutFromService } from "./authService";
-import { apiClient } from "../../services/apiClient";
+import { apiClient } from "@/services/apiClient";
 import { useRouter } from "next/navigation";
-import { CART_STORAGE_KEY } from "../../components/pages/Store/Cart/hooks/usePersistentCart";
+import { CART_STORAGE_KEY } from "@/components/pages/Store/Cart/hooks/usePersistentCart";
 
 export const AuthContext = createContext();
 


### PR DESCRIPTION
This pull request updates the authentication logic to ensure that the user's cart data is cleared from local storage when they log out or when their session expires. This helps maintain user privacy and prevents stale cart data from persisting across sessions.

**Authentication and Cart Management Improvements:**

* Added a `clearCartStorage` function to remove the cart from local storage using the `CART_STORAGE_KEY` constant. This function is called during logout and when the session expires to ensure cart data is cleared.
* Updated the `logout` function to call `clearCartStorage` before resetting the authentication state.
* Updated the session expiration handler (`handleExpired`) to call `clearCartStorage` when the session expires.

**Imports and Dependencies:**

* Imported `CART_STORAGE_KEY` from the cart hook to support cart data removal.