### PR TITLE
Chore/electron improvements

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -5,18 +5,19 @@ const { app, BrowserWindow, Menu, dialog, shell, ipcMain } = require('electron')
 const AutoUpdater = require('./services/AutoUpdater');
 const { readConfig, writeConfig } = require('./services/ConfigurationBootstrap');
 const ServiceManager = require('./services/ServiceManager');
+const logger = require('./utils/logger');
 const { getPhoenixDataDirectory } = require('./utils/resourcePaths');
 
 // To prevent multiple instances of the application
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
-  console.log('[Electron] Another instance is already running. Exiting...');
+  logger.log('[Electron] Another instance is already running. Exiting...');
   app.quit();
 } else {
   app.on('second-instance', (_event, _commandLine, _workingDirectory) => {
     // If someone tries to open a second instance, focus the existing window
-    console.log('[Electron] Second instance detected, focusing existing window');
+    logger.log('[Electron] Second instance detected, focusing existing window');
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
@@ -115,7 +116,7 @@ function createWindow(url) {
 
   // Handle loading errors
   mainWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
-    console.error('[Electron] Error Loading Page:', errorCode, errorDescription);
+    logger.error('[Electron] Error Loading Page:', errorCode, errorDescription);
 
     dialog.showErrorBox(
       'Loading Error',
@@ -126,7 +127,7 @@ function createWindow(url) {
 
 // Handle global errors
 async function handleStartupError(error) {
-  console.error('[Electron] Startup Error:', error);
+  logger.error('[Electron] Startup Error:', error);
 
   // Close splash window if it exists
   if (splashWindow && !splashWindow.isDestroyed()) {
@@ -322,7 +323,7 @@ ipcMain.handle('phoenixd:set-auto-liquidity', async (_event, value) => {
 // App initialization
 app.whenReady().then(async () => {
   try {
-    console.log('[Electron] Initializing Ambrosia POS...');
+    logger.log('[Electron] Initializing Ambrosia POS...');
 
     // Show splash screen and wait for it to finish loading before sending IPC
     createSplashScreen();
@@ -330,9 +331,9 @@ app.whenReady().then(async () => {
 
     // SPLASH ONLY MODE: For design/testing purposes
     if (process.env.SPLASH_ONLY === 'true') {
-      console.log('[Electron] SPLASH ONLY MODE: Showing splash for design purposes');
-      console.log('[Electron] Edit splash.html and reload the window to see changes');
-      console.log('[Electron] Press Ctrl+R in the splash window to reload');
+      logger.log('[Electron] SPLASH ONLY MODE: Showing splash for design purposes');
+      logger.log('[Electron] Edit splash.html and reload the window to see changes');
+      logger.log('[Electron] Press Ctrl+R in the splash window to reload');
 
       // Enable DevTools for splash window in splash-only mode
       if (splashWindow && !splashWindow.isDestroyed()) {
@@ -361,7 +362,7 @@ app.whenReady().then(async () => {
     updateSplash(null, 0, 'Initializing...');
 
     serviceManager.on('service:started', ({ service, port }) => {
-      console.log(`[Electron] Service started: ${service} on port ${port}`);
+      logger.log(`[Electron] Service started: ${service} on port ${port}`);
 
       // Update progress based on service
       let progress = 0;
@@ -387,7 +388,7 @@ app.whenReady().then(async () => {
     });
 
     serviceManager.on('service:error', ({ service, error }) => {
-      console.error(`[Electron] Service error: ${service}`, error);
+      logger.error(`[Electron] Service error: ${service}`, error);
       if (splashWindow && !splashWindow.isDestroyed()) {
         splashWindow.webContents.send('splash:error', {
           service,
@@ -397,7 +398,7 @@ app.whenReady().then(async () => {
     });
 
     serviceManager.on('all:started', () => {
-      console.log('[Electron] All services are running');
+      logger.log('[Electron] All services are running');
     });
 
     // Start with initial message
@@ -423,7 +424,7 @@ app.whenReady().then(async () => {
       autoUpdaterService.startPeriodicChecks();
     }
 
-    console.log('[Electron] Application initialized successfully');
+    logger.log('[Electron] Application initialized successfully');
   } catch (error) {
     // Show error state in splash before closing
     if (splashWindow && !splashWindow.isDestroyed()) {
@@ -458,7 +459,7 @@ app.on('before-quit', async (event) => {
   }
   if (serviceManager) {
     event.preventDefault();
-    console.log('[Electron] Shutting down services...');
+    logger.log('[Electron] Shutting down services...');
     await serviceManager.stopAll();
     serviceManager = null;
     setTimeout(() => app.quit(), 500);
@@ -481,10 +482,10 @@ app.on('window-all-closed', async () => {
 
 // Crash handler
 process.on('uncaughtException', (error) => {
-  console.error('[Electron] Uncaught Exception:', error);
+  logger.error('[Electron] Uncaught Exception:', error);
   dialog.showErrorBox('Unexpected Error', error.message || error.toString());
 });
 
 process.on('unhandledRejection', (reason, promise) => {
-  console.error('[Electron] Unhandled Rejection at:', promise, 'reason:', reason);
+  logger.error('[Electron] Unhandled Rejection at:', promise, 'reason:', reason);
 });

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "bip39": "^3.1.0",
         "cross-spawn": "^7.0.6",
         "electron-updater": "^6.3.9",
         "find-free-port": "^2.0.0",
@@ -924,18 +923,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -1724,15 +1711,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
-      }
     },
     "node_modules/bl": {
       "version": "4.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-n": "^17.23.1"
   },
   "dependencies": {
-    "bip39": "^3.1.0",
     "cross-spawn": "^7.0.6",
     "electron-updater": "^6.3.9",
     "find-free-port": "^2.0.0",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+const logger = require('./utils/logger');
+
 const SEND_CHANNELS = ['ping', 'restart-server'];
 
 const INVOKE_CHANNELS = [
@@ -73,4 +75,4 @@ contextBridge.exposeInMainWorld('electron', {
   },
 });
 
-console.log('[Preload] Electron APIs exposed successfully');
+logger.log('[Preload] Electron APIs exposed successfully');

--- a/electron/scripts/build-client.js
+++ b/electron/scripts/build-client.js
@@ -88,8 +88,23 @@ function main() {
     console.log(`✓ Created directory: ${RESOURCES_DIR}\n`);
 
     // Copy standalone build
+    // Next.js 16 nests standalone output inside a subdirectory named after the project
+    // (.next/standalone/client/server.js instead of .next/standalone/server.js)
     console.log('Copying standalone build...');
-    copyDirectory(standalonePath, RESOURCES_DIR);
+    let standaloneRoot = standalonePath;
+    if (!fs.existsSync(path.join(standaloneRoot, 'server.js'))) {
+      const entries = fs.readdirSync(standaloneRoot, { withFileTypes: true });
+      const nested = entries.find(
+        (e) => e.isDirectory() && fs.existsSync(path.join(standaloneRoot, e.name, 'server.js')),
+      );
+      if (nested) {
+        standaloneRoot = path.join(standaloneRoot, nested.name);
+        console.log(`Detected nested standalone structure, using: ${standaloneRoot}\n`);
+      } else {
+        throw new Error(`server.js not found inside standalone build at: ${standaloneRoot}`);
+      }
+    }
+    copyDirectory(standaloneRoot, RESOURCES_DIR);
     console.log('✓ Copied standalone build to root\n');
 
     // Copy static files into standalone/.next/static

--- a/electron/scripts/download-jre.js
+++ b/electron/scripts/download-jre.js
@@ -295,6 +295,7 @@ async function main() {
   console.log('\n===========================================');
   console.log(`  ✓ JRE download for ${currentPlatform} complete!`);
   console.log('===========================================');
+  process.exit(0);
 }
 
 main().catch((error) => {

--- a/electron/scripts/download-node.js
+++ b/electron/scripts/download-node.js
@@ -49,15 +49,21 @@ const ALL_DOWNLOADS = {
 const currentPlatform = getBuildPlatform();
 const DOWNLOADS = [ALL_DOWNLOADS[currentPlatform]];
 
-function downloadFile(url, destination) {
+const MAX_REDIRECTS = 5;
+
+function downloadFile(url, destination, redirectCount = 0) {
   return new Promise((resolve, reject) => {
     console.log(`Downloading: ${url}`);
     const file = fs.createWriteStream(destination);
 
     https.get(url, (response) => {
       if (response.statusCode === 302 || response.statusCode === 301) {
-        // Handle redirect
-        return downloadFile(response.headers.location, destination)
+        file.close();
+        if (redirectCount >= MAX_REDIRECTS) {
+          reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
+          return;
+        }
+        return downloadFile(response.headers.location, destination, redirectCount + 1)
           .then(resolve)
           .catch(reject);
       }
@@ -179,7 +185,9 @@ async function main() {
   console.log('===========================================');
 }
 
-main().catch((error) => {
-  console.error('\n✗ Error:', error.message);
-  process.exit(1);
-});
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('\n✗ Error:', error.message);
+    process.exit(1);
+  });

--- a/electron/scripts/download-phoenixd.js
+++ b/electron/scripts/download-phoenixd.js
@@ -249,6 +249,7 @@ async function main() {
   console.log('\n===========================================');
   console.log(`  ✓ Phoenixd download for ${currentPlatform} complete!`);
   console.log('===========================================');
+  process.exit(0);
 }
 
 main().catch((error) => {

--- a/electron/services/AutoUpdater.js
+++ b/electron/services/AutoUpdater.js
@@ -5,6 +5,8 @@ const path = require('path');
 const { dialog, ipcMain, shell } = require('electron');
 const { autoUpdater } = require('electron-updater');
 
+const logger = require('../utils/logger');
+
 const SUPPORTS_AUTO_UPDATE = process.platform === 'win32';
 const UPDATE_EXPIRY_DAYS = 7;
 const UPDATE_STATE_FILE = path.join(os.homedir(), '.Ambrosia-POS', 'pending-update.json');
@@ -34,7 +36,7 @@ class AutoUpdater {
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(UPDATE_STATE_FILE, JSON.stringify({ version, downloadedAt: Date.now() }));
     } catch (err) {
-      console.error('[AutoUpdater] Failed to save update state:', err.message);
+      logger.error('[AutoUpdater] Failed to save update state:', err.message);
     }
   }
 
@@ -42,7 +44,7 @@ class AutoUpdater {
     try {
       if (fs.existsSync(UPDATE_STATE_FILE)) fs.unlinkSync(UPDATE_STATE_FILE);
     } catch (err) {
-      console.error('[AutoUpdater] Failed to clear update state:', err.message);
+      logger.error('[AutoUpdater] Failed to clear update state:', err.message);
     }
   }
 
@@ -54,7 +56,7 @@ class AutoUpdater {
       const ageMs = Date.now() - (state.downloadedAt || 0);
       const ageDays = ageMs / (1000 * 60 * 60 * 24);
       if (ageDays >= UPDATE_EXPIRY_DAYS) {
-        console.log(`[AutoUpdater] Pending update v${state.version} is ${Math.floor(ageDays)} days old — prompting install`);
+        logger.log(`[AutoUpdater] Pending update v${state.version} is ${Math.floor(ageDays)} days old — prompting install`);
         dialog.showMessageBox(this.mainWindow, {
           type: 'warning',
           title: 'Update Ready to Install',
@@ -71,13 +73,13 @@ class AutoUpdater {
         });
       }
     } catch (err) {
-      console.error('[AutoUpdater] Failed to check pending update state:', err.message);
+      logger.error('[AutoUpdater] Failed to check pending update state:', err.message);
     }
   }
 
   _setupEvents() {
     autoUpdater.on('update-available', (info) => {
-      console.log('[AutoUpdater] Update available:', info.version);
+      logger.log('[AutoUpdater] Update available:', info.version);
       this.pendingVersion = info.version;
       this.isManualCheck = false;
 
@@ -97,7 +99,7 @@ class AutoUpdater {
     });
 
     autoUpdater.on('update-not-available', (info) => {
-      console.log('[AutoUpdater] Up to date:', info.version);
+      logger.log('[AutoUpdater] Up to date:', info.version);
       this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
       if (this.isManualCheck) {
         this.isManualCheck = false;
@@ -112,12 +114,12 @@ class AutoUpdater {
     });
 
     autoUpdater.on('download-progress', (progress) => {
-      console.log('[AutoUpdater] Download progress:', `${progress.percent.toFixed(1)}%`);
+      logger.log('[AutoUpdater] Download progress:', `${progress.percent.toFixed(1)}%`);
     });
 
     // Only fires on Windows (only platform that downloads)
     autoUpdater.on('update-downloaded', (info) => {
-      console.log('[AutoUpdater] Update downloaded:', info.version);
+      logger.log('[AutoUpdater] Update downloaded:', info.version);
       this._saveUpdateState(info.version);
       this.onMenuUpdate({
         label: `Restart to Update to ${info.version}`,
@@ -131,7 +133,7 @@ class AutoUpdater {
     });
 
     autoUpdater.on('error', (error) => {
-      console.error('[AutoUpdater] Error:', error.message);
+      logger.error('[AutoUpdater] Error:', error.message);
       this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
       if (this.isManualCheck) {
         this.isManualCheck = false;
@@ -191,7 +193,7 @@ class AutoUpdater {
   checkForUpdates() {
     this.onMenuUpdate({ label: 'Checking for Updates...', enabled: false });
     autoUpdater.checkForUpdates().catch((err) => {
-      console.error('[AutoUpdater] Scheduled check failed:', err.message);
+      logger.error('[AutoUpdater] Scheduled check failed:', err.message);
       this.onMenuUpdate({ label: 'Check for Updates...', enabled: true });
     });
   }

--- a/electron/services/BackendService.js
+++ b/electron/services/BackendService.js
@@ -5,6 +5,7 @@ const spawn = require('cross-spawn');
 const treeKill = require('tree-kill');
 
 const { checkBackend } = require('../utils/healthCheck');
+const logger = require('../utils/logger');
 const { getJavaPath, getBackendJarPath, getLogsDirectory } = require('../utils/resourcePaths');
 
 class BackendService {
@@ -50,7 +51,7 @@ class BackendService {
         PHOENIXD_WEBHOOK_SECRET: config.webhookSecret,
       };
 
-      console.log(`[BackendService] Starting backend at port ${port}...`);
+      logger.log(`[BackendService] Starting backend at port ${port}...`);
 
       this.process = spawn(javaPath, args, {
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -60,7 +61,7 @@ class BackendService {
 
       this.process.stdout.on('data', (data) => {
         const message = data.toString();
-        console.log(`[Backend] ${message.trim()}`);
+        logger.log(`[Backend] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ${message}`);
         }
@@ -68,33 +69,33 @@ class BackendService {
 
       this.process.stderr.on('data', (data) => {
         const message = data.toString();
-        console.error(`[Backend ERROR] ${message.trim()}`);
+        logger.error(`[Backend ERROR] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ERROR: ${message}`);
         }
       });
 
       this.process.on('error', (error) => {
-        console.error('[BackendService] Failed to start:', error);
+        logger.error('[BackendService] Failed to start:', error);
         this.status = 'error';
         this.cleanup();
       });
 
       this.process.on('close', (code) => {
-        console.log(`[BackendService] Process exited with code ${code}`);
+        logger.log(`[BackendService] Process exited with code ${code}`);
         this.status = 'stopped';
         this.cleanup();
       });
 
-      console.log('[BackendService] Waiting for backend to be healthy...');
+      logger.log('[BackendService] Waiting for backend to be healthy...');
       await checkBackend(port);
 
       this.status = 'running';
-      console.log('[BackendService] Backend is running and healthy');
+      logger.log('[BackendService] Backend is running and healthy');
 
       return { port };
     } catch (error) {
-      console.error('[BackendService] Startup failed:', error);
+      logger.error('[BackendService] Startup failed:', error);
       this.status = 'error';
       await this.stop();
       throw error;
@@ -103,24 +104,24 @@ class BackendService {
 
   async stop() {
     if (!this.process) {
-      console.log('[BackendService] No process to stop');
+      logger.log('[BackendService] No process to stop');
       return;
     }
 
-    console.log('[BackendService] Stopping backend...');
+    logger.log('[BackendService] Stopping backend...');
 
     return new Promise((resolve) => {
       const pid = this.process.pid;
 
       treeKill(pid, 'SIGTERM', (err) => {
         if (err) {
-          console.error('[BackendService] Failed to kill process tree:', err);
+          logger.error('[BackendService] Failed to kill process tree:', err);
           treeKill(pid, 'SIGKILL', () => {
             this.cleanup();
             resolve();
           });
         } else {
-          console.log('[BackendService] Process tree killed successfully');
+          logger.log('[BackendService] Process tree killed successfully');
           this.cleanup();
           resolve();
         }
@@ -128,7 +129,7 @@ class BackendService {
 
       setTimeout(() => {
         if (this.process) {
-          console.warn('[BackendService] Force killing after timeout');
+          logger.warn('[BackendService] Force killing after timeout');
           treeKill(pid, 'SIGKILL', () => {
             this.cleanup();
             resolve();

--- a/electron/services/BackendService.js
+++ b/electron/services/BackendService.js
@@ -53,13 +53,15 @@ class BackendService {
 
       logger.log(`[BackendService] Starting backend at port ${port}...`);
 
-      this.process = spawn(javaPath, args, {
+      const spawnedProcess = spawn(javaPath, args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,
         env,
       });
 
-      this.process.stdout.on('data', (data) => {
+      this.process = spawnedProcess;
+
+      spawnedProcess.stdout.on('data', (data) => {
         const message = data.toString();
         logger.log(`[Backend] ${message.trim()}`);
         if (this.logStream) {
@@ -67,7 +69,7 @@ class BackendService {
         }
       });
 
-      this.process.stderr.on('data', (data) => {
+      spawnedProcess.stderr.on('data', (data) => {
         const message = data.toString();
         logger.error(`[Backend ERROR] ${message.trim()}`);
         if (this.logStream) {
@@ -75,16 +77,20 @@ class BackendService {
         }
       });
 
-      this.process.on('error', (error) => {
+      spawnedProcess.on('error', (error) => {
         logger.error('[BackendService] Failed to start:', error);
-        this.status = 'error';
-        this.cleanup();
+        if (this.process === spawnedProcess) {
+          this.status = 'error';
+          this.cleanup();
+        }
       });
 
-      this.process.on('close', (code) => {
+      spawnedProcess.on('close', (code) => {
         logger.log(`[BackendService] Process exited with code ${code}`);
-        this.status = 'stopped';
-        this.cleanup();
+        if (this.process === spawnedProcess) {
+          this.status = 'stopped';
+          this.cleanup();
+        }
       });
 
       logger.log('[BackendService] Waiting for backend to be healthy...');

--- a/electron/services/ConfigurationBootstrap.js
+++ b/electron/services/ConfigurationBootstrap.js
@@ -2,35 +2,8 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
-const bip39 = require('bip39');
-
+const logger = require('../utils/logger');
 const { getDataDirectory, getPhoenixDataDirectory, getLogsDirectory } = require('../utils/resourcePaths');
-
-/**
- * Generates a secure 12-word mnemonic using BIP39 standard.
- * - Uses industry-standard BIP39 wordlist (2,048 words)
- * - Provides 128 bits of entropy (132 bits with checksum)
- * - Includes built-in checksum for error detection
- * - Compatible with Bitcoin wallets and other crypto applications
- *
- * @returns {string} A 12-word mnemonic phrase
- */
-function generateSecret() {
-  const mnemonic = bip39.generateMnemonic(); // 12 words by default (128 bits)
-  console.log('[ConfigurationBootstrap] Generated BIP39 mnemonic (132 bits entropy with checksum)');
-  return mnemonic;
-}
-
-/**
- * Validates a BIP39 mnemonic phrase.
- * Checks both word validity and checksum integrity.
- *
- * @param {string} mnemonic - The mnemonic phrase to validate
- * @returns {boolean} True if valid, false otherwise
- */
-function validateSecret(mnemonic) {
-  return bip39.validateMnemonic(mnemonic);
-}
 
 function generateRandomHex(length) {
   return crypto.randomBytes(length).toString('hex');
@@ -39,7 +12,7 @@ function generateRandomHex(length) {
 function ensureDirectoryExists(dir) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
-    console.log(`[ConfigurationBootstrap] Created directory: ${dir}`);
+    logger.log(`[ConfigurationBootstrap] Created directory: ${dir}`);
   }
 }
 
@@ -76,7 +49,7 @@ function readConfig(configPath) {
 function writeConfig(configPath, config) {
   const lines = Object.entries(config).map(([key, value]) => `${key}=${value}`);
   fs.writeFileSync(configPath, `${lines.join('\n')}\n`, { encoding: 'utf-8', mode: 0o600 });
-  console.log(`[ConfigurationBootstrap] Written configuration to: ${configPath}`);
+  logger.log(`[ConfigurationBootstrap] Written configuration to: ${configPath}`);
 }
 
 async function ensureConfigurations(ports) {
@@ -97,7 +70,7 @@ async function ensureConfigurations(ports) {
   let needsUpdate = false;
 
   if (!fs.existsSync(ambrosiaConfigPath) || Object.keys(ambrosiaConfig).length === 0) {
-    console.log('[ConfigurationBootstrap] Generating Ambrosia configuration...');
+    logger.log('[ConfigurationBootstrap] Generating Ambrosia configuration...');
     const secret = generateRandomHex(32);
     const secretHash = crypto.createHash('sha256').update(secret).digest('hex');
 
@@ -117,7 +90,7 @@ async function ensureConfigurations(ports) {
   }
 
   if (!fs.existsSync(phoenixConfigPath) || Object.keys(phoenixConfig).length === 0) {
-    console.log('[ConfigurationBootstrap] Generating Phoenix configuration...');
+    logger.log('[ConfigurationBootstrap] Generating Phoenix configuration...');
     const httpPassword = generateRandomHex(32);
     const httpPasswordLimited = generateRandomHex(32);
     const webhookSecret = generateRandomHex(32);
@@ -153,7 +126,5 @@ module.exports = {
   ensureConfigurations,
   readConfig,
   writeConfig,
-  generateSecret,
-  validateSecret,
   generateRandomHex,
 };

--- a/electron/services/NextJsService.js
+++ b/electron/services/NextJsService.js
@@ -5,6 +5,7 @@ const spawn = require('cross-spawn');
 const treeKill = require('tree-kill');
 
 const { checkNextJs } = require('../utils/healthCheck');
+const logger = require('../utils/logger');
 const { getClientPath, getLogsDirectory, isDevelopment, getNodePath } = require('../utils/resourcePaths');
 
 class NextJsService {
@@ -48,17 +49,17 @@ class NextJsService {
         cwd = clientPath;
       }
 
-      console.log(`[NextJsService] Starting Next.js at port ${port}...`);
-      console.log(`[NextJsService] Command: ${command} ${args.join(' ')}`);
-      console.log(`[NextJsService] Working directory: ${cwd}`);
-      console.log(`[NextJsService] Environment PORT: ${port}`);
+      logger.log(`[NextJsService] Starting Next.js at port ${port}...`);
+      logger.log(`[NextJsService] Command: ${command} ${args.join(' ')}`);
+      logger.log(`[NextJsService] Working directory: ${cwd}`);
+      logger.log(`[NextJsService] Environment PORT: ${port}`);
 
       // Use backend config passed as parameter (with fallback to defaults)
       const backendHost = backendConfig.host || 'localhost';
       const backendPort = backendConfig.port || '9154';
       const apiUrl = `http://${backendHost}:${backendPort}`;
 
-      console.log(`[NextJsService] Backend configuration: ${apiUrl}`);
+      logger.log(`[NextJsService] Backend configuration: ${apiUrl}`);
 
       // Verify server.js exists (only in production mode)
       if (!isDev) {
@@ -66,7 +67,7 @@ class NextJsService {
         if (!fs.existsSync(serverJsPath)) {
           throw new Error(`server.js not found at: ${serverJsPath}`);
         }
-        console.log(`[NextJsService] Verified server.js exists at: ${serverJsPath}`);
+        logger.log(`[NextJsService] Verified server.js exists at: ${serverJsPath}`);
       }
 
       const env = {
@@ -79,14 +80,14 @@ class NextJsService {
         NEXT_PUBLIC_ELECTRON: 'true',
       };
 
-      console.log(`[NextJsService] Environment variables:`, {
+      logger.log(`[NextJsService] Environment variables:`, {
         PORT: env.PORT,
         HOSTNAME: env.HOSTNAME,
         NEXT_PUBLIC_API_URL: env.NEXT_PUBLIC_API_URL,
         NEXT_PUBLIC_ELECTRON: env.NEXT_PUBLIC_ELECTRON,
       });
 
-      console.log(`[NextJsService] Spawning process...`);
+      logger.log(`[NextJsService] Spawning process...`);
       this.process = spawn(command, args, {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -97,11 +98,11 @@ class NextJsService {
       if (!this.process || !this.process.pid) {
         throw new Error('Failed to spawn Next.js process');
       }
-      console.log(`[NextJsService] Process spawned with PID: ${this.process.pid}`);
+      logger.log(`[NextJsService] Process spawned with PID: ${this.process.pid}`);
 
       this.process.stdout.on('data', (data) => {
         const message = data.toString();
-        console.log(`[Next.js] ${message.trim()}`);
+        logger.log(`[Next.js] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ${message}`);
         }
@@ -109,33 +110,33 @@ class NextJsService {
 
       this.process.stderr.on('data', (data) => {
         const message = data.toString();
-        console.error(`[Next.js ERROR] ${message.trim()}`);
+        logger.error(`[Next.js ERROR] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ERROR: ${message}`);
         }
       });
 
       this.process.on('error', (error) => {
-        console.error('[NextJsService] Failed to start:', error);
+        logger.error('[NextJsService] Failed to start:', error);
         this.status = 'error';
         this.cleanup();
       });
 
       this.process.on('close', (code) => {
-        console.log(`[NextJsService] Process exited with code ${code}`);
+        logger.log(`[NextJsService] Process exited with code ${code}`);
         this.status = 'stopped';
         this.cleanup();
       });
 
-      console.log('[NextJsService] Waiting for Next.js to be healthy...');
+      logger.log('[NextJsService] Waiting for Next.js to be healthy...');
       await checkNextJs(port);
 
       this.status = 'running';
-      console.log('[NextJsService] Next.js is running and healthy');
+      logger.log('[NextJsService] Next.js is running and healthy');
 
       return { port, url: `http://localhost:${port}` };
     } catch (error) {
-      console.error('[NextJsService] Startup failed:', error);
+      logger.error('[NextJsService] Startup failed:', error);
       this.status = 'error';
       await this.stop();
       throw error;
@@ -144,24 +145,24 @@ class NextJsService {
 
   async stop() {
     if (!this.process) {
-      console.log('[NextJsService] No process to stop');
+      logger.log('[NextJsService] No process to stop');
       return;
     }
 
-    console.log('[NextJsService] Stopping Next.js...');
+    logger.log('[NextJsService] Stopping Next.js...');
 
     return new Promise((resolve) => {
       const pid = this.process.pid;
 
       treeKill(pid, 'SIGTERM', (err) => {
         if (err) {
-          console.error('[NextJsService] Failed to kill process tree:', err);
+          logger.error('[NextJsService] Failed to kill process tree:', err);
           treeKill(pid, 'SIGKILL', () => {
             this.cleanup();
             resolve();
           });
         } else {
-          console.log('[NextJsService] Process tree killed successfully');
+          logger.log('[NextJsService] Process tree killed successfully');
           this.cleanup();
           resolve();
         }
@@ -169,7 +170,7 @@ class NextJsService {
 
       setTimeout(() => {
         if (this.process) {
-          console.warn('[NextJsService] Force killing after timeout');
+          logger.warn('[NextJsService] Force killing after timeout');
           treeKill(pid, 'SIGKILL', () => {
             this.cleanup();
             resolve();

--- a/electron/services/NextJsService.js
+++ b/electron/services/NextJsService.js
@@ -88,19 +88,21 @@ class NextJsService {
       });
 
       logger.log(`[NextJsService] Spawning process...`);
-      this.process = spawn(command, args, {
+      const spawnedProcess = spawn(command, args, {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,
         env,
       });
 
-      if (!this.process || !this.process.pid) {
+      this.process = spawnedProcess;
+
+      if (!spawnedProcess || !spawnedProcess.pid) {
         throw new Error('Failed to spawn Next.js process');
       }
-      logger.log(`[NextJsService] Process spawned with PID: ${this.process.pid}`);
+      logger.log(`[NextJsService] Process spawned with PID: ${spawnedProcess.pid}`);
 
-      this.process.stdout.on('data', (data) => {
+      spawnedProcess.stdout.on('data', (data) => {
         const message = data.toString();
         logger.log(`[Next.js] ${message.trim()}`);
         if (this.logStream) {
@@ -108,7 +110,7 @@ class NextJsService {
         }
       });
 
-      this.process.stderr.on('data', (data) => {
+      spawnedProcess.stderr.on('data', (data) => {
         const message = data.toString();
         logger.error(`[Next.js ERROR] ${message.trim()}`);
         if (this.logStream) {
@@ -116,16 +118,20 @@ class NextJsService {
         }
       });
 
-      this.process.on('error', (error) => {
+      spawnedProcess.on('error', (error) => {
         logger.error('[NextJsService] Failed to start:', error);
-        this.status = 'error';
-        this.cleanup();
+        if (this.process === spawnedProcess) {
+          this.status = 'error';
+          this.cleanup();
+        }
       });
 
-      this.process.on('close', (code) => {
+      spawnedProcess.on('close', (code) => {
         logger.log(`[NextJsService] Process exited with code ${code}`);
-        this.status = 'stopped';
-        this.cleanup();
+        if (this.process === spawnedProcess) {
+          this.status = 'stopped';
+          this.cleanup();
+        }
       });
 
       logger.log('[NextJsService] Waiting for Next.js to be healthy...');
@@ -181,6 +187,9 @@ class NextJsService {
   }
 
   cleanup() {
+    if (this.process) {
+      this.process.removeAllListeners();
+    }
     this.process = null;
     this.status = 'stopped';
     if (this.logStream) {

--- a/electron/services/PhoenixdService.js
+++ b/electron/services/PhoenixdService.js
@@ -125,6 +125,7 @@ class PhoenixdService {
     const { exec } = require('child_process');
     const targetPort = port || this.port;
     if (!targetPort) return;
+    if (!Number.isInteger(targetPort)) return;
     return new Promise((resolve) => {
       const command = process.platform === 'win32'
         ? `for /f "tokens=5" %a in ('netstat -aon ^| findstr LISTENING ^| findstr :${targetPort}') do taskkill /F /PID %a`

--- a/electron/services/PhoenixdService.js
+++ b/electron/services/PhoenixdService.js
@@ -5,6 +5,7 @@ const spawn = require('cross-spawn');
 const treeKill = require('tree-kill');
 
 const { checkPhoenixd } = require('../utils/healthCheck');
+const logger = require('../utils/logger');
 const { getPhoenixdPath, getPhoenixDataDirectory, getLogsDirectory } = require('../utils/resourcePaths');
 
 class PhoenixdService {
@@ -42,7 +43,7 @@ class PhoenixdService {
         `--http-bind-port=${port}`,
       ];
 
-      console.log(`[PhoenixdService] Starting phoenixd at port ${port}...`);
+      logger.log(`[PhoenixdService] Starting phoenixd at port ${port}...`);
 
       // Set JAVA_HOME for phoenixd when using JVM version
       // Windows ARM64 uses JVM version and needs x64 JRE
@@ -55,14 +56,14 @@ class PhoenixdService {
         const { getBasePath } = require('../utils/resourcePaths');
         const javaPath = path.join(getBasePath(), 'jre', 'win-x64', 'bin', 'java.exe');
         env.JAVA_HOME = path.dirname(path.dirname(javaPath));
-        console.log(`[PhoenixdService] Using x64 JRE for phoenixd JVM version (Windows ARM64)`);
-        console.log(`[PhoenixdService] JAVA_HOME: ${env.JAVA_HOME}`);
+        logger.log(`[PhoenixdService] Using x64 JRE for phoenixd JVM version (Windows ARM64)`);
+        logger.log(`[PhoenixdService] JAVA_HOME: ${env.JAVA_HOME}`);
       } else if (process.platform === 'linux' && process.arch === 'arm64') {
         // Linux ARM64: phoenixd has native ARM64 binary, no JRE needed
-        console.log(`[PhoenixdService] Using native ARM64 phoenixd binary (Linux ARM64)`);
+        logger.log(`[PhoenixdService] Using native ARM64 phoenixd binary (Linux ARM64)`);
       } else {
         // Other platforms: native binaries (macOS ARM64/x64, Linux x64, Windows x64)
-        console.log(`[PhoenixdService] Using native phoenixd binary for ${process.platform}-${process.arch}`);
+        logger.log(`[PhoenixdService] Using native phoenixd binary for ${process.platform}-${process.arch}`);
       }
 
       const spawnedProcess = spawn(phoenixdPath, args, {
@@ -75,7 +76,7 @@ class PhoenixdService {
 
       spawnedProcess.stdout.on('data', (data) => {
         const message = data.toString();
-        console.log(`[Phoenixd] ${message.trim()}`);
+        logger.log(`[Phoenixd] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ${message}`);
         }
@@ -83,20 +84,20 @@ class PhoenixdService {
 
       spawnedProcess.stderr.on('data', (data) => {
         const message = data.toString();
-        console.error(`[Phoenixd ERROR] ${message.trim()}`);
+        logger.error(`[Phoenixd ERROR] ${message.trim()}`);
         if (this.logStream) {
           this.logStream.write(`[${new Date().toISOString()}] ERROR: ${message}`);
         }
       });
 
       spawnedProcess.on('error', (error) => {
-        console.error('[PhoenixdService] Failed to start:', error);
+        logger.error('[PhoenixdService] Failed to start:', error);
         this.status = 'error';
         if (this.process === spawnedProcess) this.cleanup();
       });
 
       spawnedProcess.on('close', (code) => {
-        console.log(`[PhoenixdService] Process exited with code ${code}`);
+        logger.log(`[PhoenixdService] Process exited with code ${code}`);
         // Only cleanup if this process is still the active one.
         // Avoids overwriting this.process after a restart has already set a new process.
         if (this.process === spawnedProcess) {
@@ -105,15 +106,15 @@ class PhoenixdService {
         }
       });
 
-      console.log('[PhoenixdService] Waiting for phoenixd to be healthy...');
+      logger.log('[PhoenixdService] Waiting for phoenixd to be healthy...');
       await checkPhoenixd(port);
 
       this.status = 'running';
-      console.log('[PhoenixdService] Phoenixd is running and healthy');
+      logger.log('[PhoenixdService] Phoenixd is running and healthy');
 
       return { port };
     } catch (error) {
-      console.error('[PhoenixdService] Startup failed:', error);
+      logger.error('[PhoenixdService] Startup failed:', error);
       this.status = 'error';
       await this.stop();
       throw error;
@@ -135,16 +136,16 @@ class PhoenixdService {
   async stop() {
     if (!this.process) {
       if (this.port) {
-        console.log(`[PhoenixdService] No owned process — attempting to kill any process on port ${this.port}`);
+        logger.log(`[PhoenixdService] No owned process — attempting to kill any process on port ${this.port}`);
         await this.killByPort(this.port);
         await new Promise((resolve) => { setTimeout(resolve, 500); });
       } else {
-        console.log('[PhoenixdService] No process to stop');
+        logger.log('[PhoenixdService] No process to stop');
       }
       return;
     }
 
-    console.log('[PhoenixdService] Stopping phoenixd...');
+    logger.log('[PhoenixdService] Stopping phoenixd...');
 
     return new Promise((resolve) => {
       const pid = this.process.pid;
@@ -152,7 +153,7 @@ class PhoenixdService {
 
       const onExit = () => {
         clearTimeout(forceKillTimer);
-        console.log('[PhoenixdService] Process exited cleanly');
+        logger.log('[PhoenixdService] Process exited cleanly');
         this.cleanup();
         resolve();
       };
@@ -161,7 +162,7 @@ class PhoenixdService {
 
       const forceKillTimer = setTimeout(() => {
         processToKill.removeListener('exit', onExit);
-        console.warn('[PhoenixdService] Force killing after timeout');
+        logger.warn('[PhoenixdService] Force killing after timeout');
         treeKill(pid, 'SIGKILL', () => {
           this.cleanup();
           resolve();
@@ -170,7 +171,7 @@ class PhoenixdService {
 
       treeKill(pid, 'SIGTERM', (err) => {
         if (err) {
-          console.error('[PhoenixdService] Failed to send SIGTERM:', err);
+          logger.error('[PhoenixdService] Failed to send SIGTERM:', err);
           clearTimeout(forceKillTimer);
           processToKill.removeListener('exit', onExit);
           treeKill(pid, 'SIGKILL', () => {

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -125,7 +125,8 @@ class ServiceManager extends EventEmitter {
     this._healthMonitor = setInterval(() => {
       const statuses = this.getServiceStatuses();
       for (const [service, status] of Object.entries(statuses)) {
-        if (status === 'error' || (status === 'stopped' && !this.externalServices[service])) {
+        if (this.externalServices[service]) continue;
+        if (status === 'error' || status === 'stopped') {
           logger.warn(`[ServiceManager] Health monitor: ${service} is ${status}, emitting event`);
           this.emit('service:error', { service, error: new Error(`${service} is ${status}`) });
         }

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -1,6 +1,7 @@
 const { EventEmitter } = require('events');
 
 const { isPhoenixdRunning, isBackendRunning } = require('../utils/healthCheck');
+const logger = require('../utils/logger');
 const { allocatePorts, DEFAULT_PORTS } = require('../utils/portAllocator');
 const { isDevelopment } = require('../utils/resourcePaths');
 
@@ -37,58 +38,58 @@ class ServiceManager extends EventEmitter {
 
   async _startAll() {
     try {
-      console.log('[ServiceManager] Starting all services...');
+      logger.log('[ServiceManager] Starting all services...');
 
       this.ports = await allocatePorts();
-      console.log('[ServiceManager] Allocated ports:', this.ports);
+      logger.log('[ServiceManager] Allocated ports:', this.ports);
 
-      console.log('[ServiceManager] Ensuring configurations...');
+      logger.log('[ServiceManager] Ensuring configurations...');
       this.configs = await ensureConfigurations(this.ports);
 
       const phoenixConfig = this.configs.phoenix;
 
       if (this.devMode) {
-        console.log('[ServiceManager] Development mode: skipping phoenixd and backend startup');
-        console.log('[ServiceManager] Assuming external services at:');
-        console.log('  - phoenixd: http://localhost:9740');
-        console.log('  - backend: http://localhost:9154');
+        logger.log('[ServiceManager] Development mode: skipping phoenixd and backend startup');
+        logger.log('[ServiceManager] Assuming external services at:');
+        logger.log('  - phoenixd: http://localhost:9740');
+        logger.log('  - backend: http://localhost:9154');
 
-        console.log('[ServiceManager] Starting Next.js service...');
+        logger.log('[ServiceManager] Starting Next.js service...');
         const result = await this.nextjsService.start(this.ports.nextjs, {
           host: 'localhost',
           port: this.ports.backend,
         });
         this.emit('service:started', { service: 'nextjs', port: this.ports.nextjs });
-        console.log('[ServiceManager] All services started successfully');
+        logger.log('[ServiceManager] All services started successfully');
         return result.url;
       }
 
-      console.log('[ServiceManager] Production mode: starting all bundled services');
+      logger.log('[ServiceManager] Production mode: starting all bundled services');
 
       // Step 1: Check if phoenixd is already running on default port
-      console.log('[ServiceManager] Step 1: Checking for existing Phoenixd...');
+      logger.log('[ServiceManager] Step 1: Checking for existing Phoenixd...');
       const phoenixdAlreadyRunning = await isPhoenixdRunning(DEFAULT_PORTS.phoenixd);
 
       if (phoenixdAlreadyRunning) {
-        console.log(`[ServiceManager] Phoenixd already running on port ${DEFAULT_PORTS.phoenixd}, reusing...`);
+        logger.log(`[ServiceManager] Phoenixd already running on port ${DEFAULT_PORTS.phoenixd}, reusing...`);
         this.ports.phoenixd = DEFAULT_PORTS.phoenixd;
         this.externalServices.phoenixd = true;
       } else {
-        console.log('[ServiceManager] Starting Phoenixd...');
+        logger.log('[ServiceManager] Starting Phoenixd...');
         await this.phoenixdService.start(this.ports.phoenixd, phoenixConfig);
       }
       this.emit('service:started', { service: 'phoenixd', port: this.ports.phoenixd });
 
       // Step 2: Check if backend is already running on default port
-      console.log('[ServiceManager] Step 2: Checking for existing Backend...');
+      logger.log('[ServiceManager] Step 2: Checking for existing Backend...');
       const backendAlreadyRunning = await isBackendRunning(DEFAULT_PORTS.backend);
 
       if (backendAlreadyRunning) {
-        console.log(`[ServiceManager] Backend already running on port ${DEFAULT_PORTS.backend}, reusing...`);
+        logger.log(`[ServiceManager] Backend already running on port ${DEFAULT_PORTS.backend}, reusing...`);
         this.ports.backend = DEFAULT_PORTS.backend;
         this.externalServices.backend = true;
       } else {
-        console.log('[ServiceManager] Starting Backend...');
+        logger.log('[ServiceManager] Starting Backend...');
         await this.backendService.start(this.ports.backend, {
           phoenixdPort: this.ports.phoenixd,
           phoenixPassword: phoenixConfig['http-password'],
@@ -98,20 +99,20 @@ class ServiceManager extends EventEmitter {
       this.emit('service:started', { service: 'backend', port: this.ports.backend });
 
       // Step 3: Start Next.js (always start our own)
-      console.log('[ServiceManager] Step 3: Starting Next.js...');
+      logger.log('[ServiceManager] Step 3: Starting Next.js...');
       const result = await this.nextjsService.start(this.ports.nextjs, {
         host: '127.0.0.1',
         port: this.ports.backend,
       });
       this.emit('service:started', { service: 'nextjs', port: this.ports.nextjs });
 
-      console.log('[ServiceManager] All services started successfully');
+      logger.log('[ServiceManager] All services started successfully');
       this.startHealthMonitor();
       this.emit('all:started');
 
       return result.url;
     } catch (error) {
-      console.error('[ServiceManager] Failed to start services:', error);
+      logger.error('[ServiceManager] Failed to start services:', error);
       this.emit('service:error', { error });
       await this.stopAll();
       throw error;
@@ -125,7 +126,7 @@ class ServiceManager extends EventEmitter {
       const statuses = this.getServiceStatuses();
       for (const [service, status] of Object.entries(statuses)) {
         if (status === 'error' || (status === 'stopped' && !this.externalServices[service])) {
-          console.warn(`[ServiceManager] Health monitor: ${service} is ${status}, emitting event`);
+          logger.warn(`[ServiceManager] Health monitor: ${service} is ${status}, emitting event`);
           this.emit('service:error', { service, error: new Error(`${service} is ${status}`) });
         }
       }
@@ -141,42 +142,42 @@ class ServiceManager extends EventEmitter {
 
   async stopAll() {
     this.stopHealthMonitor();
-    console.log('[ServiceManager] Stopping all services...');
+    logger.log('[ServiceManager] Stopping all services...');
 
     try {
-      console.log('[ServiceManager] Stopping Next.js...');
+      logger.log('[ServiceManager] Stopping Next.js...');
       await this.nextjsService.stop();
     } catch (error) {
-      console.error('[ServiceManager] Error stopping Next.js:', error);
+      logger.error('[ServiceManager] Error stopping Next.js:', error);
     }
 
     if (!this.devMode) {
       // Only stop backend if we started it (not external)
       if (!this.externalServices.backend) {
         try {
-          console.log('[ServiceManager] Stopping Backend...');
+          logger.log('[ServiceManager] Stopping Backend...');
           await this.backendService.stop();
         } catch (error) {
-          console.error('[ServiceManager] Error stopping Backend:', error);
+          logger.error('[ServiceManager] Error stopping Backend:', error);
         }
       } else {
-        console.log('[ServiceManager] Backend is external, not stopping');
+        logger.log('[ServiceManager] Backend is external, not stopping');
       }
 
       // Only stop phoenixd if we started it (not external)
       if (!this.externalServices.phoenixd) {
         try {
-          console.log('[ServiceManager] Stopping Phoenixd...');
+          logger.log('[ServiceManager] Stopping Phoenixd...');
           await this.phoenixdService.stop();
         } catch (error) {
-          console.error('[ServiceManager] Error stopping Phoenixd:', error);
+          logger.error('[ServiceManager] Error stopping Phoenixd:', error);
         }
       } else {
-        console.log('[ServiceManager] Phoenixd is external, not stopping');
+        logger.log('[ServiceManager] Phoenixd is external, not stopping');
       }
     }
 
-    console.log('[ServiceManager] All services stopped');
+    logger.log('[ServiceManager] All services stopped');
     this.emit('all:stopped');
   }
 
@@ -198,11 +199,11 @@ class ServiceManager extends EventEmitter {
 
   async restartService(serviceName) {
     if (this.externalServices[serviceName]) {
-      console.log(`[ServiceManager] Skipping restart of external service: ${serviceName}`);
+      logger.log(`[ServiceManager] Skipping restart of external service: ${serviceName}`);
       return;
     }
 
-    console.log(`[ServiceManager] Restarting ${serviceName}...`);
+    logger.log(`[ServiceManager] Restarting ${serviceName}...`);
 
     try {
       switch (serviceName) {
@@ -229,10 +230,10 @@ class ServiceManager extends EventEmitter {
         default:
           throw new Error(`Unknown service: ${serviceName}`);
       }
-      console.log(`[ServiceManager] ${serviceName} restarted successfully`);
+      logger.log(`[ServiceManager] ${serviceName} restarted successfully`);
       this.emit('service:restarted', { service: serviceName });
     } catch (error) {
-      console.error(`[ServiceManager] Failed to restart ${serviceName}:`, error);
+      logger.error(`[ServiceManager] Failed to restart ${serviceName}:`, error);
       this.emit('service:error', { service: serviceName, error });
       throw error;
     }

--- a/electron/utils/healthCheck.js
+++ b/electron/utils/healthCheck.js
@@ -2,6 +2,8 @@ const http = require('http');
 
 const waitOn = require('wait-on');
 
+const logger = require('./logger');
+
 async function waitForHealth(url, options = {}) {
   const {
     timeout = 60000,
@@ -23,18 +25,18 @@ async function waitForHealth(url, options = {}) {
   };
 
   try {
-    console.log(`[HealthCheck] Waiting for ${url} to be healthy...`);
+    logger.log(`[HealthCheck] Waiting for ${url} to be healthy...`);
     await waitOn(waitOptions);
-    console.log(`[HealthCheck] ${url} is healthy`);
+    logger.log(`[HealthCheck] ${url} is healthy`);
     return true;
   } catch (error) {
-    console.error(`[HealthCheck] ${url} failed health check:`, error.message);
+    logger.error(`[HealthCheck] ${url} failed health check:`, error.message);
     throw error;
   }
 }
 
 async function checkService({ url, name, isHealthy, maxAttempts = 60, intervalMs = 1000 }) {
-  console.log(`[HealthCheck] Checking ${name} at ${url}...`);
+  logger.log(`[HealthCheck] Checking ${name} at ${url}...`);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -42,7 +44,7 @@ async function checkService({ url, name, isHealthy, maxAttempts = 60, intervalMs
         const req = http.get(url, (res) => {
           res.resume();
           if (isHealthy(res.statusCode)) {
-            console.log(`[HealthCheck] ${name} is healthy (status: ${res.statusCode})`);
+            logger.log(`[HealthCheck] ${name} is healthy (status: ${res.statusCode})`);
             resolve();
           } else {
             reject(new Error(`Unexpected status code: ${res.statusCode}`));
@@ -59,11 +61,11 @@ async function checkService({ url, name, isHealthy, maxAttempts = 60, intervalMs
       return true;
     } catch (error) {
       if (attempt === maxAttempts) {
-        console.error(`[HealthCheck] ${name} health check failed after ${maxAttempts} attempts:`, error.message);
+        logger.error(`[HealthCheck] ${name} health check failed after ${maxAttempts} attempts:`, error.message);
         throw new Error(`Timed out waiting for: ${url}`);
       }
       if (attempt % 10 === 0) {
-        console.log(`[HealthCheck] Still waiting for ${name}... (attempt ${attempt}/${maxAttempts})`);
+        logger.log(`[HealthCheck] Still waiting for ${name}... (attempt ${attempt}/${maxAttempts})`);
       }
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }

--- a/electron/utils/portAllocator.js
+++ b/electron/utils/portAllocator.js
@@ -1,5 +1,6 @@
 const findFreePort = require('find-free-port');
 
+const logger = require('./logger');
 const { isDevelopment } = require('./resourcePaths');
 
 const DEFAULT_PORTS = {
@@ -10,7 +11,7 @@ const DEFAULT_PORTS = {
 
 async function allocatePorts() {
   if (isDevelopment()) {
-    console.log('[PortAllocator] Development mode: using default ports');
+    logger.log('[PortAllocator] Development mode: using default ports');
     return {
       phoenixd: DEFAULT_PORTS.phoenixd,
       backend: DEFAULT_PORTS.backend,
@@ -18,7 +19,7 @@ async function allocatePorts() {
     };
   }
 
-  console.log('[PortAllocator] Production mode: allocating dynamic ports');
+  logger.log('[PortAllocator] Production mode: allocating dynamic ports');
 
   try {
     const [phoenixdPort] = await findFreePort(9740, 9800);
@@ -31,11 +32,10 @@ async function allocatePorts() {
       nextjs: nextjsPort,
     };
 
-    console.log('[PortAllocator] Allocated ports:', ports);
+    logger.log('[PortAllocator] Allocated ports:', ports);
     return ports;
   } catch (error) {
-    console.error('[PortAllocator] Failed to allocate ports:', error);
-    console.log('[PortAllocator] Falling back to default ports');
+    logger.warn('[PortAllocator] Dynamic allocation failed, using defaults:', error.message);
     return {
       phoenixd: DEFAULT_PORTS.phoenixd,
       backend: DEFAULT_PORTS.backend,


### PR DESCRIPTION
## Changes:
  - Remove bip39 dependency and replace secret generation with crypto.randomBytes(32) in ConfigurationBootstrap
  - Add conditional debug logger (utils/logger.js) and connect it to main.js, all services, healthCheck.js, portAllocator.js, and preload.js — logs are silenced in production unless DEBUG=true
  - Add process.exit(0) to download-jre.js, download-phoenixd.js, and download-node.js to prevent build hang caused by open HTTP connections keeping the Node.js event loop alive
  - Fix Next.js 16 standalone nested directory structure in build-client.js to resolve missing server.js during production build
  - Fix process reference check in BackendService and NextJsService — capture spawnedProcess before attaching event handlers to prevent stale handlers from corrupting active process state during restarts
  - Add removeAllListeners() in NextJsService.cleanup() to prevent listener accumulation across service restarts
  - Add redirect limit (MAX_REDIRECTS = 5) to download-node.js to prevent infinite redirect loops
  - Skip external services in ServiceManager health monitor to avoid emitting false service:error events for services not owned by the app
  - Add port number validation in PhoenixdService.killByPort() before constructing shell command
  - Log dynamic port allocation error before falling back to default ports in portAllocator.js