### PR TITLE
Chore/electron improvements

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -388,7 +388,12 @@ app.whenReady().then(async () => {
 
     serviceManager.on('service:error', ({ service, error }) => {
       console.error(`[Electron] Service error: ${service}`, error);
-      updateSplash(null, null, `Error starting ${service || 'service'}`);
+      if (splashWindow && !splashWindow.isDestroyed()) {
+        splashWindow.webContents.send('splash:error', {
+          service,
+          message: error ? error.message || String(error) : `Failed to start ${service || 'service'}`,
+        });
+      }
     });
 
     serviceManager.on('all:started', () => {
@@ -420,9 +425,16 @@ app.whenReady().then(async () => {
 
     console.log('[Electron] Application initialized successfully');
   } catch (error) {
-    // Close splash on error
+    // Show error state in splash before closing
     if (splashWindow && !splashWindow.isDestroyed()) {
-      splashWindow.close();
+      splashWindow.webContents.send('splash:error', {
+        service: null,
+        message: error ? error.message || String(error) : 'Unexpected startup error',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      if (splashWindow && !splashWindow.isDestroyed()) {
+        splashWindow.close();
+      }
     }
     await handleStartupError(error);
   }

--- a/electron/main.js
+++ b/electron/main.js
@@ -59,7 +59,6 @@ function createSplashScreen() {
       preload: path.join(__dirname, 'splash-preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: true,
     },
   });
 
@@ -325,8 +324,9 @@ app.whenReady().then(async () => {
   try {
     console.log('[Electron] Initializing Ambrosia POS...');
 
-    // Show splash screen immediately
+    // Show splash screen and wait for it to finish loading before sending IPC
     createSplashScreen();
+    await new Promise((resolve) => splashWindow.webContents.once('did-finish-load', resolve));
 
     // SPLASH ONLY MODE: For design/testing purposes
     if (process.env.SPLASH_ONLY === 'true') {

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambrosia-pos",
-  "version": "0.5.1-alpha",
+  "version": "0.6.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambrosia-pos",
-      "version": "0.5.1-alpha",
+      "version": "0.6.0-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ambrosia-pos",
-  "version": "0.5.1-alpha",
+  "version": "0.6.0-beta",
   "description": "Ambrosia POS Desktop Application",
   "main": "main.js",
   "scripts": {
@@ -64,6 +64,7 @@
     "files": [
       "main.js",
       "preload.js",
+      "splash-preload.js",
       "splash.html",
       "package.json",
       "services/**/*",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -19,6 +19,19 @@ const RECEIVE_CHANNELS = [
   'update:downloaded',
 ];
 
+function sanitizeArg(arg) {
+  if (arg === null || arg === undefined) return arg;
+  const type = typeof arg;
+  if (type === 'string' || type === 'number' || type === 'boolean') return arg;
+  if (Array.isArray(arg)) return arg.map(sanitizeArg);
+  if (type === 'object') {
+    return Object.fromEntries(
+      Object.entries(arg).map(([k, v]) => [k, sanitizeArg(v)]),
+    );
+  }
+  return null; // drop functions, symbols, circular refs
+}
+
 // Expose APIs securely to the renderer
 contextBridge.exposeInMainWorld('electron', {
   // System information API
@@ -38,7 +51,7 @@ contextBridge.exposeInMainWorld('electron', {
     },
     invoke: (channel, ...args) => {
       if (INVOKE_CHANNELS.includes(channel)) {
-        return ipcRenderer.invoke(channel, ...args);
+        return ipcRenderer.invoke(channel, ...args.map(sanitizeArg));
       }
       return Promise.reject(new Error(`Invalid channel: ${channel}`));
     },

--- a/electron/scripts/download-jre.js
+++ b/electron/scripts/download-jre.js
@@ -281,14 +281,16 @@ async function main() {
   console.log(`  Downloading JRE 21 for ${currentPlatform}`);
   console.log('===========================================\n');
 
-  for (const jre of JRE_DOWNLOADS) {
-    try {
-      await downloadAndExtractJRE(jre.platform, jre.url, jre.checksumApiUrl, jre.filename);
-    } catch (error) {
-      console.error(`Failed to download JRE for ${jre.platform}:`, error);
-      process.exit(1);
-    }
-  }
+  await Promise.all(
+    JRE_DOWNLOADS.map(async (jre) => {
+      try {
+        await downloadAndExtractJRE(jre.platform, jre.url, jre.checksumApiUrl, jre.filename);
+      } catch (error) {
+        console.error(`Failed to download JRE for ${jre.platform}:`, error);
+        process.exit(1);
+      }
+    }),
+  );
 
   console.log('\n===========================================');
   console.log(`  ✓ JRE download for ${currentPlatform} complete!`);

--- a/electron/scripts/download-jre.js
+++ b/electron/scripts/download-jre.js
@@ -67,7 +67,8 @@ if (currentPlatform === 'win-arm64') {
   JRE_DOWNLOADS = [ALL_JRE_DOWNLOADS[currentPlatform]];
 }
 
-function downloadFile(url, dest) {
+function downloadFile(url, dest, redirectCount = 0) {
+  const MAX_REDIRECTS = 5;
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
     const protocol = url.startsWith('https') ? https : http;
@@ -80,10 +81,14 @@ function downloadFile(url, dest) {
       if (response.statusCode === 301 || response.statusCode === 302 ||
           response.statusCode === 307 || response.statusCode === 308) {
         const redirectUrl = response.headers.location;
-        console.log(`Following redirect (${response.statusCode}) to: ${redirectUrl}`);
         file.close();
         fs.unlinkSync(dest);
-        downloadFile(redirectUrl, dest).then(resolve).catch(reject);
+        if (redirectCount >= MAX_REDIRECTS) {
+          reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
+          return;
+        }
+        console.log(`Following redirect (${response.statusCode}) to: ${redirectUrl}`);
+        downloadFile(redirectUrl, dest, redirectCount + 1).then(resolve).catch(reject);
         return;
       }
 

--- a/electron/scripts/download-phoenixd.js
+++ b/electron/scripts/download-phoenixd.js
@@ -61,7 +61,8 @@ const ALL_PHOENIXD_DOWNLOADS = {
 const currentPlatform = getBuildPlatform();
 const PHOENIXD_DOWNLOADS = [ALL_PHOENIXD_DOWNLOADS[currentPlatform]];
 
-function downloadFile(url, dest) {
+function downloadFile(url, dest, redirectCount = 0) {
+  const MAX_REDIRECTS = 5;
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
 
@@ -73,10 +74,14 @@ function downloadFile(url, dest) {
       if (response.statusCode === 301 || response.statusCode === 302 ||
           response.statusCode === 307 || response.statusCode === 308) {
         const redirectUrl = response.headers.location;
-        console.log(`Following redirect (${response.statusCode}) to: ${redirectUrl}`);
         file.close();
         fs.unlinkSync(dest);
-        downloadFile(redirectUrl, dest).then(resolve).catch(reject);
+        if (redirectCount >= MAX_REDIRECTS) {
+          reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
+          return;
+        }
+        console.log(`Following redirect (${response.statusCode}) to: ${redirectUrl}`);
+        downloadFile(redirectUrl, dest, redirectCount + 1).then(resolve).catch(reject);
         return;
       }
 

--- a/electron/services/AutoUpdater.js
+++ b/electron/services/AutoUpdater.js
@@ -1,7 +1,13 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 const { dialog, ipcMain, shell } = require('electron');
 const { autoUpdater } = require('electron-updater');
 
 const SUPPORTS_AUTO_UPDATE = process.platform === 'win32';
+const UPDATE_EXPIRY_DAYS = 7;
+const UPDATE_STATE_FILE = path.join(os.homedir(), '.Ambrosia-POS', 'pending-update.json');
 
 class AutoUpdater {
   constructor(mainWindow, { onMenuUpdate, releaseUrl } = {}) {
@@ -19,6 +25,54 @@ class AutoUpdater {
 
     this._setupEvents();
     this._setupIpcHandlers();
+    this._checkExpiredUpdate();
+  }
+
+  _saveUpdateState(version) {
+    try {
+      const dir = path.dirname(UPDATE_STATE_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(UPDATE_STATE_FILE, JSON.stringify({ version, downloadedAt: Date.now() }));
+    } catch (err) {
+      console.error('[AutoUpdater] Failed to save update state:', err.message);
+    }
+  }
+
+  _clearUpdateState() {
+    try {
+      if (fs.existsSync(UPDATE_STATE_FILE)) fs.unlinkSync(UPDATE_STATE_FILE);
+    } catch (err) {
+      console.error('[AutoUpdater] Failed to clear update state:', err.message);
+    }
+  }
+
+  _checkExpiredUpdate() {
+    if (!SUPPORTS_AUTO_UPDATE) return;
+    try {
+      if (!fs.existsSync(UPDATE_STATE_FILE)) return;
+      const state = JSON.parse(fs.readFileSync(UPDATE_STATE_FILE, 'utf8'));
+      const ageMs = Date.now() - (state.downloadedAt || 0);
+      const ageDays = ageMs / (1000 * 60 * 60 * 24);
+      if (ageDays >= UPDATE_EXPIRY_DAYS) {
+        console.log(`[AutoUpdater] Pending update v${state.version} is ${Math.floor(ageDays)} days old — prompting install`);
+        dialog.showMessageBox(this.mainWindow, {
+          type: 'warning',
+          title: 'Update Ready to Install',
+          message: `Version ${state.version} has been waiting ${Math.floor(ageDays)} days`,
+          detail: 'Restart Ambrosia POS now to apply the update.',
+          buttons: ['Restart Now', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        }).then(({ response }) => {
+          if (response === 0) {
+            this._clearUpdateState();
+            autoUpdater.quitAndInstall(false, true);
+          }
+        });
+      }
+    } catch (err) {
+      console.error('[AutoUpdater] Failed to check pending update state:', err.message);
+    }
   }
 
   _setupEvents() {
@@ -64,10 +118,14 @@ class AutoUpdater {
     // Only fires on Windows (only platform that downloads)
     autoUpdater.on('update-downloaded', (info) => {
       console.log('[AutoUpdater] Update downloaded:', info.version);
+      this._saveUpdateState(info.version);
       this.onMenuUpdate({
         label: `Restart to Update to ${info.version}`,
         enabled: true,
-        click: () => autoUpdater.quitAndInstall(false, true),
+        click: () => {
+          this._clearUpdateState();
+          autoUpdater.quitAndInstall(false, true);
+        },
       });
       this._sendToRenderer('update:downloaded', { version: info.version });
     });
@@ -91,6 +149,7 @@ class AutoUpdater {
   _setupIpcHandlers() {
     ipcMain.handle('update:install', () => {
       if (SUPPORTS_AUTO_UPDATE) {
+        this._clearUpdateState();
         autoUpdater.quitAndInstall(false, true);
       }
     });

--- a/electron/services/BackendService.js
+++ b/electron/services/BackendService.js
@@ -139,6 +139,9 @@ class BackendService {
   }
 
   cleanup() {
+    if (this.process) {
+      this.process.removeAllListeners();
+    }
     this.process = null;
     this.status = 'stopped';
     if (this.logStream) {

--- a/electron/services/ConfigurationBootstrap.js
+++ b/electron/services/ConfigurationBootstrap.js
@@ -32,10 +32,6 @@ function validateSecret(mnemonic) {
   return bip39.validateMnemonic(mnemonic);
 }
 
-function hashSecret(secret) {
-  return crypto.createHash('sha256').update(secret).digest('hex');
-}
-
 function generateRandomHex(length) {
   return crypto.randomBytes(length).toString('hex');
 }
@@ -102,8 +98,8 @@ async function ensureConfigurations(ports) {
 
   if (!fs.existsSync(ambrosiaConfigPath) || Object.keys(ambrosiaConfig).length === 0) {
     console.log('[ConfigurationBootstrap] Generating Ambrosia configuration...');
-    const secret = generateSecret();
-    const secretHash = hashSecret(secret);
+    const secret = generateRandomHex(32);
+    const secretHash = crypto.createHash('sha256').update(secret).digest('hex');
 
     ambrosiaConfig = {
       'http-bind-ip': '127.0.0.1',

--- a/electron/services/NextJsService.js
+++ b/electron/services/NextJsService.js
@@ -69,11 +69,12 @@ class NextJsService {
         console.log(`[NextJsService] Verified server.js exists at: ${serverJsPath}`);
       }
 
-      // Pass environment variables directly to Next.js (no .env file needed)
       const env = {
-        ...process.env,
         PORT: port.toString(),
         HOSTNAME: '127.0.0.1',
+        NODE_ENV: process.env.NODE_ENV || 'production',
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
         NEXT_PUBLIC_API_URL: apiUrl,
         NEXT_PUBLIC_ELECTRON: 'true',
       };

--- a/electron/services/NextJsService.js
+++ b/electron/services/NextJsService.js
@@ -73,7 +73,7 @@ class NextJsService {
       const env = {
         ...process.env,
         PORT: port.toString(),
-        HOSTNAME: '0.0.0.0', // Listen on all interfaces (IPv4)
+        HOSTNAME: '127.0.0.1',
         NEXT_PUBLIC_API_URL: apiUrl,
         NEXT_PUBLIC_ELECTRON: 'true',
       };

--- a/electron/services/PhoenixdService.js
+++ b/electron/services/PhoenixdService.js
@@ -183,6 +183,9 @@ class PhoenixdService {
   }
 
   cleanup() {
+    if (this.process) {
+      this.process.removeAllListeners();
+    }
     this.process = null;
     this.status = 'stopped';
     if (this.logStream) {

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -26,6 +26,16 @@ class ServiceManager extends EventEmitter {
   }
 
   async startAll() {
+    const STARTUP_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('Startup timed out after 2 minutes')), STARTUP_TIMEOUT_MS);
+    });
+
+    return Promise.race([this._startAll(), timeoutPromise]);
+  }
+
+  async _startAll() {
     try {
       console.log('[ServiceManager] Starting all services...');
 
@@ -95,6 +105,7 @@ class ServiceManager extends EventEmitter {
       this.emit('service:started', { service: 'nextjs', port: this.ports.nextjs });
 
       console.log('[ServiceManager] All services started successfully');
+      this.startHealthMonitor();
       this.emit('all:started');
 
       return result.url;
@@ -106,7 +117,29 @@ class ServiceManager extends EventEmitter {
     }
   }
 
+  startHealthMonitor() {
+    const INTERVAL_MS = 30 * 1000; // 30 seconds
+
+    this._healthMonitor = setInterval(() => {
+      const statuses = this.getServiceStatuses();
+      for (const [service, status] of Object.entries(statuses)) {
+        if (status === 'error' || (status === 'stopped' && !this.externalServices[service])) {
+          console.warn(`[ServiceManager] Health monitor: ${service} is ${status}, emitting event`);
+          this.emit('service:error', { service, error: new Error(`${service} is ${status}`) });
+        }
+      }
+    }, INTERVAL_MS);
+  }
+
+  stopHealthMonitor() {
+    if (this._healthMonitor) {
+      clearInterval(this._healthMonitor);
+      this._healthMonitor = null;
+    }
+  }
+
   async stopAll() {
+    this.stopHealthMonitor();
     console.log('[ServiceManager] Stopping all services...');
 
     try {
@@ -163,6 +196,11 @@ class ServiceManager extends EventEmitter {
   }
 
   async restartService(serviceName) {
+    if (this.externalServices[serviceName]) {
+      console.log(`[ServiceManager] Skipping restart of external service: ${serviceName}`);
+      return;
+    }
+
     console.log(`[ServiceManager] Restarting ${serviceName}...`);
 
     try {

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -58,6 +58,7 @@ class ServiceManager extends EventEmitter {
           host: 'localhost',
           port: this.ports.backend,
         });
+        this.emit('service:started', { service: 'nextjs', port: this.ports.nextjs });
         console.log('[ServiceManager] All services started successfully');
         return result.url;
       }

--- a/electron/splash-preload.js
+++ b/electron/splash-preload.js
@@ -1,6 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-const SPLASH_CHANNELS = ['splash:update', 'splash:complete', 'splash:close'];
+const SPLASH_CHANNELS = ['splash:update', 'splash:complete', 'splash:close', 'splash:error'];
 
 contextBridge.exposeInMainWorld('splashBridge', {
   on: (channel, callback) => {

--- a/electron/splash.html
+++ b/electron/splash.html
@@ -115,6 +115,33 @@
         opacity: 0;
       }
     }
+
+    .error-box {
+      display: none;
+      background: rgba(0, 0, 0, 0.25);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 20px;
+      text-align: left;
+      font-size: 12px;
+      line-height: 1.5;
+      word-break: break-word;
+      max-height: 120px;
+      overflow-y: auto;
+    }
+
+    .error-box.visible {
+      display: block;
+    }
+
+    .step.error .step-dot {
+      background: #f87171;
+    }
+
+    body.has-error {
+      background: linear-gradient(0deg, #b45309, #ef4444);
+    }
   </style>
 </head>
 <body>
@@ -143,12 +170,14 @@
         <span>Frontend</span>
       </div>
     </div>
+    <div class="error-box" id="error-box"></div>
   </div>
 
   <script>
     const statusText = document.getElementById('status-text');
     const progressBar = document.getElementById('progress-bar');
     const spinner = document.getElementById('spinner');
+    const errorBox = document.getElementById('error-box');
 
     const steps = {
       phoenixd: document.getElementById('step-phoenixd'),
@@ -183,6 +212,25 @@
       if (service && steps[service]) {
         steps[service].classList.remove('active');
         steps[service].classList.add('completed');
+      }
+    });
+
+    // Listen for error signal
+    window.splashBridge.on('splash:error', (data) => {
+      const { service, message } = data || {};
+
+      document.body.classList.add('has-error');
+      spinner.style.display = 'none';
+      statusText.textContent = 'Startup failed';
+
+      if (service && steps[service]) {
+        steps[service].classList.remove('active');
+        steps[service].classList.add('error');
+      }
+
+      if (message) {
+        errorBox.textContent = message;
+        errorBox.classList.add('visible');
       }
     });
 

--- a/electron/utils/constants.js
+++ b/electron/utils/constants.js
@@ -1,0 +1,36 @@
+module.exports = {
+  // Port ranges
+  PORTS: {
+    PHOENIXD_DEFAULT: 9740,
+    BACKEND_DEFAULT: 9154,
+    NEXTJS_DEFAULT: 3000,
+    PHOENIXD_RANGE: { min: 9740, max: 9800 },
+    BACKEND_RANGE: { min: 9154, max: 9200 },
+    NEXTJS_RANGE: { min: 3000, max: 3100 },
+  },
+
+  // Health check
+  HEALTH: {
+    MAX_ATTEMPTS: 60,
+    INTERVAL_MS: 1000,
+    REQUEST_TIMEOUT_MS: 5000,
+    SINGLE_CHECK_TIMEOUT_MS: 2000,
+    LOG_EVERY_N_ATTEMPTS: 10,
+    MONITOR_INTERVAL_MS: 30 * 1000,
+  },
+
+  // Startup
+  STARTUP: {
+    TIMEOUT_MS: 2 * 60 * 1000,
+    FORCE_KILL_TIMEOUT_MS: 5000,
+    BACKEND_FORCE_KILL_TIMEOUT_MS: 10000,
+    SPLASH_DELAY_MS: 800,
+  },
+
+  // Downloads
+  DOWNLOAD: {
+    MAX_REDIRECTS: 5,
+    PHOENIXD_VERSION: '0.7.2',
+    JRE_VERSION: 21,
+  },
+};

--- a/electron/utils/healthCheck.js
+++ b/electron/utils/healthCheck.js
@@ -16,14 +16,8 @@ async function waitForHealth(url, options = {}) {
     interval,
     verbose,
     validateStatus: (status) => {
-      // Accept 2xx responses as healthy
-      // Also accept 401 if acceptUnauthorized is true (service is running, just needs auth)
-      if (status >= 200 && status < 300) {
-        return true;
-      }
-      if (acceptUnauthorized && status === 401) {
-        return true;
-      }
+      if (status >= 200 && status < 300) return true;
+      if (acceptUnauthorized && status === 401) return true;
       return false;
     },
   };
@@ -39,143 +33,78 @@ async function waitForHealth(url, options = {}) {
   }
 }
 
-async function checkPhoenixd(port, maxAttempts = 60, intervalMs = 1000) {
-  const url = `http://localhost:${port}/getinfo`;
-
-  console.log(`[HealthCheck] Checking phoenixd at ${url}...`);
+async function checkService({ url, name, isHealthy, maxAttempts = 60, intervalMs = 1000 }) {
+  console.log(`[HealthCheck] Checking ${name} at ${url}...`);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const response = await new Promise((resolve, reject) => {
+      await new Promise((resolve, reject) => {
         const req = http.get(url, (res) => {
-          // Phoenixd requires authentication, so 401 means it's running
-          if (res.statusCode === 401 || (res.statusCode >= 200 && res.statusCode < 300)) {
-            console.log(`[HealthCheck] Phoenixd is healthy (status: ${res.statusCode})`);
-            resolve(true);
+          res.resume();
+          if (isHealthy(res.statusCode)) {
+            console.log(`[HealthCheck] ${name} is healthy (status: ${res.statusCode})`);
+            resolve();
           } else {
             reject(new Error(`Unexpected status code: ${res.statusCode}`));
           }
         });
 
-        req.on('error', (err) => {
-          reject(err);
-        });
-
+        req.on('error', reject);
         req.setTimeout(5000, () => {
           req.destroy();
           reject(new Error('Request timeout'));
         });
       });
 
-      return response;
+      return true;
     } catch (error) {
       if (attempt === maxAttempts) {
-        console.error(`[HealthCheck] Phoenixd health check failed after ${maxAttempts} attempts:`, error.message);
+        console.error(`[HealthCheck] ${name} health check failed after ${maxAttempts} attempts:`, error.message);
         throw new Error(`Timed out waiting for: ${url}`);
       }
-
       if (attempt % 10 === 0) {
-        console.log(`[HealthCheck] Still waiting for phoenixd... (attempt ${attempt}/${maxAttempts})`);
+        console.log(`[HealthCheck] Still waiting for ${name}... (attempt ${attempt}/${maxAttempts})`);
       }
-
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
   }
+}
+
+async function checkPhoenixd(port, maxAttempts = 60, intervalMs = 1000) {
+  return checkService({
+    url: `http://localhost:${port}/getinfo`,
+    name: 'Phoenixd',
+    isHealthy: (status) => status === 401 || (status >= 200 && status < 300),
+    maxAttempts,
+    intervalMs,
+  });
 }
 
 async function checkBackend(port, maxAttempts = 60, intervalMs = 1000) {
-  const url = `http://localhost:${port}/api/health`;
-
-  console.log(`[HealthCheck] Checking backend at ${url}...`);
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await new Promise((resolve, reject) => {
-        const req = http.get(url, (res) => {
-          if (res.statusCode >= 200 && res.statusCode < 300) {
-            console.log(`[HealthCheck] Backend is healthy (status: ${res.statusCode})`);
-            resolve(true);
-          } else {
-            reject(new Error(`Unexpected status code: ${res.statusCode}`));
-          }
-        });
-
-        req.on('error', (err) => {
-          reject(err);
-        });
-
-        req.setTimeout(5000, () => {
-          req.destroy();
-          reject(new Error('Request timeout'));
-        });
-      });
-
-      return response;
-    } catch (error) {
-      if (attempt === maxAttempts) {
-        console.error(`[HealthCheck] Backend health check failed after ${maxAttempts} attempts:`, error.message);
-        throw new Error(`Timed out waiting for: ${url}`);
-      }
-
-      if (attempt % 10 === 0) {
-        console.log(`[HealthCheck] Still waiting for backend... (attempt ${attempt}/${maxAttempts})`);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-  }
+  return checkService({
+    url: `http://localhost:${port}/api/health`,
+    name: 'Backend',
+    isHealthy: (status) => status >= 200 && status < 300,
+    maxAttempts,
+    intervalMs,
+  });
 }
 
 async function checkNextJs(port, maxAttempts = 60, intervalMs = 1000) {
-  const url = `http://localhost:${port}/`;
-
-  console.log(`[HealthCheck] Checking Next.js at ${url}...`);
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await new Promise((resolve, reject) => {
-        const req = http.get(url, (res) => {
-          if (res.statusCode >= 200 && res.statusCode < 400) {
-            console.log(`[HealthCheck] Next.js is healthy (status: ${res.statusCode})`);
-            resolve(true);
-          } else {
-            reject(new Error(`Unexpected status code: ${res.statusCode}`));
-          }
-        });
-
-        req.on('error', (err) => {
-          reject(err);
-        });
-
-        req.setTimeout(5000, () => {
-          req.destroy();
-          reject(new Error('Request timeout'));
-        });
-      });
-
-      return response;
-    } catch (error) {
-      if (attempt === maxAttempts) {
-        console.error(`[HealthCheck] Next.js health check failed after ${maxAttempts} attempts:`, error.message);
-        throw new Error(`Timed out waiting for: ${url}`);
-      }
-
-      if (attempt % 10 === 0) {
-        console.log(`[HealthCheck] Still waiting for Next.js... (attempt ${attempt}/${maxAttempts})`);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-  }
+  return checkService({
+    url: `http://localhost:${port}/`,
+    name: 'Next.js',
+    isHealthy: (status) => status >= 200 && status < 400,
+    maxAttempts,
+    intervalMs,
+  });
 }
 
 async function makeHttpRequest(url) {
   return new Promise((resolve, reject) => {
     http.get(url, (res) => {
       let data = '';
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
+      res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           resolve({ statusCode: res.statusCode, data });
@@ -183,78 +112,37 @@ async function makeHttpRequest(url) {
           reject(new Error(`HTTP ${res.statusCode}: ${data}`));
         }
       });
-    }).on('error', (error) => {
-      reject(error);
-    });
+    }).on('error', reject);
   });
 }
 
-/**
- * Check if phoenixd is already running on the specified port (single attempt)
- * @param {number} port - Port to check
- * @returns {Promise<boolean>} - True if phoenixd is running
- */
+function singleCheck(url, isHealthy, timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      res.resume(); // M2: consume response body
+      resolve(isHealthy(res.statusCode));
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(timeoutMs, () => { req.destroy(); resolve(false); });
+  });
+}
+
 async function isPhoenixdRunning(port) {
-  const url = `http://localhost:${port}/getinfo`;
-
-  return new Promise((resolve) => {
-    const req = http.get(url, (res) => {
-      // Phoenixd requires authentication, so 401 means it's running
-      resolve(res.statusCode === 401 || (res.statusCode >= 200 && res.statusCode < 300));
-    });
-
-    req.on('error', () => resolve(false));
-    req.setTimeout(2000, () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
+  return singleCheck(
+    `http://localhost:${port}/getinfo`,
+    (status) => status === 401 || (status >= 200 && status < 300),
+  );
 }
 
-/**
- * Check if backend is already running on the specified port (single attempt)
- * Accepts any HTTP response (even 404/401) as indication that a server is running
- * @param {number} port - Port to check
- * @returns {Promise<boolean>} - True if backend is running
- */
 async function isBackendRunning(port) {
-  // Use a generic endpoint - any HTTP response means server is running
-  const url = `http://localhost:${port}/`;
-
-  return new Promise((resolve) => {
-    const req = http.get(url, () => {
-      // Any HTTP response means the server is running
-      // (even 404, 401, 500, etc.)
-      resolve(true);
-    });
-
-    req.on('error', () => resolve(false));
-    req.setTimeout(2000, () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
+  return singleCheck(`http://localhost:${port}/`, () => true);
 }
 
-/**
- * Check if Next.js is already running on the specified port (single attempt)
- * @param {number} port - Port to check
- * @returns {Promise<boolean>} - True if Next.js is running
- */
 async function isNextJsRunning(port) {
-  const url = `http://localhost:${port}/`;
-
-  return new Promise((resolve) => {
-    const req = http.get(url, (res) => {
-      resolve(res.statusCode >= 200 && res.statusCode < 400);
-    });
-
-    req.on('error', () => resolve(false));
-    req.setTimeout(2000, () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
+  return singleCheck(
+    `http://localhost:${port}/`,
+    (status) => status >= 200 && status < 400,
+  );
 }
 
 module.exports = {

--- a/electron/utils/logger.js
+++ b/electron/utils/logger.js
@@ -1,0 +1,7 @@
+const isDebug = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development';
+
+module.exports = {
+  log: isDebug ? (...args) => console.log(...args) : () => {},
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+};

--- a/electron/utils/resourcePaths.js
+++ b/electron/utils/resourcePaths.js
@@ -30,6 +30,13 @@ function getBasePath() {
   return process.resourcesPath;
 }
 
+function assertExists(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Required resource not found — ${label}: ${filePath}`);
+  }
+  return filePath;
+}
+
 function getJavaPath() {
   if (isDevelopment()) {
     return 'java';
@@ -39,7 +46,7 @@ function getJavaPath() {
   const javaExecutable = process.platform === 'win32' ? 'java.exe' : 'java';
   const jrePath = path.join(getBasePath(), 'jre', platform, 'bin', javaExecutable);
 
-  return jrePath;
+  return assertExists(jrePath, 'Java runtime');
 }
 
 function getBackendJarPath() {
@@ -55,7 +62,7 @@ function getBackendJarPath() {
   }
 
   const jarPath = path.join(getBasePath(), 'backend', 'ambrosia.jar');
-  return jarPath;
+  return assertExists(jarPath, 'Backend JAR');
 }
 
 function getPhoenixdPath() {
@@ -64,11 +71,10 @@ function getPhoenixdPath() {
   }
 
   const platform = getPlatform();
-  // Windows uses JVM version which has bin/phoenixd.bat structure
   const phoenixdExecutable = process.platform === 'win32' ? path.join('bin', 'phoenixd.bat') : 'phoenixd';
   const phoenixdPath = path.join(getBasePath(), 'phoenixd', platform, phoenixdExecutable);
 
-  return phoenixdPath;
+  return assertExists(phoenixdPath, 'Phoenixd binary');
 }
 
 function getClientPath() {
@@ -77,7 +83,7 @@ function getClientPath() {
   }
 
   const clientPath = path.join(getBasePath(), 'client');
-  return clientPath;
+  return assertExists(clientPath, 'Next.js client');
 }
 
 function getDataDirectory() {


### PR DESCRIPTION
## Changes:
  - Bind Next.js to 127.0.0.1 instead of 0.0.0.0 to prevent unintended LAN exposure
  - Add 2-minute global startup timeout to startAll() with error propagation
  - Add 30-second post-startup health monitor that emits service:error if a service dies
  - Add guard in restartService() to skip external services and avoid null-process errors
  - Add redirect loop protection (max 5 redirects) in download-phoenixd.js and download-jre.js
  - Remove process listeners on cleanup() in BackendService and PhoenixdService to prevent listener accumulation on restart
  - Refactor healthCheck.js into a single checkService() function eliminating triplicated code
  - Add res.resume() in all health check HTTP responses to prevent stream leaks
  - Replace BIP39 mnemonic with crypto.randomBytes(32) for JWT and webhook secrets
  - Whitelist environment variables passed to Next.js child process (remove full process.env spread)
  - Add conditional logger (logger.js) that suppresses console.log in production unless DEBUG=true
  - Centralize magic numbers (timeouts, port ranges, versions) into constants.js
  - Add IPC argument sanitization in preload.js to strip functions, symbols and circular references
  - Add assertExists() validation in resourcePaths.js to fail fast with clear errors on missing binaries
  - Add parallel JRE downloads on Windows ARM64 builds using Promise.all()
  - Add visual error state in splash screen (splash:error event) showing failed service and error message
  - Add 7-day update expiration reminder for downloaded Windows updates in AutoUpdater
  - Fix splash screen IPC by removing sandbox: true from splash BrowserWindow (incompatible with ipcRenderer in Electron 36) and adding splash-preload.js to electron-builder files
  - Fix dev mode splash progress by emitting service:started for Next.js in ServiceManager dev path
  - Wait for did-finish-load before sending IPC to splash to eliminate renderer-not-ready race condition