### PR TITLE
fix(server/products): fix migration for product categories

### DIFF
--- a/server/app/src/main/resources/db/migration/V20__nullable_product_category.sql
+++ b/server/app/src/main/resources/db/migration/V20__nullable_product_category.sql
@@ -14,6 +14,7 @@ CREATE TABLE products__new (
     FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE SET NULL
 );
 
-INSERT INTO products__new SELECT * FROM products;
+INSERT INTO products__new (id, SKU, name, description, image_url, cost_cents, category_id, quantity, min_stock_threshold, max_stock_threshold, price_cents, is_deleted)
+SELECT id, SKU, name, description, image_url, cost_cents, category_id, quantity, min_stock_threshold, max_stock_threshold, price_cents, is_deleted FROM products;
 DROP TABLE products;
 ALTER TABLE products__new RENAME TO products;

--- a/server/app/src/main/resources/db/migration/V21__product_categories_many_to_many.sql
+++ b/server/app/src/main/resources/db/migration/V21__product_categories_many_to_many.sql
@@ -1,13 +1,6 @@
-CREATE TABLE product_categories (
-    product_id BLOB NOT NULL,
-    category_id BLOB NOT NULL,
-    PRIMARY KEY (product_id, category_id),
-    FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE,
-    FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
-);
-
-INSERT INTO product_categories (product_id, category_id)
-SELECT id, category_id FROM products WHERE category_id IS NOT NULL AND is_deleted = 0;
+CREATE TEMPORARY TABLE product_categories_temp AS
+SELECT CAST(id AS TEXT) AS product_id, CAST(category_id AS TEXT) AS category_id
+FROM products WHERE category_id IS NOT NULL AND is_deleted = 0;
 
 CREATE TABLE products__new (
     id BLOB PRIMARY KEY,
@@ -28,3 +21,16 @@ SELECT id, SKU, name, description, image_url, cost_cents, quantity, min_stock_th
 
 DROP TABLE products;
 ALTER TABLE products__new RENAME TO products;
+
+CREATE TABLE product_categories (
+    product_id BLOB NOT NULL,
+    category_id BLOB NOT NULL,
+    PRIMARY KEY (product_id, category_id),
+    FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE,
+    FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
+);
+
+INSERT INTO product_categories (product_id, category_id)
+SELECT product_id, category_id FROM product_categories_temp;
+
+DROP TABLE product_categories_temp;


### PR DESCRIPTION
This pull request updates the database migration scripts to improve the handling of product-category relationships, specifically for migrating to a many-to-many association between products and categories. The changes ensure data integrity during the migration and fix issues with type consistency and table creation order.

Migration improvements for many-to-many product-category relationship:

* Changed the insertion into `products__new` to explicitly specify columns, ensuring that the column order matches and preventing data misalignment during migration.
* In `V21__product_categories_many_to_many.sql`, replaced the direct creation and population of `product_categories` with a temporary table (`product_categories_temp`) that casts IDs to text, ensuring type compatibility during migration.
* Moved the creation of the `product_categories` table and its population from the temporary table to after the `products` table is replaced, ensuring referential integrity and correct foreign key relationships.