### PR TITLE
Feature/electron updater

### DIFF
--- a/.github/workflows/electron_release.yml
+++ b/.github/workflows/electron_release.yml
@@ -90,6 +90,7 @@ jobs:
             electron/dist/*.rpm
             electron/dist/*.tar.gz
             electron/dist/*.blockmap
+            electron/dist/*.yml
           if-no-files-found: error
 
   release:

--- a/client/src/app/layout.js
+++ b/client/src/app/layout.js
@@ -1,7 +1,8 @@
 import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
-import ModuleNavigation from "../components/ModuleNavigation";
+import ModuleNavigation from "@components/ModuleNavigation";
+import UpdateBanner from "@components/UpdateBanner";
 import Providers from "./providers";
 
 const geistSans = Geist({
@@ -26,6 +27,7 @@ export default function RootLayout({ children }) {
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
+          <UpdateBanner />
           <div className="">
             <ModuleNavigation show="none">{children}</ModuleNavigation>
           </div>

--- a/client/src/components/UpdateBanner.jsx
+++ b/client/src/components/UpdateBanner.jsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+import { Button } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import {
+  isElectron,
+  isWindows,
+  onUpdateEvent,
+  installUpdate,
+  openReleasePage,
+} from "@/utils/electron";
+
+export default function UpdateBanner() {
+  const [updateAvailable, setUpdateAvailable] = useState(null);
+  const [downloaded, setDownloaded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!isElectron()) return;
+
+    const cleanups = [];
+
+    cleanups.push(
+      onUpdateEvent("update:available", (data) => {
+        setUpdateAvailable(data);
+      }),
+    );
+
+    cleanups.push(
+      onUpdateEvent("update:downloaded", (data) => {
+        setUpdateAvailable(data);
+        setDownloaded(true);
+      }),
+    );
+
+    return () => cleanups.forEach((fn) => fn());
+  }, []);
+
+  const t = useTranslations("updateBanner");
+
+  const handleAction = useCallback(() => {
+    if (downloaded && isWindows()) {
+      installUpdate();
+    } else if (isElectron()) {
+      openReleasePage();
+    } else {
+      window.open("https://github.com/olympus-btc/ambrosia/releases", "_blank");
+    }
+  }, [downloaded]);
+
+  if (!updateAvailable || dismissed) return null;
+
+  return (
+    <div className="bg-primary-50 border-b border-primary-200 px-4 py-2 flex items-center justify-between gap-4 absolute top-0 w-full z-50">
+      <span className="text-sm text-primary-700">
+        {downloaded
+          ? t("readyToInstall", { version: updateAvailable.version })
+          : t("newVersionAvailable", { version: updateAvailable.version })}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          className="bg-green-800 text-white"
+          size="sm"
+          color="primary"
+          variant={downloaded ? "solid" : "flat"}
+          onPress={handleAction}
+        >
+          {downloaded ? t("restartAndUpdate") : t("downloadFromGitHub")}
+        </Button>
+        <Button
+          size="sm"
+          variant="light"
+          isIconOnly
+          onPress={() => setDismissed(true)}
+          aria-label={t("dismiss")}
+        >
+          ✕
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/__tests__/UpdateBanner.test.jsx
+++ b/client/src/components/__tests__/UpdateBanner.test.jsx
@@ -1,0 +1,179 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import UpdateBanner from "../UpdateBanner";
+
+const mockIsElectron = jest.fn(() => true);
+const mockIsWindows = jest.fn(() => false);
+const mockInstallUpdate = jest.fn();
+const mockOpenReleasePage = jest.fn();
+const mockOnUpdateEvent = jest.fn(() => jest.fn());
+
+jest.mock("@/utils/electron", () => ({
+  isElectron: (...args) => mockIsElectron(...args),
+  isWindows: (...args) => mockIsWindows(...args),
+  installUpdate: (...args) => mockInstallUpdate(...args),
+  openReleasePage: (...args) => mockOpenReleasePage(...args),
+  onUpdateEvent: (...args) => mockOnUpdateEvent(...args),
+}));
+
+let eventCallbacks;
+
+function setupEventCapture() {
+  eventCallbacks = {};
+  mockOnUpdateEvent.mockImplementation((event, callback) => {
+    eventCallbacks[event] = callback;
+    return jest.fn();
+  });
+}
+
+function simulateUpdateAvailable(data = { version: "1.0.0" }) {
+  act(() => {
+    eventCallbacks["update:available"]?.(data);
+  });
+}
+
+function simulateUpdateDownloaded(data = { version: "1.0.0" }) {
+  act(() => {
+    eventCallbacks["update:downloaded"]?.(data);
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsElectron.mockReturnValue(true);
+  mockIsWindows.mockReturnValue(false);
+  setupEventCapture();
+  delete window.open;
+  window.open = jest.fn();
+});
+
+describe("UpdateBanner", () => {
+  describe("Initial state", () => {
+    it("renders nothing when no update is available", () => {
+      const { container } = render(<UpdateBanner />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("does not subscribe to events when not in Electron", () => {
+      mockIsElectron.mockReturnValue(false);
+      render(<UpdateBanner />);
+      expect(mockOnUpdateEvent).not.toHaveBeenCalled();
+    });
+
+    it("subscribes to update:available and update:downloaded in Electron", () => {
+      render(<UpdateBanner />);
+      expect(mockOnUpdateEvent).toHaveBeenCalledWith("update:available", expect.any(Function));
+      expect(mockOnUpdateEvent).toHaveBeenCalledWith("update:downloaded", expect.any(Function));
+    });
+  });
+
+  describe("Update available", () => {
+    it("shows banner when update:available event fires", () => {
+      render(<UpdateBanner />);
+      simulateUpdateAvailable({ version: "2.0.0" });
+
+      expect(screen.getByText("newVersionAvailable")).toBeInTheDocument();
+    });
+
+    it("shows download button for non-Windows platforms", () => {
+      mockIsWindows.mockReturnValue(false);
+      render(<UpdateBanner />);
+      simulateUpdateAvailable();
+
+      expect(screen.getByText("downloadFromGitHub")).toBeInTheDocument();
+    });
+
+    it("calls openReleasePage in Electron when download button is pressed", async () => {
+      const user = userEvent.setup();
+      render(<UpdateBanner />);
+      simulateUpdateAvailable();
+
+      await user.click(screen.getByText("downloadFromGitHub"));
+      expect(mockOpenReleasePage).toHaveBeenCalled();
+    });
+
+    it("opens GitHub releases in browser when not in Electron", async () => {
+      const user = userEvent.setup();
+      render(<UpdateBanner />);
+      simulateUpdateAvailable();
+
+      mockIsElectron.mockReturnValue(false);
+
+      await user.click(screen.getByText("downloadFromGitHub"));
+      expect(window.open).toHaveBeenCalledWith(
+        "https://github.com/olympus-btc/ambrosia/releases",
+        "_blank",
+      );
+      expect(mockOpenReleasePage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Update downloaded", () => {
+    it("shows ready to install message", () => {
+      render(<UpdateBanner />);
+      simulateUpdateDownloaded({ version: "2.0.0" });
+
+      expect(screen.getByText("readyToInstall")).toBeInTheDocument();
+    });
+
+    it("shows restart button when downloaded", () => {
+      render(<UpdateBanner />);
+      simulateUpdateDownloaded();
+
+      expect(screen.getByText("restartAndUpdate")).toBeInTheDocument();
+    });
+
+    it("calls installUpdate on Windows when downloaded", async () => {
+      mockIsWindows.mockReturnValue(true);
+      const user = userEvent.setup();
+      render(<UpdateBanner />);
+      simulateUpdateDownloaded();
+
+      await user.click(screen.getByText("restartAndUpdate"));
+      expect(mockInstallUpdate).toHaveBeenCalled();
+    });
+
+    it("calls openReleasePage on macOS/Linux even when downloaded", async () => {
+      mockIsWindows.mockReturnValue(false);
+      const user = userEvent.setup();
+      render(<UpdateBanner />);
+      simulateUpdateDownloaded();
+
+      await user.click(screen.getByText("restartAndUpdate"));
+      expect(mockOpenReleasePage).toHaveBeenCalled();
+    });
+  });
+
+  describe("Dismiss", () => {
+    it("hides banner when dismiss button is pressed", async () => {
+      const user = userEvent.setup();
+      render(<UpdateBanner />);
+      simulateUpdateAvailable();
+
+      expect(screen.getByText("newVersionAvailable")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "dismiss" }));
+      expect(screen.queryByText("newVersionAvailable")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Cleanup", () => {
+    it("calls cleanup functions on unmount", () => {
+      const cleanup1 = jest.fn();
+      const cleanup2 = jest.fn();
+      let callCount = 0;
+      mockOnUpdateEvent.mockImplementation((event, callback) => {
+        eventCallbacks[event] = callback;
+        callCount++;
+        return callCount === 1 ? cleanup1 : cleanup2;
+      });
+
+      const { unmount } = render(<UpdateBanner />);
+      unmount();
+
+      expect(cleanup1).toHaveBeenCalled();
+      expect(cleanup2).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -23,6 +23,13 @@ const componentsEn = {
       secondMessage: "Access granted as",
     },
   },
+  updateBanner: {
+    readyToInstall: "Version {version} is ready to install.",
+    newVersionAvailable: "A new version ({version}) is available.",
+    restartAndUpdate: "Restart & Update",
+    downloadFromGitHub: "Download from GitHub",
+    dismiss: "Dismiss",
+  },
 };
 
 export default componentsEn;

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -23,6 +23,13 @@ const componentsEs = {
       secondMessage: "Acceso concedido como",
     },
   },
+  updateBanner: {
+    readyToInstall: "La versión {version} está lista para instalar.",
+    newVersionAvailable: "Nueva versión ({version}) disponible.",
+    restartAndUpdate: "Reiniciar y Actualizar",
+    downloadFromGitHub: "Descargar desde GitHub",
+    dismiss: "Cerrar",
+  },
 };
 
 export default componentsEs;

--- a/client/src/utils/electron.js
+++ b/client/src/utils/electron.js
@@ -76,3 +76,42 @@ export function isWindows() {
 export function isLinux() {
   return getPlatform() === "linux";
 }
+
+/**
+ * Installs the downloaded update and restarts (Windows only)
+ */
+export async function installUpdate() {
+  const electronAPI = getElectronAPI();
+  if (electronAPI?.ipc?.invoke) {
+    return electronAPI.ipc.invoke("update:install");
+  }
+}
+
+/**
+ * Opens the GitHub release page for manual download (macOS/Linux)
+ */
+export async function openReleasePage() {
+  const electronAPI = getElectronAPI();
+  if (electronAPI?.ipc?.invoke) {
+    return electronAPI.ipc.invoke("update:open-release");
+  }
+}
+
+/**
+ * Subscribes to update events from the main process
+ * @param {string} event - update:available, update:downloaded
+ * @param {Function} callback - Event handler
+ * @returns {Function} Cleanup function to remove listener
+ */
+export function onUpdateEvent(event, callback) {
+  const electronAPI = getElectronAPI();
+  if (electronAPI?.ipc?.on) {
+    electronAPI.ipc.on(event, callback);
+    return () => {
+      if (electronAPI?.ipc?.removeListener) {
+        electronAPI.ipc.removeListener(event, callback);
+      }
+    };
+  }
+  return () => {};
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,8 @@
 const path = require('path');
 
-const { app, BrowserWindow, dialog, shell, ipcMain } = require('electron');
+const { app, BrowserWindow, Menu, dialog, shell, ipcMain } = require('electron');
 
+const AutoUpdater = require('./services/AutoUpdater');
 const ServiceManager = require('./services/ServiceManager');
 
 // To prevent multiple instances of the application
@@ -25,6 +26,23 @@ if (!gotTheLock) {
 let mainWindow = null;
 let splashWindow = null;
 let serviceManager = null;
+let autoUpdaterService = null;
+let updateMenuItem = null;
+
+function updateMenuItemState({ label, enabled, click }) {
+  if (!updateMenuItem) return;
+  updateMenuItem.label = label;
+  updateMenuItem.enabled = enabled;
+  if (click) {
+    updateMenuItem.click = click;
+  } else {
+    updateMenuItem.click = () => {
+      if (autoUpdaterService) {
+        autoUpdaterService.checkForUpdatesManual();
+      }
+    };
+  }
+}
 
 // Splash Screen Creation
 function createSplashScreen() {
@@ -131,6 +149,105 @@ async function handleStartupError(error) {
     setTimeout(() => app.quit(), 500);
   } else {
     app.quit();
+  }
+}
+
+// Application Menu
+function createAppMenu() {
+  const isMac = process.platform === 'darwin';
+
+  const updateItem = {
+    label: 'Check for Updates...',
+    click: () => {
+      if (autoUpdaterService) {
+        autoUpdaterService.checkForUpdatesManual();
+      }
+    },
+  };
+
+  const template = [
+    ...(isMac
+      ? [{
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            updateItem,
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        }]
+      : []),
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac
+          ? [{ type: 'separator' }, { role: 'front' }]
+          : [{ role: 'close' }]),
+      ],
+    },
+    ...(!isMac
+      ? [{
+          label: 'Help',
+          submenu: [
+            updateItem,
+            { type: 'separator' },
+            {
+              label: 'About Ambrosia POS',
+              click: () => {
+                dialog.showMessageBox(mainWindow, {
+                  type: 'info',
+                  title: 'About Ambrosia POS',
+                  message: `Ambrosia POS v${app.getVersion()}`,
+                  buttons: ['OK'],
+                });
+              },
+            },
+          ],
+        }]
+      : []),
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+
+  // Store reference to update menu item for dynamic updates
+  if (isMac) {
+    updateMenuItem = menu.items[0].submenu.items[1];
+  } else {
+    const helpMenu = menu.items[menu.items.length - 1];
+    updateMenuItem = helpMenu.submenu.items[0];
   }
 }
 
@@ -250,6 +367,17 @@ app.whenReady().then(async () => {
 
     createWindow(url);
 
+    createAppMenu();
+
+    // Start auto-update checks (production only)
+    if (app.isPackaged) {
+      autoUpdaterService = new AutoUpdater(mainWindow, {
+        onMenuUpdate: updateMenuItemState,
+        releaseUrl: 'https://github.com/olympus-btc/ambrosia/releases',
+      });
+      autoUpdaterService.startPeriodicChecks();
+    }
+
     console.log('[Electron] Application initialized successfully');
   } catch (error) {
     // Close splash on error
@@ -272,6 +400,10 @@ app.on('activate', () => {
 
 // Clean shutdown
 app.on('before-quit', async (event) => {
+  if (autoUpdaterService) {
+    autoUpdaterService.destroy();
+    autoUpdaterService = null;
+  }
   if (serviceManager) {
     event.preventDefault();
     console.log('[Electron] Shutting down services...');
@@ -282,6 +414,10 @@ app.on('before-quit', async (event) => {
 });
 
 app.on('window-all-closed', async () => {
+  if (autoUpdaterService) {
+    autoUpdaterService.destroy();
+    autoUpdaterService = null;
+  }
   if (serviceManager) {
     await serviceManager.stopAll();
     serviceManager = null;

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "bip39": "^3.1.0",
         "cross-spawn": "^7.0.6",
+        "electron-updater": "^6.3.9",
         "find-free-port": "^2.0.0",
         "tree-kill": "^1.2.2",
         "wait-on": "^8.0.1"
@@ -1480,7 +1481,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -1837,7 +1837,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2360,7 +2359,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2814,6 +2812,69 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.7.3.tgz",
+      "integrity": "sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -4030,7 +4091,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -4826,7 +4886,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4901,7 +4960,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -4938,6 +4996,19 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -5259,7 +5330,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -6265,7 +6335,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6921,6 +6990,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/electron/package.json
+++ b/electron/package.json
@@ -37,11 +37,19 @@
   "dependencies": {
     "bip39": "^3.1.0",
     "cross-spawn": "^7.0.6",
+    "electron-updater": "^6.3.9",
     "find-free-port": "^2.0.0",
     "tree-kill": "^1.2.2",
     "wait-on": "^8.0.1"
   },
   "build": {
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "olympus-btc",
+        "repo": "ambrosia"
+      }
+    ],
     "appId": "com.olympus-btc.ambrosia-pos",
     "productName": "AmbrosiaPoS",
     "afterPack": "./scripts/afterPack.js",
@@ -74,7 +82,8 @@
       "category": "public.app-category.business",
       "artifactName": "ambrosia-pos-${version}-${arch}.${ext}",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "icon": "build/icon.icns",
       "hardenedRuntime": true,

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,22 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+const SEND_CHANNELS = ['ping', 'restart-server'];
+
+const INVOKE_CHANNELS = [
+  'services:get-statuses',
+  'services:restart',
+  'services:get-logs',
+  'update:install',
+  'update:open-release',
+];
+
+const RECEIVE_CHANNELS = [
+  'pong',
+  'server-status',
+  'update:available',
+  'update:downloaded',
+];
+
 // Expose APIs securely to the renderer
 contextBridge.exposeInMainWorld('electron', {
   // System information API
@@ -10,30 +27,31 @@ contextBridge.exposeInMainWorld('electron', {
     electron: process.versions.electron,
   },
 
-  // API for communication with main process (future)
+  // API for communication with main process
   ipc: {
     send: (channel, ...args) => {
-      // Whitelist of allowed channels
-      const validChannels = ['ping', 'restart-server'];
-      if (validChannels.includes(channel)) {
+      if (SEND_CHANNELS.includes(channel)) {
         ipcRenderer.send(channel, ...args);
       }
     },
+    invoke: (channel, ...args) => {
+      if (INVOKE_CHANNELS.includes(channel)) {
+        return ipcRenderer.invoke(channel, ...args);
+      }
+      return Promise.reject(new Error(`Invalid channel: ${channel}`));
+    },
     on: (channel, callback) => {
-      const validChannels = ['pong', 'server-status'];
-      if (validChannels.includes(channel)) {
-        ipcRenderer.on(channel, (event, ...args) => callback(...args));
+      if (RECEIVE_CHANNELS.includes(channel)) {
+        ipcRenderer.on(channel, (_event, ...args) => callback(...args));
       }
     },
     once: (channel, callback) => {
-      const validChannels = ['pong', 'server-status'];
-      if (validChannels.includes(channel)) {
-        ipcRenderer.once(channel, (event, ...args) => callback(...args));
+      if (RECEIVE_CHANNELS.includes(channel)) {
+        ipcRenderer.once(channel, (_event, ...args) => callback(...args));
       }
     },
     removeListener: (channel, callback) => {
-      const validChannels = ['pong', 'server-status'];
-      if (validChannels.includes(channel)) {
+      if (RECEIVE_CHANNELS.includes(channel)) {
         ipcRenderer.removeListener(channel, callback);
       }
     },

--- a/electron/services/AutoUpdater.js
+++ b/electron/services/AutoUpdater.js
@@ -1,0 +1,177 @@
+const { dialog, ipcMain, shell } = require('electron');
+const { autoUpdater } = require('electron-updater');
+
+const SUPPORTS_AUTO_UPDATE = process.platform === 'win32';
+
+class AutoUpdater {
+  constructor(mainWindow, { onMenuUpdate, releaseUrl } = {}) {
+    this.mainWindow = mainWindow;
+    this.checkInterval = null;
+    this.isManualCheck = false;
+    this.onMenuUpdate = onMenuUpdate || (() => {});
+    this.releaseUrl = releaseUrl || '';
+    this.pendingVersion = null;
+
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = false;
+    autoUpdater.forceCodeSigning = false;
+    autoUpdater.logger = console;
+
+    this._setupEvents();
+    this._setupIpcHandlers();
+  }
+
+  _setupEvents() {
+    autoUpdater.on('update-available', (info) => {
+      console.log('[AutoUpdater] Update available:', info.version);
+      this.pendingVersion = info.version;
+      this.isManualCheck = false;
+
+      if (SUPPORTS_AUTO_UPDATE) {
+        // Windows: download silently
+        this.onMenuUpdate({ label: 'Downloading Update...', enabled: false });
+        autoUpdater.downloadUpdate();
+      } else {
+        // macOS/Linux: notify and let user go to release page
+        this.onMenuUpdate({
+          label: `Update Available: ${info.version}`,
+          enabled: true,
+          click: () => this._showUpdateAvailableDialog(info.version),
+        });
+        this._sendToRenderer('update:available', { version: info.version });
+      }
+    });
+
+    autoUpdater.on('update-not-available', (info) => {
+      console.log('[AutoUpdater] Up to date:', info.version);
+      this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
+      if (this.isManualCheck) {
+        this.isManualCheck = false;
+        dialog.showMessageBox(this.mainWindow, {
+          type: 'info',
+          title: 'No Updates Available',
+          message: 'You\'re up to date!',
+          detail: `Ambrosia POS ${info.version} is the latest version.`,
+          buttons: ['OK'],
+        });
+      }
+    });
+
+    autoUpdater.on('download-progress', (progress) => {
+      console.log('[AutoUpdater] Download progress:', `${progress.percent.toFixed(1)}%`);
+    });
+
+    // Only fires on Windows (only platform that downloads)
+    autoUpdater.on('update-downloaded', (info) => {
+      console.log('[AutoUpdater] Update downloaded:', info.version);
+      this.onMenuUpdate({
+        label: `Restart to Update to ${info.version}`,
+        enabled: true,
+        click: () => autoUpdater.quitAndInstall(false, true),
+      });
+      this._sendToRenderer('update:downloaded', { version: info.version });
+    });
+
+    autoUpdater.on('error', (error) => {
+      console.error('[AutoUpdater] Error:', error.message);
+      this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
+      if (this.isManualCheck) {
+        this.isManualCheck = false;
+        dialog.showMessageBox(this.mainWindow, {
+          type: 'error',
+          title: 'Update Error',
+          message: 'Could not check for updates',
+          detail: error.message,
+          buttons: ['OK'],
+        });
+      }
+    });
+  }
+
+  _setupIpcHandlers() {
+    ipcMain.handle('update:install', () => {
+      if (SUPPORTS_AUTO_UPDATE) {
+        autoUpdater.quitAndInstall(false, true);
+      }
+    });
+
+    ipcMain.handle('update:open-release', () => {
+      this._openReleasePage(this.pendingVersion);
+    });
+  }
+
+  _showUpdateAvailableDialog(version) {
+    dialog.showMessageBox(this.mainWindow, {
+      type: 'info',
+      title: 'Update Available',
+      message: `Version ${version} is available.`,
+      detail: 'Would you like to go to the download page?',
+      buttons: ['Download', 'Later'],
+      defaultId: 0,
+      cancelId: 1,
+    }).then(({ response }) => {
+      if (response === 0) {
+        this._openReleasePage(version);
+      }
+    });
+  }
+
+  _openReleasePage(version) {
+    const url = version
+      ? `${this.releaseUrl}/tag/v${version}`
+      : this.releaseUrl;
+    shell.openExternal(url);
+  }
+
+  _sendToRenderer(channel, data) {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send(channel, data);
+    }
+  }
+
+  checkForUpdates() {
+    this.onMenuUpdate({ label: 'Checking for Updates...', enabled: false });
+    autoUpdater.checkForUpdates().catch((err) => {
+      console.error('[AutoUpdater] Scheduled check failed:', err.message);
+      this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
+    });
+  }
+
+  checkForUpdatesManual() {
+    this.isManualCheck = true;
+    this.onMenuUpdate({ label: 'Checking for Updates...', enabled: false });
+    autoUpdater.checkForUpdates().catch((err) => {
+      this.isManualCheck = false;
+      this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
+      dialog.showMessageBox(this.mainWindow, {
+        type: 'error',
+        title: 'Update Error',
+        message: 'Could not check for updates',
+        detail: err.message,
+        buttons: ['OK'],
+      });
+    });
+  }
+
+  startPeriodicChecks(intervalMs = 6 * 60 * 60 * 1000) {
+    this.checkForUpdates();
+    this.checkInterval = setInterval(() => {
+      this.checkForUpdates();
+    }, intervalMs);
+  }
+
+  stopPeriodicChecks() {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
+  }
+
+  destroy() {
+    this.stopPeriodicChecks();
+    ipcMain.removeHandler('update:install');
+    ipcMain.removeHandler('update:open-release');
+  }
+}
+
+module.exports = AutoUpdater;


### PR DESCRIPTION
### Changes:
                                                  
  - Add AutoUpdater service (electron/services/AutoUpdater.js).
  - Windows: auto-downloads update silently, shows "Restart & Update" when ready.
  - macOS/Linux: notifies update available and redirects to GitHub release page.
  - Add periodic update checks every 6 hours (production only) and manual "Check for Updates..." menu item.
  - Dynamic menu item updates to reflect update state (checking, downloading, ready to install).
  - Native dialog feedback on manual check: "You're up to date" or error message.
  - Add UpdateBanner component for in-app update notification.
  - Add browser fallback: opens GitHub releases page via window.open when not in Electron.