### PR TITLE
refactor(client): add httpClient in configurationsProvider

### DIFF
--- a/client/src/providers/configurations/configurationsProvider.jsx
+++ b/client/src/providers/configurations/configurationsProvider.jsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import { apiClient } from "../../services/apiClient";
-import { useUpload } from "../../components/hooks/useUpload";
+import { httpClient } from "@/lib/http/httpClient"
+import { parseJsonResponse } from "@/lib/http/parseJsonResponse"
+import { useUpload } from "@/components/hooks/useUpload";
 
 export const ConfigurationsContext = createContext();
 
@@ -31,12 +32,14 @@ export function ConfigurationsProvider({ children }) {
   const fetchConfig = async () => {
     try {
       setIsLoading(true);
-      const data = await apiClient("/config", {
+      const configResponse = await httpClient("/config", {
         skipRefresh: true,
-        silentAuth: true,
       });
-      setConfig(data);
-    } catch (err) {
+
+      const configData = await parseJsonResponse(configResponse);
+
+      setConfig(configData);
+    } catch (error) {
       setConfig(null);
     } finally {
       setIsLoading(false);
@@ -64,12 +67,15 @@ export function ConfigurationsProvider({ children }) {
 
 
     try {
-      const updateConfigResponse = await apiClient(`/config`, {
+      const updateConfigResponse = await httpClient(`/config`, {
         method: "PUT",
-        body: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
           ...configDataToSend,
           ...(logoUrl && { businessLogoUrl: logoUrl }),
-        },
+        }),
       });
 
       await fetchConfig();


### PR DESCRIPTION
This pull request refactors the configuration provider to use a new HTTP client and improves how JSON responses are handled. The most important changes are grouped below:

**HTTP client migration:**

* Replaced usage of `apiClient` with `httpClient` for all configuration-related API calls in `configurationsProvider.jsx`. [[1]](diffhunk://#diff-16bc79447c0c251c233ebce353ba98a30af7dbf58d7ab990e2f17c00f7a45a8bL4-R6) [[2]](diffhunk://#diff-16bc79447c0c251c233ebce353ba98a30af7dbf58d7ab990e2f17c00f7a45a8bL34-R42) [[3]](diffhunk://#diff-16bc79447c0c251c233ebce353ba98a30af7dbf58d7ab990e2f17c00f7a45a8bL67-R78)

**JSON response handling:**

* Added `parseJsonResponse` to process responses from the new HTTP client, ensuring proper parsing and error handling. [[1]](diffhunk://#diff-16bc79447c0c251c233ebce353ba98a30af7dbf58d7ab990e2f17c00f7a45a8bL4-R6) [[2]](diffhunk://#diff-16bc79447c0c251c233ebce353ba98a30af7dbf58d7ab990e2f17c00f7a45a8bL34-R42)

**Request formatting improvements:**

* Updated the configuration update request to include explicit `Content-Type: application/json` headers and use `JSON.stringify` for the request body.