### PR TITLE
fix build dist filenames for each platform and architecture

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4367,9 +4367,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/electron/build/tar.gz-install-instructions.md
+++ b/electron/build/tar.gz-install-instructions.md
@@ -9,37 +9,37 @@ This tar.gz archive is provided for advanced users on Linux distributions that d
 ### 1. Extract the archive
 
 ```bash
-tar -xzf ambrosia-app-*.tar.gz
+tar -xzf ambrosia-pos-*.tar.gz
 ```
 
 ### 2. Move to a permanent location (optional)
 
 **System-wide install:**
 ```bash
-sudo mv ambrosia-app-* /opt/AmbrosiaPoS
+sudo mv ambrosia-pos-* /opt/AmbrosiaPoS
 ```
 
 **User-only install:**
 ```bash
-mv ambrosia-app-* ~/.local/share/AmbrosiaPoS
+mv ambrosia-pos-* ~/.local/share/AmbrosiaPoS
 ```
 
 ### 3. Run the application
 
 ```bash
 cd /opt/AmbrosiaPoS  # or your chosen location
-./ambrosia-app
+./ambrosia-pos
 ```
 
 ### 4. Create a desktop shortcut (optional)
 
-Create a file at `~/.local/share/applications/ambrosia-app.desktop`:
+Create a file at `~/.local/share/applications/ambrosia-pos.desktop`:
 
 ```ini
 [Desktop Entry]
 Name=Ambrosia POS
 Comment=Restaurant and Retail POS with Bitcoin Lightning
-Exec=/opt/AmbrosiaPoS/ambrosia-app
+Exec=/opt/AmbrosiaPoS/ambrosia-pos
 Icon=/opt/AmbrosiaPoS/resources/app/build/icon.png
 Terminal=false
 Type=Application
@@ -84,7 +84,7 @@ rm -rf ~/.phoenix
 ### 3. Remove desktop entry (if created)
 
 ```bash
-rm ~/.local/share/applications/ambrosia-app.desktop
+rm ~/.local/share/applications/ambrosia-pos.desktop
 ```
 
 ## Support

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ambrosia-app",
-  "version": "0.5.1",
+  "name": "ambrosia-pos",
+  "version": "0.5.1-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ambrosia-app",
-      "version": "0.5.1",
+      "name": "ambrosia-pos",
+      "version": "0.5.1-alpha",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -717,9 +717,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1687,13 +1687,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
-      "integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2513,7 +2513,6 @@
       "integrity": "sha512-IkGlOLfJ3q7y9iaDMnNSArDdPg3Ntx8Ps6aL7yTEIpL6znA+t5L/LRTAGFz1J/12hM/NiNEYg0LoBEheqGdZXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.6.0",
         "builder-util": "26.4.1",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ambrosia-app",
-  "version": "0.5.1",
+  "name": "ambrosia-pos",
+  "version": "0.5.1-alpha",
   "description": "Ambrosia POS Desktop Application",
   "main": "main.js",
   "scripts": {
@@ -72,9 +72,9 @@
     ],
     "mac": {
       "category": "public.app-category.business",
+      "artifactName": "ambrosia-pos-${version}-${arch}.${ext}",
       "target": [
-        "dmg",
-        "zip"
+        "dmg"
       ],
       "icon": "build/icon.icns",
       "hardenedRuntime": true,
@@ -94,14 +94,17 @@
         "rpm",
         "tar.gz"
       ],
+      "artifactName": "ambrosia-pos-${version}-${arch}.${ext}",
       "category": "Office",
       "icon": "build/icon.png",
       "maintainer": "Ivan Robles <contact@ivanrobles.pro>"
     },
     "deb": {
+      "artifactName": "ambrosia-pos_${version}_${arch}.${ext}",
       "afterInstall": "build/postinst"
     },
     "rpm": {
+      "artifactName": "ambrosia-pos-${version}.${arch}.${ext}",
       "depends": [
         "libxcrypt-compat"
       ],
@@ -111,6 +114,7 @@
       ]
     },
     "nsis": {
+      "artifactName": "ambrosia-pos-${version}-${arch}-setup.${ext}",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,


### PR DESCRIPTION
### Changes:
- Dist file name follow the platform conventions `macOS`, `windows`, `debian`, `redhat`, `linux`.

### Examples:
- macOS: ambrosia-pos-0.5.1-alpha-arm64.dmg                            
- Windows: ambrosia-pos-0.5.1-alpha-x64-setup.exe
- Linux: ambrosia-pos-0.5.1-alpha-x64.tar.gz
- Linux (deb): ambrosia-pos_0.5.1-alpha_amd64.deb
- Linux (rpm): ambrosia-pos-0.5.1-alpha.x86_64.rpm