### PR TITLE
fix (server): server security hardening

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -110,7 +110,7 @@ class Ambrosia : CliktCommand() {
                 value
             }
         val jwtAccessTokenExpirationSeconds by
-            option("--jwt-access-token-expiration", help = "Access token expiration in seconds (default: 60)").default("60")
+            option("--jwt-access-token-expiration", help = "Access token expiration in seconds").default("60")
         val phoenixdWebhookSecret by
             option(
                 "--phoenixd-webhook-secret",

--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -13,6 +13,7 @@ import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
+import io.ktor.server.plugins.origin
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.pingPeriod
 import io.ktor.server.websocket.timeout

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 private object LoginRateLimiter {
     private val failedAttempts = ConcurrentHashMap<String, Pair<Int, Long>>()
     private const val MAX_FAILURES = 5
-    private val WINDOW_MS = 2 * 60 * 1000L // 2 minutes
+    private val WINDOW_MS = 2 * 60 * 1000L
 
     fun isBlocked(ip: String): Boolean {
         val (count, since) = failedAttempts[ip] ?: return false

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -188,7 +188,6 @@ fun Route.auth(
 
             tokenService.revokeRefreshToken(userId)
 
-            // Eliminar las cookies usando maxAge = 0
             call.response.cookies.append(
                 Cookie(
                     name = "accessToken",

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -27,6 +27,39 @@ import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.InvalidCredentialsException
 import pos.ambrosia.utils.InvalidTokenException
 import java.sql.Connection
+import java.util.concurrent.ConcurrentHashMap
+
+private object LoginRateLimiter {
+    private val failedAttempts = ConcurrentHashMap<String, Pair<Int, Long>>()
+    private const val MAX_FAILURES = 5
+    private val WINDOW_MS = 2 * 60 * 1000L // 2 minutes
+
+    fun isBlocked(ip: String): Boolean {
+        val (count, since) = failedAttempts[ip] ?: return false
+        return if (System.currentTimeMillis() - since >= WINDOW_MS) {
+            failedAttempts.remove(ip)
+            false
+        } else {
+            count >= MAX_FAILURES
+        }
+    }
+
+    fun recordFailure(ip: String) {
+        val now = System.currentTimeMillis()
+        failedAttempts.compute(ip) { _, existing ->
+            if (existing != null) {
+                val (count, since) = existing
+                if (now - since < WINDOW_MS) Pair(count + 1, since) else Pair(1, now)
+            } else {
+                Pair(1, now)
+            }
+        }
+    }
+
+    fun reset(ip: String) {
+        failedAttempts.remove(ip)
+    }
+}
 
 fun Application.configureAuth() {
     val connection: Connection = DatabaseConnection.getConnection()
@@ -42,6 +75,12 @@ fun Route.auth(
     permissionsService: PermissionsService,
 ) {
     post("/login") {
+        val ip = call.request.origin.remoteAddress
+        if (LoginRateLimiter.isBlocked(ip)) {
+            call.respond(HttpStatusCode.TooManyRequests)
+            return@post
+        }
+
         val loginRequest = call.receive<AuthRequest>()
         val userInfo = authService.authenticateUser(loginRequest.name, loginRequest.pin.toCharArray())
         logger.info(userInfo?.toString() ?: "User not found")
@@ -50,8 +89,11 @@ fun Route.auth(
                 call.request.header("X-Forwarded-Proto") == "https"
 
         if (userInfo == null) {
+            LoginRateLimiter.recordFailure(ip)
             throw InvalidCredentialsException()
         }
+
+        LoginRateLimiter.reset(ip)
         val accessTokenResponse = tokenService.generateAccessToken(userInfo)
         val refreshTokenResponse = tokenService.generateRefreshToken(userInfo)
 
@@ -105,8 +147,6 @@ fun Route.auth(
         val isSecureRequest =
             call.request.origin.scheme == "https" ||
                 call.request.header("X-Forwarded-Proto") == "https"
-
-        logger.info("Refreshing token with: $refreshToken")
 
         val isValidRefreshToken = tokenService.validateRefreshToken(refreshToken)
         if (!isValidRefreshToken) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -88,7 +88,6 @@ fun Application.handler() {
             logger.error("Print ticket error: ${cause.message}")
             call.respond(HttpStatusCode.ServiceUnavailable, Message("Error processing print job"))
         }
-        // catch-all handlers van al final para no sombrar los específicos
         exception<Exception> { call, cause ->
             logger.error("Unhandled exception: ${cause.message}")
             call.respond(HttpStatusCode.InternalServerError, Message("Internal server error"))

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -19,7 +19,9 @@ import pos.ambrosia.utils.PhoenixBalanceException
 import pos.ambrosia.utils.PhoenixConnectionException
 import pos.ambrosia.utils.PhoenixNodeInfoException
 import pos.ambrosia.utils.PhoenixServiceException
+import pos.ambrosia.utils.PrintTicketException
 import pos.ambrosia.utils.UnauthorizedApiException
+import pos.ambrosia.utils.WalletOnlyException
 import java.sql.SQLException
 
 fun Application.handler() {
@@ -27,13 +29,6 @@ fun Application.handler() {
         exception<SQLException> { call, cause ->
             logger.error("Database connection error: ${cause.message}", cause)
             call.respond(HttpStatusCode.InternalServerError, Message("Error connecting to the database"))
-        }
-        exception<Throwable> { call, cause ->
-            logger.error("Unhandled Throwable: ${cause.message}", cause)
-            call.respondText(
-                text = cause.message ?: "",
-                status = defaultExceptionStatusCode(cause) ?: HttpStatusCode.InternalServerError,
-            )
         }
         exception<InvalidCredentialsException> { call, cause ->
             logger.warn("Invalid login attempt: ${cause.message}")
@@ -43,6 +38,10 @@ fun Application.handler() {
             logger.warn("Invalid token: ${cause.message}")
             call.respond(HttpStatusCode.Unauthorized, Message("Invalid token"))
         }
+        exception<UnauthorizedApiException> { call, _ ->
+            logger.warn("Unauthorized API access attempt")
+            call.respond(HttpStatusCode.Unauthorized, Message("Unauthorized API access"))
+        }
         exception<DuplicateUserNameException> { call, cause ->
             logger.warn("Duplicate user name: ${cause.message}")
             call.respond(HttpStatusCode.Conflict, Message("User name already exists"))
@@ -50,14 +49,6 @@ fun Application.handler() {
         exception<LastUserDeletionException> { call, cause ->
             logger.warn("Attempt to delete last user: ${cause.message}")
             call.respond(HttpStatusCode.Conflict, Message("Cannot delete the last user"))
-        }
-        exception<Exception> { call, cause ->
-            logger.error("Unhandled exception: ${cause.message}")
-            call.respond(HttpStatusCode.InternalServerError, Message("Internal server error"))
-        }
-        exception<UnauthorizedApiException> { call, _ ->
-            logger.warn("Unauthorized API access attempt")
-            call.respond(HttpStatusCode.Unauthorized, Message("Unauthorized API access"))
         }
         exception<AdminOnlyException> { call, _ ->
             logger.warn("Non-admin user attempted to access admin-only endpoint")
@@ -88,6 +79,23 @@ fun Application.handler() {
         exception<PhoenixServiceException> { call, cause ->
             logger.error("Phoenix service error: ${cause.message}")
             call.respond(HttpStatusCode.ServiceUnavailable, Message("Lightning node service error"))
+        }
+        exception<WalletOnlyException> { call, _ ->
+            logger.warn("Wallet-only endpoint accessed without wallet token")
+            call.respond(HttpStatusCode.Forbidden, Message("Wallet access required"))
+        }
+        exception<PrintTicketException> { call, cause ->
+            logger.error("Print ticket error: ${cause.message}")
+            call.respond(HttpStatusCode.ServiceUnavailable, Message("Error processing print job"))
+        }
+        // catch-all handlers van al final para no sombrar los específicos
+        exception<Exception> { call, cause ->
+            logger.error("Unhandled exception: ${cause.message}")
+            call.respond(HttpStatusCode.InternalServerError, Message("Internal server error"))
+        }
+        exception<Throwable> { call, cause ->
+            logger.error("Unhandled Throwable: ${cause.message}", cause)
+            call.respond(HttpStatusCode.InternalServerError, Message("Internal server error"))
         }
     }
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
@@ -141,7 +141,6 @@ private fun Route.initialSetupRoutes(connection: Connection) {
                 throw IllegalStateException("Failed to set base currency")
             }
 
-            connection.autoCommit = false
             connection.commit()
             call.respond(HttpStatusCode.Created, mapOf("message" to "Initial setup completed", "userId" to userId, "roleId" to roleId))
         } catch (e: Exception) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
@@ -23,6 +23,7 @@ import pos.ambrosia.services.PrintService
 import pos.ambrosia.services.PrinterConfigService
 import pos.ambrosia.services.PrinterConfigUpdateStatus
 import pos.ambrosia.services.TicketTemplateService
+import pos.ambrosia.utils.PrintTicketException
 
 fun Application.configurePrinters() {
     val connection = DatabaseConnection.getConnection()
@@ -123,7 +124,7 @@ fun Route.printers(
                 )
                 call.respondText("Print job sent", status = HttpStatusCode.OK)
             } catch (e: Exception) {
-                throw pos.ambrosia.utils.PrintTicketException(e.message ?: "An unknown error occurred during printing.")
+                throw PrintTicketException(e.message ?: "An unknown error occurred during printing.")
             }
         }
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -90,7 +90,6 @@ fun Route.roles(
 
             val updatedRole = call.receive<Role>()
             val isUpdated = roleService.updateRole(id, updatedRole)
-            logger.info(isUpdated.toString())
 
             if (!isUpdated) {
                 call.respond(HttpStatusCode.NotFound, "Role with ID: $id not found")

--- a/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
@@ -72,10 +72,9 @@ class AuthService(
             val storedPasswordHashBase64 = resultSet.getString("role_password")
             val storedPasswordHash = SecurePinProcessor.base64ToByteArray(storedPasswordHashBase64)
 
-            // The salt for role password is the role ID.
             val isValidPassword =
                 SecurePinProcessor.verifyPin(rolePassword, roleId, storedPasswordHash, env)
-            rolePassword.fill('\u0000') // Clear password from memory
+            rolePassword.fill('\u0000')
 
             return isValidPassword
         }

--- a/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
@@ -44,7 +44,6 @@ class AuthService(
             val isValidPin = SecurePinProcessor.verifyPin(pin, userIdString, storedPinHash, env)
             pin.fill('\u0000') // Limpiar PIN de memoria
 
-            logger.info("Authentication result for user pin: $isValidPin")
             if (isValidPin) {
                 return AuthResponse(
                     id = userIdString,
@@ -78,7 +77,6 @@ class AuthService(
                 SecurePinProcessor.verifyPin(rolePassword, roleId, storedPasswordHash, env)
             rolePassword.fill('\u0000') // Clear password from memory
 
-            logger.info("Authentication result for role password: $isValidPassword")
             return isValidPassword
         }
         return false

--- a/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/AuthService.kt
@@ -42,7 +42,7 @@ class AuthService(
             val storedPinHash = SecurePinProcessor.base64ToByteArray(storedPinHashBase64)
 
             val isValidPin = SecurePinProcessor.verifyPin(pin, userIdString, storedPinHash, env)
-            pin.fill('\u0000') // Limpiar PIN de memoria
+            pin.fill('\u0000')
 
             if (isValidPin) {
                 return AuthResponse(

--- a/server/app/src/main/kotlin/pos/ambrosia/util/SecurePinProcessor.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/SecurePinProcessor.kt
@@ -56,7 +56,6 @@ object SecurePinProcessor {
         env: ApplicationEnvironment,
     ): Boolean {
         val newHash = hashPinForStorage(enteredPin, id, env)
-        logger.info("Pins: " + newHash + " = " + storedHash)
         return MessageDigest.isEqual(newHash, storedHash)
     }
 

--- a/server/e2e_tests_py/tests/test_rate_limit_e2e.py
+++ b/server/e2e_tests_py/tests/test_rate_limit_e2e.py
@@ -1,0 +1,117 @@
+"""End-to-end tests for the login rate limiter (LoginRateLimiter in Authorize.kt).
+
+The rate limiter only counts FAILED login attempts per IP address:
+  - Successful login  → counter reset, no token consumed
+  - Failed login      → counter incremented
+  - After 5 failures  → 429 Too Many Requests for 2 minutes
+
+Because successful logins do not consume tokens, these tests can run
+as part of the full suite without breaking other auth tests.
+"""
+
+import logging
+
+import pytest
+
+from ambrosia.auth_utils import DEFAULT_TEST_USER
+from ambrosia.http_client import AmbrosiaHttpClient
+
+logger = logging.getLogger(__name__)
+
+# Must match LoginRateLimiter.MAX_FAILURES in Authorize.kt
+MAX_FAILURES = 5
+INVALID_CREDS = {"name": "nonexistent_user", "pin": "9999"}
+
+
+class TestLoginRateLimit:
+    """Tests for the failure-based login rate limiter."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.slow
+    async def test_successful_logins_do_not_consume_rate_limit_tokens(
+        self, server_url: str
+    ):
+        """Successful logins must not count toward the rate limit.
+
+        After a successful login the failure counter is reset, so a user
+        who occasionally mistyped their PIN is not locked out.
+        """
+        async with AmbrosiaHttpClient(server_url) as client:
+            # Accumulate MAX_FAILURES - 1 failed attempts
+            for i in range(MAX_FAILURES - 1):
+                response = await client.post("/auth/login", json=INVALID_CREDS)
+                assert response.status_code in (400, 401), (
+                    f"Failed attempt {i + 1}: expected 400/401, got {response.status_code}"
+                )
+
+            # A successful login resets the counter — must return 200, not 429
+            response = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert response.status_code == 200, (
+                f"Successful login after {MAX_FAILURES - 1} failures: "
+                f"expected 200 (counter reset), got {response.status_code}"
+            )
+            logger.info(
+                f"✓ Successful login after {MAX_FAILURES - 1} failures returned 200 "
+                "(counter reset confirmed)"
+            )
+
+            # Counter is now 0 again — a full new window of failures is available
+            for i in range(MAX_FAILURES - 1):
+                response = await client.post("/auth/login", json=INVALID_CREDS)
+                assert response.status_code in (400, 401), (
+                    f"Post-reset failed attempt {i + 1}: expected 400/401, "
+                    f"got {response.status_code} (counter should have reset)"
+                )
+
+        logger.info("✓ Successful logins correctly reset the failure counter")
+
+    @pytest.mark.asyncio
+    @pytest.mark.slow
+    async def test_rate_limit_blocks_after_five_failed_logins(self, server_url: str):
+        """After MAX_FAILURES consecutive bad logins the IP must be blocked (429).
+
+        Also verifies:
+        - Each of the first MAX_FAILURES attempts returns a credential error (not 429)
+        - A brand-new client session from the same IP shares the blocked bucket
+        """
+        async with AmbrosiaHttpClient(server_url) as client:
+            # Reset the counter with a successful login so the test is order-independent
+            reset = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert reset.status_code == 200, (
+                f"Pre-test reset login: expected 200, got {reset.status_code}"
+            )
+
+            # Exhaust the allowed failures
+            for i in range(MAX_FAILURES):
+                response = await client.post("/auth/login", json=INVALID_CREDS)
+                assert response.status_code in (400, 401), (
+                    f"Failed attempt {i + 1}/{MAX_FAILURES}: expected 400/401, "
+                    f"got {response.status_code}"
+                )
+                logger.info(f"Attempt {i + 1}/{MAX_FAILURES}: {response.status_code}")
+
+            # Next attempt must be blocked — even with valid credentials
+            response = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert response.status_code == 429, (
+                f"Attempt {MAX_FAILURES + 1}: expected 429 (rate limited), "
+                f"got {response.status_code}"
+            )
+            logger.info(
+                f"Attempt {MAX_FAILURES + 1}: {response.status_code} (blocked ✓)"
+            )
+
+        # New client session from the same IP must also be blocked (bucket is per-IP)
+        async with AmbrosiaHttpClient(server_url) as new_client:
+            response = await new_client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert response.status_code == 429, (
+                "New session from same IP should share the blocked bucket, "
+                f"got {response.status_code}"
+            )
+            logger.info(
+                f"New session, same IP: {response.status_code} (shared bucket ✓)"
+            )
+
+        logger.info(
+            f"✓ IP blocked after {MAX_FAILURES} failed logins; "
+            "block is shared across sessions"
+        )


### PR DESCRIPTION
### Summary

- Add IP-based rate limiting to `POST /auth/login` (blocks after 5 failed attempts in 2 min window)
- Remove sensitive data from logs: refresh tokens, PIN hashes, and auth results
- Reorder Ktor exception handlers so specific handlers
- Add missing `WalletOnlyException` and `PrintTicketException` mappings to `Handler.kt`
- Remove duplicate `autoCommit = false` in `InitialSetup.kt` that could corrupt transactions
- Remove debug log without context in `Roles.kt` update handler

### Commits

| Commit | Type | Description |
|---|---|---|
| `9e445f7` | `feat` | Add login rate limiting to auth endpoint |
| `91ac4ff` | `fix` | Remove sensitive auth data from logs |
| `b82fbbb` | `fix` | Reorder exception handlers and add missing mappings |
| `2cf76e1` | `fix` | Remove duplicate autoCommit in initial setup transaction |
| `c784d53` | `fix` | Remove debug log without context in roles update |
| `e4f0cc0` | `docs` | Clarify jwt-access-token-expiration CLI option |

### Test plan

- [x] E2E rate limiting: `pytest tests/test_rate_limit_e2e.py`
- [x] Server unit tests: `./gradlew test`
- [x] Kotlin linter: `./gradlew ktlintCheck`
- [x] Verify login blocks after 5 failed attempts and resets on success
