### PR TITLE
Feature/settings auto liquidity

### DIFF
--- a/client/src/components/pages/Store/Settings/Lightning/LightningCard.jsx
+++ b/client/src/components/pages/Store/Settings/Lightning/LightningCard.jsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { addToast, Card, CardBody, CardHeader, Switch } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { useAutoLiquidity } from "@/hooks/useAutoLiquidity";
+
+export function LightningCard() {
+  const t = useTranslations("lightning");
+  const { enabled, loading, restarting, toggle } = useAutoLiquidity();
+
+  const handleToggle = async (newEnabled) => {
+    const result = await toggle(newEnabled);
+    if (result === "manual") {
+      addToast({ color: "warning", description: t("manualRestartRequired") });
+    } else if (result) {
+      addToast({ color: "success", description: t("restartSuccess") });
+    } else {
+      addToast({ color: "danger", description: t("restartError") });
+    }
+  };
+
+  return (
+    <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+      <CardHeader className="flex flex-col items-start">
+        <h2 className="text-2xl font-semibold text-green-900">
+          {t("title")}
+        </h2>
+      </CardHeader>
+
+      <CardBody>
+        <div className="flex flex-col gap-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="font-semibold text-gray-700">
+                {t("autoLiquidityLabel")}
+              </span>
+              <span className="text-sm text-gray-500">
+                {t("autoLiquidityDescription")}
+              </span>
+              {enabled && (
+                <span className="text-xs text-amber-600 mt-1">
+                  ⚠ {t("autoLiquidityWarning")}
+                </span>
+              )}
+            </div>
+
+            <Switch
+              isSelected={enabled}
+              isDisabled={loading || restarting}
+              onValueChange={handleToggle}
+            />
+          </div>
+
+          {restarting && (
+            <p className="text-sm text-gray-500 italic">{t("restarting")}</p>
+          )}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -9,6 +9,7 @@ import { useTranslations, useLocale } from "next-intl";
 
 import { useUpload } from "@components/hooks/useUpload";
 import { LanguageSwitcher } from "@i18n/I18nProvider";
+import { isElectron } from "@lib/isElectron";
 import { useConfigurations } from "@providers/configurations/configurationsProvider";
 
 import { useCurrency } from "../../../hooks/useCurrency";
@@ -20,6 +21,7 @@ import { useTemplates } from "../hooks/useTemplates";
 import { StoreLayout } from "../StoreLayout";
 
 import { EditSettingsModal } from "./EditSettingsModal";
+import { LightningCard } from "./Lightning/LightningCard";
 import { PrinterSettingsCard } from "./Printer/PrinterSettingsCard";
 import { SeedCard } from "./Seed/SeedCard";
 import { TemplateList } from "./TicketTemplate/TemplateList";
@@ -325,6 +327,12 @@ export function Settings() {
         <div className="flex flex-col lg:w-[47%] h-full">
           <TutorialsCard t={t} />
         </div>
+
+        {isElectron && (
+          <div className="flex flex-col lg:w-[47%] h-full">
+            <LightningCard />
+          </div>
+        )}
       </div>
 
       <EditSettingsModal

--- a/client/src/components/pages/Store/Settings/__tests__/LightningCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/LightningCard.test.jsx
@@ -1,0 +1,183 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import * as useAutoLiquidityHook from "@/hooks/useAutoLiquidity";
+import { I18nProvider } from "@i18n/I18nProvider";
+
+import { LightningCard } from "../Lightning/LightningCard";
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Card: ({ children, ...props }) => <div {...props}>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  Switch: ({ isSelected, isDisabled, onValueChange }) => (
+    <button
+      role="switch"
+      aria-checked={isSelected}
+      disabled={isDisabled}
+      onClick={() => onValueChange && onValueChange(!isSelected)}
+    />
+  ),
+}));
+
+const { addToast } = require("@heroui/react");
+
+const mockToggle = jest.fn();
+
+function mockHook(overrides = {}) {
+  jest.spyOn(useAutoLiquidityHook, "useAutoLiquidity").mockReturnValue({
+    enabled: false,
+    loading: false,
+    restarting: false,
+    error: null,
+    toggle: mockToggle,
+    ...overrides,
+  });
+}
+
+function renderCard() {
+  return render(
+    <I18nProvider>
+      <LightningCard />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LightningCard", () => {
+  describe("Rendering", () => {
+    it("renders the title", () => {
+      mockHook();
+      renderCard();
+      expect(screen.getByText("title")).toBeInTheDocument();
+    });
+
+    it("renders the auto liquidity label", () => {
+      mockHook();
+      renderCard();
+      expect(screen.getByText("autoLiquidityLabel")).toBeInTheDocument();
+    });
+
+    it("renders the description", () => {
+      mockHook();
+      renderCard();
+      expect(screen.getByText("autoLiquidityDescription")).toBeInTheDocument();
+    });
+
+    it("renders switch in off state when enabled=false", () => {
+      mockHook({ enabled: false });
+      renderCard();
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("renders switch in on state when enabled=true", () => {
+      mockHook({ enabled: true });
+      renderCard();
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("shows warning text when enabled=true", () => {
+      mockHook({ enabled: true });
+      renderCard();
+      expect(screen.getByText(/autoLiquidityWarning/)).toBeInTheDocument();
+    });
+
+    it("does not show warning text when enabled=false", () => {
+      mockHook({ enabled: false });
+      renderCard();
+      expect(screen.queryByText(/autoLiquidityWarning/)).not.toBeInTheDocument();
+    });
+
+    it("shows restarting text when restarting=true", () => {
+      mockHook({ restarting: true });
+      renderCard();
+      expect(screen.getByText("restarting")).toBeInTheDocument();
+    });
+
+    it("does not show restarting text when restarting=false", () => {
+      mockHook({ restarting: false });
+      renderCard();
+      expect(screen.queryByText("restarting")).not.toBeInTheDocument();
+    });
+
+    it("disables switch when loading=true", () => {
+      mockHook({ loading: true });
+      renderCard();
+      expect(screen.getByRole("switch")).toBeDisabled();
+    });
+
+    it("disables switch when restarting=true", () => {
+      mockHook({ restarting: true });
+      renderCard();
+      expect(screen.getByRole("switch")).toBeDisabled();
+    });
+
+    it("enables switch when loading=false and restarting=false", () => {
+      mockHook({ loading: false, restarting: false });
+      renderCard();
+      expect(screen.getByRole("switch")).not.toBeDisabled();
+    });
+  });
+
+  describe("Toggle interactions", () => {
+    it("calls toggle when switch is clicked", async () => {
+      const user = userEvent.setup();
+      mockToggle.mockResolvedValue(true);
+      mockHook({ enabled: false });
+      renderCard();
+
+      await user.click(screen.getByRole("switch"));
+
+      expect(mockToggle).toHaveBeenCalledWith(true);
+    });
+
+    it("shows success toast when toggle returns true", async () => {
+      const user = userEvent.setup();
+      mockToggle.mockResolvedValue(true);
+      mockHook({ enabled: false });
+      renderCard();
+
+      await act(async () => {
+        await user.click(screen.getByRole("switch"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "success", description: "restartSuccess" }),
+      );
+    });
+
+    it("shows warning toast when toggle returns 'manual'", async () => {
+      const user = userEvent.setup();
+      mockToggle.mockResolvedValue("manual");
+      mockHook({ enabled: false });
+      renderCard();
+
+      await act(async () => {
+        await user.click(screen.getByRole("switch"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "warning", description: "manualRestartRequired" }),
+      );
+    });
+
+    it("shows danger toast when toggle returns false", async () => {
+      const user = userEvent.setup();
+      mockToggle.mockResolvedValue(false);
+      mockHook({ enabled: false });
+      renderCard();
+
+      await act(async () => {
+        await user.click(screen.getByRole("switch"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "restartError" }),
+      );
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
@@ -3,12 +3,17 @@ import userEvent from "@testing-library/user-event";
 
 import * as usePrintersHook from "@/components/pages/Store/hooks/usePrinter";
 import * as useTemplatesHook from "@/components/pages/Store/hooks/useTemplates";
+import * as useAutoLiquidityHook from "@/hooks/useAutoLiquidity";
 import * as useCurrencyHook from "@components/hooks/useCurrency";
 import * as useModulesHook from "@hooks/useModules";
 import { I18nProvider } from "@i18n/I18nProvider";
 import * as configurationsProvider from "@providers/configurations/configurationsProvider";
 
 import { Settings } from "../Settings";
+
+jest.mock("@lib/isElectron", () => ({
+  get isElectron() { return global.__mockIsElectron ?? false; },
+}));
 
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
@@ -140,6 +145,14 @@ beforeEach(() => {
     createTemplate: jest.fn(),
     updateTemplate: jest.fn(),
     deleteTemplate: jest.fn(),
+  });
+
+  jest.spyOn(useAutoLiquidityHook, "useAutoLiquidity").mockReturnValue({
+    enabled: false,
+    loading: false,
+    restarting: false,
+    error: null,
+    toggle: jest.fn(),
   });
 });
 
@@ -420,6 +433,30 @@ describe("Settings page", () => {
       await waitFor(() => {
         expect(mockUpdateCurrency).toHaveBeenCalledWith({ acronym: "EUR" });
       });
+    });
+  });
+
+  describe("LightningCard visibility", () => {
+    it("does not render LightningCard when not in Electron context", async () => {
+      global.__mockIsElectron = false;
+
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.queryByText("autoLiquidityLabel")).not.toBeInTheDocument();
+    });
+
+    it("renders LightningCard when in Electron context", async () => {
+      global.__mockIsElectron = true;
+
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.getByText("autoLiquidityLabel")).toBeInTheDocument();
+
+      global.__mockIsElectron = false;
     });
   });
 

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -615,6 +615,16 @@ const storeEn = {
       confirming: "Closing...",
     },
   },
+  lightning: {
+    title: "Lightning Network",
+    autoLiquidityLabel: "Auto Liquidity",
+    autoLiquidityDescription: "Automatically open channels when inbound liquidity is needed.",
+    autoLiquidityWarning: "On-chain fees apply each time a channel is opened automatically.",
+    restarting: "Restarting Lightning...",
+    restartSuccess: "Lightning restarted successfully",
+    restartError: "Failed to restart Lightning",
+    manualRestartRequired: "Config saved. Restart phoenixd manually to apply the change.",
+  },
 };
 
 export default storeEn;

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -619,6 +619,16 @@ const storeEs = {
       confirming: "Cerrando...",
     },
   },
+  lightning: {
+    title: "Lightning Network",
+    autoLiquidityLabel: "Auto Liquidez",
+    autoLiquidityDescription: "Abre canales automáticamente cuando se necesita liquidez entrante.",
+    autoLiquidityWarning: "Se aplican comisiones on-chain cada vez que se abre un canal automáticamente.",
+    restarting: "Reiniciando Lightning...",
+    restartSuccess: "Lightning reiniciado correctamente",
+    restartError: "Error al reiniciar Lightning",
+    manualRestartRequired: "Configuración guardada. Reinicia phoenixd manualmente para aplicar el cambio.",
+  },
 };
 
 export default storeEs;

--- a/client/src/hooks/__tests__/useAutoLiquidity.test.js
+++ b/client/src/hooks/__tests__/useAutoLiquidity.test.js
@@ -1,0 +1,212 @@
+import { renderHook, act } from "@testing-library/react";
+
+import { useAutoLiquidity } from "../useAutoLiquidity";
+
+jest.mock("@lib/isElectron", () => ({ isElectron: true }));
+
+const mockInvoke = jest.fn();
+const originalError = console.error;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  console.error = jest.fn();
+  window.electron = { ipc: { invoke: mockInvoke } };
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  console.error = originalError;
+  delete window.electron;
+});
+
+describe("useAutoLiquidity", () => {
+  describe("initial load", () => {
+    it("starts with loading=true and enabled=false", () => {
+      mockInvoke.mockResolvedValue("off");
+      const { result } = renderHook(() => useAutoLiquidity());
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.enabled).toBe(false);
+    });
+
+    it("sets enabled=false when config returns 'off'", async () => {
+      mockInvoke.mockResolvedValue("off");
+      const { result } = renderHook(() => useAutoLiquidity());
+
+      await act(async () => {});
+
+      expect(result.current.enabled).toBe(false);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("sets enabled=true when config returns '2m'", async () => {
+      mockInvoke.mockResolvedValue("2m");
+      const { result } = renderHook(() => useAutoLiquidity());
+
+      await act(async () => {});
+
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("sets error when IPC call fails on mount", async () => {
+      mockInvoke.mockRejectedValue(new Error("IPC error"));
+      const { result } = renderHook(() => useAutoLiquidity());
+
+      await act(async () => {});
+
+      expect(result.current.error).toBe("IPC error");
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe("toggle", () => {
+    it("updates enabled optimistically before IPC resolves", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      act(() => {
+        result.current.toggle(true);
+      });
+
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.restarting).toBe(true);
+    });
+
+    it("sends '2m' when enabling", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      await act(async () => {
+        const togglePromise = result.current.toggle(true);
+        jest.runAllTimers();
+        await togglePromise;
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("phoenixd:set-auto-liquidity", "2m");
+    });
+
+    it("sends 'off' when disabling", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("2m")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      await act(async () => {
+        const togglePromise = result.current.toggle(false);
+        jest.runAllTimers();
+        await togglePromise;
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("phoenixd:set-auto-liquidity", "off");
+    });
+
+    it("returns true on success", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      let returnValue;
+      await act(async () => {
+        const togglePromise = result.current.toggle(true);
+        jest.runAllTimers();
+        returnValue = await togglePromise;
+      });
+
+      expect(returnValue).toBe(true);
+    });
+
+    it("returns 'manual' when requiresManualRestart is true", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue({ requiresManualRestart: true });
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      let returnValue;
+      await act(async () => {
+        const togglePromise = result.current.toggle(true);
+        jest.runAllTimers();
+        returnValue = await togglePromise;
+      });
+
+      expect(returnValue).toBe("manual");
+    });
+
+    it("reverts enabled and returns false when IPC fails", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockRejectedValue(new Error("restart failed"));
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      let returnValue;
+      await act(async () => {
+        const togglePromise = result.current.toggle(true);
+        jest.runAllTimers();
+        returnValue = await togglePromise;
+      });
+
+      expect(returnValue).toBe(false);
+      expect(result.current.enabled).toBe(false);
+      expect(result.current.error).toBe("restart failed");
+    });
+
+    it("sets restarting=false after toggle completes", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      await act(async () => {
+        const togglePromise = result.current.toggle(true);
+        jest.runAllTimers();
+        await togglePromise;
+      });
+
+      expect(result.current.restarting).toBe(false);
+    });
+
+    it("debounces rapid successive calls and only sends one IPC call", async () => {
+      mockInvoke
+        .mockResolvedValueOnce("off")
+        .mockResolvedValue(true);
+
+      const { result } = renderHook(() => useAutoLiquidity());
+      await act(async () => {});
+
+      await act(async () => {
+        result.current.toggle(true);
+        result.current.toggle(false);
+        result.current.toggle(true);
+        jest.runAllTimers();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const setCalls = mockInvoke.mock.calls.filter(
+        ([channel]) => channel === "phoenixd:set-auto-liquidity",
+      );
+      expect(setCalls).toHaveLength(1);
+      expect(setCalls[0][1]).toBe("2m");
+    });
+  });
+});

--- a/client/src/hooks/useAutoLiquidity.js
+++ b/client/src/hooks/useAutoLiquidity.js
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { isElectron } from "@lib/isElectron";
+
+const DEBOUNCE_MS = 500;
+
+export function useAutoLiquidity() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [restarting, setRestarting] = useState(false);
+  const [error, setError] = useState(null);
+  const debounceTimer = useRef(null);
+
+  useEffect(() => {
+    if (!isElectron) {
+      setLoading(false);
+      return;
+    }
+    window.electron.ipc
+      .invoke("phoenixd:get-auto-liquidity")
+      .then((value) => {
+        setEnabled(value !== "off");
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggle = useCallback(async (newEnabled) => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+
+    setEnabled(newEnabled);
+    setRestarting(true);
+    setError(null);
+
+    await new Promise((resolve) => {
+      debounceTimer.current = setTimeout(resolve, DEBOUNCE_MS);
+    });
+
+    try {
+      const value = newEnabled ? "2m" : "off";
+      const result = await window.electron.ipc.invoke("phoenixd:set-auto-liquidity", value);
+      if (result?.requiresManualRestart) {
+        return "manual";
+      }
+      return true;
+    } catch (err) {
+      setEnabled(!newEnabled);
+      setError(err.message);
+      return false;
+    } finally {
+      setRestarting(false);
+    }
+  }, []);
+
+  return { enabled, loading, restarting, error, toggle };
+}

--- a/client/src/lib/__tests__/isElectron.test.js
+++ b/client/src/lib/__tests__/isElectron.test.js
@@ -1,0 +1,7 @@
+import { isElectron } from "../isElectron";
+
+describe("isElectron", () => {
+  it("is false when window.electron is not defined", () => {
+    expect(isElectron).toBe(false);
+  });
+});

--- a/client/src/lib/isElectron.js
+++ b/client/src/lib/isElectron.js
@@ -1,0 +1,1 @@
+export const isElectron = typeof window !== "undefined" && !!window.electron;

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,7 +3,9 @@ const path = require('path');
 const { app, BrowserWindow, Menu, dialog, shell, ipcMain } = require('electron');
 
 const AutoUpdater = require('./services/AutoUpdater');
+const { readConfig, writeConfig } = require('./services/ConfigurationBootstrap');
 const ServiceManager = require('./services/ServiceManager');
+const { getPhoenixDataDirectory } = require('./utils/resourcePaths');
 
 // To prevent multiple instances of the application
 const gotTheLock = app.requestSingleInstanceLock();
@@ -280,6 +282,42 @@ ipcMain.handle('services:restart', async (event, serviceName) => {
 ipcMain.handle('services:get-logs', () => {
   const logsDir = path.join(require('os').homedir(), '.Ambrosia-POS', 'logs');
   return { logsDir };
+});
+
+const phoenixConfigPath = path.join(getPhoenixDataDirectory(), 'phoenix.conf');
+
+let phoenixdRestartInProgress = false;
+
+ipcMain.handle('phoenixd:get-auto-liquidity', () => {
+  const phoenixConfig = readConfig(phoenixConfigPath);
+  return phoenixConfig['auto-liquidity'] ?? 'off';
+});
+
+ipcMain.handle('phoenixd:set-auto-liquidity', async (_event, value) => {
+  if (!serviceManager) {
+    throw new Error('ServiceManager not initialized');
+  }
+  if (phoenixdRestartInProgress) {
+    throw new Error('A restart is already in progress');
+  }
+
+  const phoenixConfig = readConfig(phoenixConfigPath);
+  phoenixConfig['auto-liquidity'] = value;
+  writeConfig(phoenixConfigPath, phoenixConfig);
+
+  if (!serviceManager.isDevMode()) {
+    if (serviceManager.configs?.phoenix) {
+      serviceManager.configs.phoenix['auto-liquidity'] = value;
+    }
+    phoenixdRestartInProgress = true;
+    try {
+      await serviceManager.restartService('phoenixd');
+    } finally {
+      phoenixdRestartInProgress = false;
+    }
+  }
+
+  return true;
 });
 
 // App initialization

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -8,6 +8,8 @@ const INVOKE_CHANNELS = [
   'services:get-logs',
   'update:install',
   'update:open-release',
+  'phoenixd:get-auto-liquidity',
+  'phoenixd:set-auto-liquidity',
 ];
 
 const RECEIVE_CHANNELS = [

--- a/electron/services/PhoenixdService.js
+++ b/electron/services/PhoenixdService.js
@@ -65,13 +65,15 @@ class PhoenixdService {
         console.log(`[PhoenixdService] Using native phoenixd binary for ${process.platform}-${process.arch}`);
       }
 
-      this.process = spawn(phoenixdPath, args, {
+      const spawnedProcess = spawn(phoenixdPath, args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,
         env,
       });
 
-      this.process.stdout.on('data', (data) => {
+      this.process = spawnedProcess;
+
+      spawnedProcess.stdout.on('data', (data) => {
         const message = data.toString();
         console.log(`[Phoenixd] ${message.trim()}`);
         if (this.logStream) {
@@ -79,7 +81,7 @@ class PhoenixdService {
         }
       });
 
-      this.process.stderr.on('data', (data) => {
+      spawnedProcess.stderr.on('data', (data) => {
         const message = data.toString();
         console.error(`[Phoenixd ERROR] ${message.trim()}`);
         if (this.logStream) {
@@ -87,16 +89,20 @@ class PhoenixdService {
         }
       });
 
-      this.process.on('error', (error) => {
+      spawnedProcess.on('error', (error) => {
         console.error('[PhoenixdService] Failed to start:', error);
         this.status = 'error';
-        this.cleanup();
+        if (this.process === spawnedProcess) this.cleanup();
       });
 
-      this.process.on('close', (code) => {
+      spawnedProcess.on('close', (code) => {
         console.log(`[PhoenixdService] Process exited with code ${code}`);
-        this.status = 'stopped';
-        this.cleanup();
+        // Only cleanup if this process is still the active one.
+        // Avoids overwriting this.process after a restart has already set a new process.
+        if (this.process === spawnedProcess) {
+          this.status = 'stopped';
+          this.cleanup();
+        }
       });
 
       console.log('[PhoenixdService] Waiting for phoenixd to be healthy...');
@@ -114,9 +120,27 @@ class PhoenixdService {
     }
   }
 
+  async killByPort(port) {
+    const { exec } = require('child_process');
+    const targetPort = port || this.port;
+    if (!targetPort) return;
+    return new Promise((resolve) => {
+      const command = process.platform === 'win32'
+        ? `for /f "tokens=5" %a in ('netstat -aon ^| findstr LISTENING ^| findstr :${targetPort}') do taskkill /F /PID %a`
+        : `lsof -ti TCP:${targetPort} -sTCP:LISTEN | xargs kill -9`;
+      exec(command, () => resolve());
+    });
+  }
+
   async stop() {
     if (!this.process) {
-      console.log('[PhoenixdService] No process to stop');
+      if (this.port) {
+        console.log(`[PhoenixdService] No owned process — attempting to kill any process on port ${this.port}`);
+        await this.killByPort(this.port);
+        await new Promise((resolve) => { setTimeout(resolve, 500); });
+      } else {
+        console.log('[PhoenixdService] No process to stop');
+      }
       return;
     }
 
@@ -124,30 +148,37 @@ class PhoenixdService {
 
     return new Promise((resolve) => {
       const pid = this.process.pid;
+      const processToKill = this.process;
+
+      const onExit = () => {
+        clearTimeout(forceKillTimer);
+        console.log('[PhoenixdService] Process exited cleanly');
+        this.cleanup();
+        resolve();
+      };
+
+      processToKill.once('exit', onExit);
+
+      const forceKillTimer = setTimeout(() => {
+        processToKill.removeListener('exit', onExit);
+        console.warn('[PhoenixdService] Force killing after timeout');
+        treeKill(pid, 'SIGKILL', () => {
+          this.cleanup();
+          resolve();
+        });
+      }, 5000);
 
       treeKill(pid, 'SIGTERM', (err) => {
         if (err) {
-          console.error('[PhoenixdService] Failed to kill process tree:', err);
+          console.error('[PhoenixdService] Failed to send SIGTERM:', err);
+          clearTimeout(forceKillTimer);
+          processToKill.removeListener('exit', onExit);
           treeKill(pid, 'SIGKILL', () => {
             this.cleanup();
             resolve();
           });
-        } else {
-          console.log('[PhoenixdService] Process tree killed successfully');
-          this.cleanup();
-          resolve();
         }
       });
-
-      setTimeout(() => {
-        if (this.process) {
-          console.warn('[PhoenixdService] Force killing after timeout');
-          treeKill(pid, 'SIGKILL', () => {
-            this.cleanup();
-            resolve();
-          });
-        }
-      }, 5000);
     });
   }
 

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -170,6 +170,7 @@ class ServiceManager extends EventEmitter {
         case 'phoenixd':
           await this.phoenixdService.stop();
           await this.phoenixdService.start(this.ports.phoenixd, this.configs.phoenix);
+          this.externalServices.phoenixd = false;
           break;
         case 'backend':
           await this.backendService.stop();


### PR DESCRIPTION
## Changes:
  - Add Auto Liquidity toggle to Settings page (Electron only) — reads and writes `auto-liquidity` in `phoenix.conf` via IPC
  - Add `phoenixd:get-auto-liquidity` and `phoenixd:set-auto-liquidity` IPC handlers in Electron main process
  - Restart phoenixd automatically after config change, skipping restart in dev mode
  - Add restart lock to prevent concurrent phoenixd restarts from rapid UI interaction
  - Add 500ms debounce on the toggle to avoid redundant IPC calls
  - Update switch state optimistically — flips immediately, reverts on failure
  - Show contextual toasts: success on restart, warning when phoenixd is external and requires manual restart, danger on error
  - Fix race condition in `PhoenixdService`: `close` event handler now checks process identity before cleanup to avoid nullifying a newly started process
  - Fix `stop()` to wait for the actual process exit event before resolving, preventing port conflicts between stop and start
  - Fix `killByPort` to use `-sTCP:LISTEN` (macOS/Linux) so only the listening process is killed — prevents accidentally killing Electron itself via its pooled HTTP connections
  - Add `externalServices.phoenixd = false` after a successful restart in `ServiceManager` so subsequent toggles work within the same session
  - Add `isElectron` utility in `@lib/isElectron` for safe SSR-compatible Electron detection
  - Add `lightning` i18n keys in English and Spanish locales
  - Add tests for `isElectron`, `useAutoLiquidity` hook, `LightningCard` component, and `LightningCard` visibility in `Settings`