### PR TITLE
Feature/dynamic renderer

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,7 +1,16 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Creates optimized bundle with minified deps for Electron
   output: "standalone",
+
+  // Pin file tracing root to client/ to prevent Turbopack from going up to
+  // the monorepo root and breaking PostCSS/Tailwind module resolution
+  outputFileTracingRoot: __dirname,
 
   // Image configuration for Electron
   images: {

--- a/client/src/components/DynamicModuleRenderer.jsx
+++ b/client/src/components/DynamicModuleRenderer.jsx
@@ -1,5 +1,22 @@
 "use client";
 
+/**
+ * DynamicModuleRenderer — lazy-loads feature components by path at runtime.
+ *
+ * Supported componentBase values and their resolution conventions:
+ *
+ * "modules" (legacy feature modules)
+ *   - Resolves: src/modules/{componentPath}/{componentFile}
+ *   - Export:   default export or named export matching componentFile
+ *   - Example:  componentBase="modules" componentPath="auth" componentFile="AuthProvider"
+ *
+ * "components/pages" (page-level components)
+ *   - Resolves: src/components/pages/{componentPath}/{componentFile}/index  (preferred)
+ *              src/components/pages/{componentPath}/{componentFile}         (fallback)
+ *   - Export:   default, named matching componentFile, or named matching {componentFile}Page
+ *   - Example:  componentBase="components/pages" componentPath="Store" componentFile="Store"
+ */
+
 import React from "react";
 
 import dynamic from "next/dynamic";

--- a/client/src/components/DynamicModuleRenderer.jsx
+++ b/client/src/components/DynamicModuleRenderer.jsx
@@ -24,45 +24,23 @@ export default function DynamicModuleRenderer({
         return Comp;
       }),
       "components/pages": async () => {
+        let mod;
         try {
-          const mod = await import(
+          mod = await import(
+            `./pages/${componentPath}/${componentFile}/index`
+          );
+        } catch {
+          mod = await import(
             `./pages/${componentPath}/${componentFile}`
           );
-          const Comp =
-            mod.default || mod[componentFile] || mod[`${componentFile}Page`];
-          if (Comp) return Comp;
-        } catch (error) {
-          console.error(error);
         }
-
-        try {
-          const modNested = await import(
-            `./pages/${componentPath}/${componentFile}/${componentFile}Page`
+        const Comp =
+          mod.default || mod[componentFile] || mod[`${componentFile}Page`];
+        if (!Comp)
+          throw new Error(
+            `DynamicModuleRenderer: component export not found for "${componentBase}/${componentPath}/${componentFile}"`,
           );
-          const CompNested =
-            modNested.default ||
-            modNested[`${componentFile}Page`] ||
-            modNested[componentFile];
-          if (CompNested) return CompNested;
-        } catch (error) {
-          console.error(error);
-          try {
-            const modIndex = await import(
-              `./pages/${componentPath}/${componentFile}/index`
-            );
-            const CompIndex =
-              modIndex.default ||
-              modIndex[`${componentFile}Page`] ||
-              modIndex[componentFile];
-            if (CompIndex) return CompIndex;
-          } catch (error) {
-            console.error(error);
-          }
-        }
-
-        throw new Error(
-          `DynamicModuleRenderer: could not resolve component at "${componentBase}/${componentPath}/${componentFile}". Tried flat, nested <Name>Page, and index patterns.`,
-        );
+        return Comp;
       },
     };
 


### PR DESCRIPTION
## Changes:
  - Simplify DynamicModuleRenderer dynamic imports from 3 to 2 paths (try `/index`, fallback to flat file), remove console.error from catch blocks
  - Fix Turbopack resolving PostCSS/Tailwind modules from monorepo root instead of `client/` by setting `outputFileTracingRoot` in `next.config.mjs`
  - Add JSDoc to `DynamicModuleRenderer` documenting supported `componentBase` values, resolution order, and export conventions