### PR TITLE
solve not 1 default for send form

### DIFF
--- a/client/src/components/pages/Store/Products/AddProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/AddProductsModal.jsx
@@ -52,7 +52,7 @@ export function AddProductsModal({
         productCategory: "",
         productSKU: "",
         productPrice: "",
-        productStock: "",
+        productStock: 1,
         productMinStock: 0,
         productMaxStock: 0,
         productImage: null,
@@ -186,7 +186,7 @@ export function AddProductsModal({
               <NumberInput
                 label={t("modal.productStockLabel")}
                 placeholder={t("modal.productStockPlaceholder")}
-                defaultValue={1}
+                value={data.productStock}
                 minValue={0}
                 maxValue={1000000}
                 isRequired

--- a/client/src/components/pages/Store/Products/Products.jsx
+++ b/client/src/components/pages/Store/Products/Products.jsx
@@ -24,7 +24,7 @@ export function Products() {
     productCategory: "",
     productSKU: "",
     productPrice: "",
-    productStock: "",
+    productStock: 1,
     productMinStock: 0,
     productMaxStock: 0,
     productImage: null,

--- a/client/src/components/pages/Store/Products/__tests__/AddProductsModal.test.jsx
+++ b/client/src/components/pages/Store/Products/__tests__/AddProductsModal.test.jsx
@@ -259,7 +259,7 @@ describe("AddProductsModal", () => {
       productCategory: "",
       productSKU: "",
       productPrice: "",
-      productStock: "",
+      productStock: 1,
       productMinStock: 0,
       productMaxStock: 0,
       productImage: null,


### PR DESCRIPTION
This pull request updates how the initial value for `productStock` is handled across the Add Products modal and related components. Instead of starting as an empty string, `productStock` now defaults to 1, ensuring a more consistent and user-friendly experience when adding new products.

**Default value improvements:**

* Changed the initial value of `productStock` from an empty string to `1` in the `AddProductsModal`, `Products`, and related test files. This ensures that new products start with a sensible default stock value. [[1]](diffhunk://#diff-a71eeaa4f4478cc74b94ae1558a5b2b200e1b474367c3d5a80bd40b7fae587caL55-R55) [[2]](diffhunk://#diff-62a7c46229d16a11fc732dbb18d328111d18d5e2b46b18942de5eef3a4755a16L27-R27) [[3]](diffhunk://#diff-7dbbba51d42007d2b87f6d8609c902da246da7612c7b1e16379cea747c88639eL262-R262)

**Form handling:**

* Updated the `NumberInput` for product stock in `AddProductsModal` to use the controlled `value` prop (bound to `data.productStock`) instead of the uncontrolled `defaultValue`, aligning with React best practices and reflecting the new default.