### PR TITLE
Fix/shifts

### DIFF
--- a/client/src/components/turn/OpenTurnForm.jsx
+++ b/client/src/components/turn/OpenTurnForm.jsx
@@ -10,10 +10,10 @@ import { useTranslations } from "next-intl";
 import { useTurn } from "@/hooks/turn/useTurn";
 
 export default function OpenTurnForm({ onOpened }) {
-  const [initialAmount, setInitialAmount] = useState(1);
+  const [initialAmount, setInitialAmount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const { updateTurn, openShift } = useTurn();
+  const { updateTurn, openShift, refreshTurn } = useTurn();
   const router = useRouter();
 
   const t = useTranslations("shifts");
@@ -26,7 +26,7 @@ export default function OpenTurnForm({ onOpened }) {
     e.preventDefault();
     setError("");
 
-    if (!initialAmount || initialAmount < 1) {
+    if (initialAmount == null || isNaN(Number(initialAmount)) || initialAmount < 0) {
       setError(t("invalidAmount"));
       return;
     }
@@ -36,8 +36,12 @@ export default function OpenTurnForm({ onOpened }) {
       const id = await openShift(initialAmount);
       updateTurn(id);
       onOpened?.(id);
-    } catch {
-      setError(t("openShiftError"));
+    } catch (err) {
+      if (err?.message === "shift_already_open") {
+        await refreshTurn();
+      } else {
+        setError(t("openShiftError"));
+      }
     } finally {
       setIsLoading(false);
     }
@@ -59,7 +63,7 @@ export default function OpenTurnForm({ onOpened }) {
           startContent={
             <span className="text-default-400 text-small">$</span>
           }
-          minValue={1}
+          minValue={0}
           value={initialAmount}
           onValueChange={handleAmountChange}
           step={0.1}

--- a/client/src/components/turn/RequireOpenTurn.jsx
+++ b/client/src/components/turn/RequireOpenTurn.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+
 import { Modal, ModalBody, ModalContent, ModalHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
@@ -8,11 +10,23 @@ import { useTurn } from "@/hooks/turn/useTurn";
 import OpenTurnForm from "../turn/OpenTurnForm";
 
 export default function RequireOpenTurn({ children }) {
-  const { openTurn, loading } = useTurn();
+  const { openTurn, loading, checkOpenShift } = useTurn();
+  const checkedRef = useRef(false);
 
   const showModal = !loading && !openTurn;
 
   const t = useTranslations("shifts");
+
+  useEffect(() => {
+    if (!showModal) {
+      checkedRef.current = false;
+      return;
+    }
+    if (checkedRef.current) return;
+    checkedRef.current = true;
+
+    checkOpenShift().catch(() => {});
+  }, [showModal, checkOpenShift]);
 
   return (
     <>

--- a/client/src/components/turn/__tests__/OpenTurnForm.test.jsx
+++ b/client/src/components/turn/__tests__/OpenTurnForm.test.jsx
@@ -113,14 +113,39 @@ describe("OpenTurnForm", () => {
   });
 
   describe("validation", () => {
-    it("shows invalidAmount error when amount is 0", async () => {
+    it("accepts $0 as a valid opening amount", async () => {
       mockOpenShift.mockResolvedValue(1);
-
       const { container } = render(<OpenTurnForm />);
 
       fireEvent.submit(container.querySelector("form"));
       await screen.findByText("openShiftButton");
+
+      expect(mockOpenShift).toHaveBeenCalledWith(0);
       expect(screen.queryByText("invalidAmount")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shift_already_open handling", () => {
+    it("calls refreshTurn when server returns shift_already_open", async () => {
+      mockOpenShift.mockRejectedValue(new Error("shift_already_open"));
+      mockRefreshTurn.mockResolvedValue(null);
+      const { container } = render(<OpenTurnForm />);
+
+      fireEvent.submit(container.querySelector("form"));
+      await screen.findByText("openShiftButton");
+
+      expect(mockRefreshTurn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show error message when shift_already_open", async () => {
+      mockOpenShift.mockRejectedValue(new Error("shift_already_open"));
+      mockRefreshTurn.mockResolvedValue(null);
+      const { container } = render(<OpenTurnForm />);
+
+      fireEvent.submit(container.querySelector("form"));
+      await screen.findByText("openShiftButton");
+
+      expect(screen.queryByText("openShiftError")).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/components/turn/__tests__/OpenTurnForm.test.jsx
+++ b/client/src/components/turn/__tests__/OpenTurnForm.test.jsx
@@ -17,10 +17,11 @@ import OpenTurnForm from "../OpenTurnForm";
 
 const mockOpenShift = jest.fn();
 const mockUpdateTurn = jest.fn();
+const mockRefreshTurn = jest.fn();
 const mockBack = jest.fn();
 
 function setupMocks() {
-  useTurn.mockReturnValue({ openShift: mockOpenShift, updateTurn: mockUpdateTurn });
+  useTurn.mockReturnValue({ openShift: mockOpenShift, updateTurn: mockUpdateTurn, refreshTurn: mockRefreshTurn });
   useRouter.mockReturnValue({ back: mockBack });
 }
 
@@ -55,7 +56,7 @@ describe("OpenTurnForm", () => {
       fireEvent.submit(container.querySelector("form"));
 
       await screen.findByText("openShiftButton");
-      expect(mockOpenShift).toHaveBeenCalledWith(1);
+      expect(mockOpenShift).toHaveBeenCalledWith(0);
     });
 
     it("calls updateTurn with the returned shift id", async () => {

--- a/client/src/components/turn/__tests__/RequireOpenTurn.test.jsx
+++ b/client/src/components/turn/__tests__/RequireOpenTurn.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 
 jest.mock("@/hooks/turn/useTurn", () => ({
   useTurn: jest.fn(),
@@ -14,7 +14,7 @@ import { useTurn } from "@/hooks/turn/useTurn";
 import RequireOpenTurn from "../RequireOpenTurn";
 
 function setupMocks({ openTurn = null, loading = false } = {}) {
-  useTurn.mockReturnValue({ openTurn, loading });
+  useTurn.mockReturnValue({ openTurn, loading, checkOpenShift: jest.fn().mockResolvedValue(null) });
 }
 
 beforeEach(() => {
@@ -84,6 +84,50 @@ describe("RequireOpenTurn", () => {
         </RequireOpenTurn>,
       );
       expect(screen.queryByText("requiredOpenShiftTitle")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("proactive shift detection", () => {
+    it("calls checkOpenShift when modal first appears", async () => {
+      const checkOpenShift = jest.fn().mockResolvedValue(null);
+      useTurn.mockReturnValue({ openTurn: null, loading: false, checkOpenShift });
+
+      render(<RequireOpenTurn><div>Content</div></RequireOpenTurn>);
+
+      await waitFor(() => {
+        expect(checkOpenShift).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does not call checkOpenShift when still loading", () => {
+      const checkOpenShift = jest.fn().mockResolvedValue(null);
+      useTurn.mockReturnValue({ openTurn: null, loading: true, checkOpenShift });
+
+      render(<RequireOpenTurn><div>Content</div></RequireOpenTurn>);
+
+      expect(checkOpenShift).not.toHaveBeenCalled();
+    });
+
+    it("does not call checkOpenShift when shift is already open", () => {
+      const checkOpenShift = jest.fn().mockResolvedValue(null);
+      useTurn.mockReturnValue({ openTurn: 5, loading: false, checkOpenShift });
+
+      render(<RequireOpenTurn><div>Content</div></RequireOpenTurn>);
+
+      expect(checkOpenShift).not.toHaveBeenCalled();
+    });
+
+    it("does not call checkOpenShift a second time on re-render", async () => {
+      const checkOpenShift = jest.fn().mockResolvedValue(null);
+      useTurn.mockReturnValue({ openTurn: null, loading: false, checkOpenShift });
+
+      const { rerender } = render(<RequireOpenTurn><div>Content</div></RequireOpenTurn>);
+
+      await waitFor(() => expect(checkOpenShift).toHaveBeenCalledTimes(1));
+
+      rerender(<RequireOpenTurn><div>Content</div></RequireOpenTurn>);
+
+      expect(checkOpenShift).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/client/src/providers/turn/TurnProvider.jsx
+++ b/client/src/providers/turn/TurnProvider.jsx
@@ -71,10 +71,11 @@ export function TurnProvider({ children }) {
       setOpenTurn: setOpenTurnId,
       updateTurn,
       refreshTurn,
+      checkOpenShift: loadOpenTurn,
       openShift,
       closeShift,
     }),
-    [openTurnId, openShiftData, loading, error, updateTurn, refreshTurn, openShift, closeShift],
+    [openTurnId, openShiftData, loading, error, updateTurn, refreshTurn, loadOpenTurn, openShift, closeShift],
   );
 
   return (

--- a/client/src/services/shiftsService.js
+++ b/client/src/services/shiftsService.js
@@ -30,6 +30,8 @@ export async function openTurn(userId, initialAmount = 0) {
       initial_amount: initialAmount,
     }),
   });
+  if (response.status === 409) throw new Error("shift_already_open");
+  if (!response.ok) throw new Error(`Failed to open shift: ${response.status}`);
   return await parseJsonResponse(response, null);
 }
 


### PR DESCRIPTION
## Changes:
  - Allow opening a shift with $0 initial cash, enabling Lightning-only merchants who don't manage a cash drawer
  - Detect a stuck/unclosed shift proactively when the "Open Shift Required" modal appears — if the server finds an open shift, the modal closes automatically and the widget activates without requiring user interaction
  - Handle shift_already_open (HTTP 409) silently by calling refreshTurn() instead of showing an error state, letting the modal resolve itself
  - Remove redundant "Shift already open" stuck-state UI from OpenTurnForm and RequireOpenTurn — the widget is the single place to manage an open shift
  - Add tests for proactive shift detection: verifies checkOpenShift is called on modal open, skipped when loading or shift already loaded, and not called twice on re-render
  - Add tests for $0 validation and silent shift_already_open handling