### PR TITLE
change host at electron services and client, add fallback.

### DIFF
--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = "http://127.0.0.1:9154";
+const DEFAULT_API_URL = "http://localhost:9154";
 
 export function getApiUrl() {
   return process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
@@ -9,8 +9,18 @@ export function getWsUrl() {
     return process.env.NEXT_PUBLIC_WS_URL;
   }
 
-  const apiUrl = getApiUrl();
-  return `${apiUrl.replace(/^http/i, "ws")}/ws/payments`;
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return `${process.env.NEXT_PUBLIC_API_URL.replace(/^http/i, "ws")}/ws/payments`;
+  }
+
+  if (typeof window !== "undefined") {
+    const host = window.location.hostname;
+    const port = process.env.NEXT_PUBLIC_PORT_API || "9154";
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${protocol}//${host}:${port}/ws/payments`;
+  }
+
+  return `ws://localhost:9154/ws/payments`;
 }
 
 export function isElectronEnv() {

--- a/electron/services/NextJsService.js
+++ b/electron/services/NextJsService.js
@@ -54,7 +54,7 @@ class NextJsService {
       console.log(`[NextJsService] Environment PORT: ${port}`);
 
       // Use backend config passed as parameter (with fallback to defaults)
-      const backendHost = backendConfig.host || '127.0.0.1';
+      const backendHost = backendConfig.host || 'localhost';
       const backendPort = backendConfig.port || '9154';
       const apiUrl = `http://${backendHost}:${backendPort}`;
 

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -45,7 +45,7 @@ class ServiceManager extends EventEmitter {
 
         console.log('[ServiceManager] Starting Next.js service...');
         const result = await this.nextjsService.start(this.ports.nextjs, {
-          host: '127.0.0.1',
+          host: 'localhost',
           port: this.ports.backend,
         });
         console.log('[ServiceManager] All services started successfully');
@@ -183,7 +183,7 @@ class ServiceManager extends EventEmitter {
         case 'nextjs':
           await this.nextjsService.stop();
           await this.nextjsService.start(this.ports.nextjs, {
-            host: '127.0.0.1',
+            host: 'localhost',
             port: this.ports.backend,
           });
           break;


### PR DESCRIPTION
## Changes:
  - Fixed Lightning payment WebSocket not detecting payments after checkout
  - Replaced hardcoded `127.0.0.1` default with `window.location.hostname` fallback in `getWsUrl()` so the WebSocket always connects to the same host the browser loaded from, ensuring auth cookies are sent correctly
  - Updated `ServiceManager.js` and `NextJsService.js` to use `localhost` instead of `127.0.0.1` when passing the backend host to Next.js in Electron mode
  - Preserved explicit `NEXT_PUBLIC_WS_URL` and `NEXT_PUBLIC_API_URL` env vars as higher-priority overrides for Docker and custom deployments
  - Root cause: commit `fad593d` (Jan 29) replaced `window.location.hostname` with a hardcoded `127.0.0.1` default — browsers don't send cookies set on `localhost` to requests targeting `127.0.0.1`, causing the WebSocket auth to fail silently