### PR TITLE
Implement Lightning Channel Closing

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -17,6 +17,7 @@ import pos.ambrosia.models.Phoenix.CreateInvoiceRequest
 import pos.ambrosia.models.Phoenix.PayInvoiceRequest
 import pos.ambrosia.models.Phoenix.PayOfferRequest
 import pos.ambrosia.models.Phoenix.PayOnchainRequest
+import pos.ambrosia.models.Phoenix.CloseChannelRequest
 import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.AuthService
 import pos.ambrosia.services.TokenService
@@ -108,7 +109,11 @@ fun Route.wallet(phoenixService: PhoenixService, tokenService: TokenService, aut
       val result = phoenixService.bumpOnchainFees(feerateSatByte)
       call.respond(HttpStatusCode.OK, result)
     }
-
+    post("/closechannel") {
+      val request = call.receive<CloseChannelRequest>()
+      val result = phoenixService.closeChannel(request)
+      call.respond(HttpStatusCode.OK, result)
+    }
     // Payments endpoints
     route("/payments") {
       // List incoming payments

--- a/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
@@ -96,3 +96,6 @@ data class PayOfferRequest(
 
 @Serializable
 data class PayOnchainRequest(val amountSat: Long, val address: String, val feerateSatByte: Long)
+
+@Serializable
+data class CloseChannelRequest(val channelId: String, val address: String, val feerateSatByte: Long)

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -219,6 +219,29 @@ class PhoenixService(app: ApplicationEnvironment, private val httpClient: HttpCl
     }
   }
 
+  /** Close a channel and send funds to an on-chain address */
+  suspend fun closeChannel(request: CloseChannelRequest): String {
+    try {
+      val response: HttpResponse =
+        httpClient.submitForm(
+          url = "$phoenixdUrl/closechannel",
+          formParameters =
+            Parameters.build {
+              append("channelId", request.channelId)
+              append("address", request.address)
+              append("feerateSatByte", request.feerateSatByte.toString())
+            }
+        )
+      if (response.status.value != 200) {
+        throw PhoenixServiceException("Phoenix node returned ${response.status.value}")
+      }
+
+      return response.bodyAsText()
+    } catch (e: Exception) {
+      throw PhoenixServiceException("Failed to close channel on Phoenix: ${e.message}")
+    }
+  }
+
   /** List incoming payments from Phoenix */
   suspend fun listIncomingPayments(
     from: Long = 0,


### PR DESCRIPTION

This PR adds the necessary functionality to close Lightning Network channels in Phoenixd via the Ambrosia POS API.

## Changes Made

### Backend (Kotlin/Ktor)
- **Models:** Registered the `CloseChannelRequest` model in `PhoenixModels.kt` to handle the parameters required by Phoenixd: `channelId`, `address`, and `feerateSatByte`.
- **Service:** Implemented the `closeChannel` method in `PhoenixService.kt`, which encapsulates the communication logic with the Phoenix daemon.
- **API/Routing:** Enabled the `POST /wallet/closechannel` endpoint within the `auth-jwt-wallet` authentication block in `Wallet.kt`, ensuring that only users with authorized wallet access can perform this action.

## Verification

The endpoint has been verified to ensure that:
1. It correctly receives parameters in JSON format.
2. It is protected by the wallet authentication middleware.
3. It successfully communicates with the underlying Phoenixd service.