### PR TITLE
fix(client/wallet): refresh node info and transactions after sending a payment

### DIFF
--- a/client/src/components/pages/Store/Wallet/StoreWallet.jsx
+++ b/client/src/components/pages/Store/Wallet/StoreWallet.jsx
@@ -145,6 +145,8 @@ function WalletInner() {
         filter={filter}
         setFilter={setFilter}
         invoiceActions={invoiceActions}
+        fetchInfo={fetchInfo}
+        fetchTransactions={fetchTransactions}
       />
 
       <InvoiceModal

--- a/client/src/components/pages/Store/Wallet/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions.jsx
@@ -22,6 +22,8 @@ export function Transactions({
   filter,
   setFilter,
   invoiceActions,
+  fetchInfo,
+  fetchTransactions,
 }) {
   const t = useTranslations("wallet");
   const tTour = useTranslations("walletTour");
@@ -114,6 +116,8 @@ export function Transactions({
               loading={loading}
               setLoading={setLoading}
               setError={setError}
+              fetchInfo={fetchInfo}
+              fetchTransactions={fetchTransactions}
             />
           </Tab>
 

--- a/client/src/components/pages/Store/Wallet/TransactionsSendTab.jsx
+++ b/client/src/components/pages/Store/Wallet/TransactionsSendTab.jsx
@@ -19,7 +19,7 @@ import { payInvoiceFromService } from "@/services/walletService";
 
 import { copyToClipboard, formatSats } from "./utils/formatters";
 
-export function TransactionsSendTab({ loading, setLoading, setError }) {
+export function TransactionsSendTab({ loading, setLoading, setError, fetchInfo, fetchTransactions }) {
   const t = useTranslations("wallet");
   const [payInvoice, setPayInvoice] = useState("");
   const [paymentResult, setPaymentResult] = useState(null);
@@ -61,6 +61,8 @@ export function TransactionsSendTab({ loading, setLoading, setError }) {
       setPayInvoice("");
       setError("");
       setInvalidInvoice(false);
+      fetchInfo?.();
+      fetchTransactions?.();
       addToast({
         title: t("payments.send.paySuccessTitle"),
         description: t("payments.send.paySuccessDescription"),


### PR DESCRIPTION
This pull request enhances the wallet functionality by ensuring that wallet information and transaction data are refreshed after sending a payment. The main changes involve passing the `fetchInfo` and `fetchTransactions` functions through the relevant components and invoking them after a successful transaction.

**Wallet data refresh improvements:**

* Passed `fetchInfo` and `fetchTransactions` as props from `WalletInner` to the `Transactions` component, enabling child components to trigger data refreshes. [[1]](diffhunk://#diff-02f76788e01ecc06fec3478d0682b6f80057b3757c71bafddb81a224bef615e6R148-R149) [[2]](diffhunk://#diff-ca395790410a6cbbea78d109279afbe4ba4ed3b4ebb4e4799135eaf34577d393R25-R26)
* Further passed `fetchInfo` and `fetchTransactions` from `Transactions` to the `TransactionsSendTab` component, making them available where payments are sent. [[1]](diffhunk://#diff-ca395790410a6cbbea78d109279afbe4ba4ed3b4ebb4e4799135eaf34577d393R119-R120) [[2]](diffhunk://#diff-ebb594063f8687579e65fedb66168daa84e70d18c83284a0f1529523ca0f0c23L22-R22)
* After a successful payment in `TransactionsSendTab`, now calls `fetchInfo` and `fetchTransactions` to update wallet balances and transaction history immediately.