### PR TITLE
Feature/pin login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 CLAUDE.md
 GEMINI.md
 Claude.md
+.claude
+*PLAN.md

--- a/client/src/components/pages/Auth/PinLogin/BusinessHeader.jsx
+++ b/client/src/components/pages/Auth/PinLogin/BusinessHeader.jsx
@@ -5,17 +5,17 @@ export function BusinessHeader({ businessName, businessLogoUrl }) {
   const t = useTranslations("pinLogin");
 
   return (
-    <div className="flex flex-col items-center justify-center">
-      <div className="mx-auto w-16 h-16 bg-mint rounded-full flex items-center justify-center shadow-lg">
+    <div className="flex flex-col items-center gap-3">
+      <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center">
         <Image
-          className="w-8 h-8 text-forest"
+          className="w-10 h-10 object-contain"
           src={businessLogoUrl || null}
           alt={businessName || ""}
         />
       </div>
-      <div className="flex flex-col items-center justify-center">
-        <h1 className="text-2xl font-bold text-deep">{businessName}</h1>
-        <p className="text-forest mt-2 text-base text-center">{t("title")}</p>
+      <div className="flex flex-col items-center gap-1">
+        <h1 className="text-2xl font-bold text-foreground">{businessName}</h1>
+        <p className="text-default-500 text-sm text-center">{t("title")}</p>
       </div>
     </div>
   );

--- a/client/src/components/pages/Auth/PinLogin/EmployeeSelect.jsx
+++ b/client/src/components/pages/Auth/PinLogin/EmployeeSelect.jsx
@@ -1,93 +1,56 @@
 import { Avatar, Select, SelectItem } from "@heroui/react";
-import { Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 export function EmployeeSelect({ employees, selectedUser, onSelect }) {
   const t = useTranslations("pinLogin");
 
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-semibold text-deep flex items-center">
-        <Users className="w-4 h-4 mr-2" />
-        {t("selectLabel")}
-      </label>
-      <Select
-        value={selectedUser}
-        onChange={(e) => onSelect(e.target.value)}
-        placeholder={t("selectPlaceholder")}
-        variant="bordered"
-        size="lg"
-        aria-label={t("selectLabel")}
-        classNames={{
-          trigger:
-            "h-12 border-2 border-mint/30 hover:border-forest data-[focus=true]:border-forest",
-          label: "text-forest/70 text-base",
-          value: "text-lg text-deep",
-          listboxWrapper: "max-h-80",
-          popoverContent: "bg-white/95 backdrop-blur-md",
-        }}
-        listboxProps={{
-          itemClasses: {
-            base: [
-              "rounded-md",
-              "text-default-500",
-              "transition-opacity",
-              "data-[hover=true]:text-foreground",
-              "data-[hover=true]:bg-default-100",
-              "data-[selectable=true]:focus:bg-default-50",
-              "data-[pressed=true]:opacity-70",
-              "data-[focus-visible=true]:ring-default-500",
-            ],
-          },
-        }}
-        renderValue={(items) => items.map((item) => {
-          const employee = employees.find((emp) => emp.id === item.key);
-          if (!employee) return null;
+    <Select
+      label={t("selectLabel")}
+      value={selectedUser}
+      onChange={(e) => onSelect(e.target.value)}
+      placeholder={t("selectPlaceholder")}
+      aria-label={t("selectLabel")}
+      renderValue={(items) => items.map((item) => {
+        const employee = employees.find((emp) => emp.id === item.key);
+        if (!employee) return null;
 
-          return (
-            <div key={item.key} className="flex items-center gap-3">
+        return (
+          <div key={item.key} className="flex items-center gap-2">
+            <Avatar color="primary" size="sm" name={employee.avatar} className="w-6 h-6 text-tiny shrink-0" />
+            <span className="text-foreground font-semibold">{employee.name}</span>
+            <span className="text-default-500 text-sm">{employee.role}</span>
+          </div>
+        );
+      })
+        }
+    >
+      {employees.length > 0 ? (
+        employees.map((employee) => (
+          <SelectItem
+            key={employee.id}
+            value={employee.id}
+            textValue={employee.name}
+            className="py-2"
+          >
+            <div className="flex items-center gap-4">
               <Avatar
-                className="shrink-0 bg-mint text-forest font-bold"
-                size="sm"
+                color="primary"
+                size="md"
                 name={employee.avatar}
               />
               <div className="flex flex-col">
-                <span className="text-deep font-semibold">{employee.name}</span>
-                <span className="text-forest text-sm">{employee.role}</span>
+                <span className="font-semibold text-foreground">{employee.name}</span>
+                <span className="text-default-500 text-sm">{employee.role}</span>
               </div>
             </div>
-          );
-        })
-        }
-      >
-        {employees.length > 0 ? (
-          employees.map((employee) => (
-            <SelectItem
-              key={employee.id}
-              value={employee.id}
-              textValue={employee.name}
-              className="py-2"
-            >
-              <div className="flex items-center gap-4">
-                <Avatar
-                  className="shrink-0 bg-mint text-forest font-bold shadow-sm"
-                  size="md"
-                  name={employee.avatar}
-                  fallback={employee.avatar}
-                />
-                <div className="flex flex-col">
-                  <span className="font-semibold text-deep text-lg">{employee.name}</span>
-                  <span className="text-forest text-sm">{employee.role}</span>
-                </div>
-              </div>
-            </SelectItem>
-          ))
-        ) : (
-          <SelectItem key="no-employee" isDisabled textValue={t("noEmployees")}>
-            {t("noEmployees")}
           </SelectItem>
-        )}
-      </Select>
-    </div>
+        ))
+      ) : (
+        <SelectItem key="no-employee" textValue={t("noEmployees")}>
+          {t("noEmployees")}
+        </SelectItem>
+      )}
+    </Select>
   );
 }

--- a/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
@@ -102,7 +102,7 @@ export default function PinLogin() {
 
   return (
     <div className="min-h-screen gradient-fresh flex items-center justify-center p-4">
-      <Card className="w-full max-w-md shadow-2xl border-0 bg-white mx-auto my-auto">
+      <Card className="w-full max-w-md rounded-lg shadow-lg mx-auto my-auto">
         <CardHeader className="text-center space-y-3 pb-4 flex flex-col items-center justify-center">
           <BusinessHeader
             businessName={config?.businessName}

--- a/client/src/components/pages/Auth/PinLogin/PinPad.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinPad.jsx
@@ -33,39 +33,27 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
 
   return (
     <>
-      <div className="space-y-2">
-        <label className="text-sm font-semibold text-deep">
-          {t("pinLabel")}
-        </label>
-        <Input
-          type="password"
-          variant="bordered"
-          value={pin}
-          readOnly
-          size="lg"
-          placeholder="----"
-          maxLength={4}
-        />
-        {error && (
-          <div className="text-red-600 text-base text-center font-semibold bg-red-50 p-3 rounded-lg border border-red-200">
-            {error}
-          </div>
-        )}
-      </div>
+      <Input
+        label={t("pinLabel")}
+        type="password"
+        value={pin}
+        readOnly
+        placeholder="----"
+        maxLength={4}
+        isInvalid={!!error}
+        errorMessage={error}
+      />
 
       <div className="grid grid-cols-3 gap-4">
         {NUMBER_PAD.flat().map((number, index) => (
           <Button
             key={index}
-            variant={number ? "bordered" : "ghost"}
-            size="md"
-            className={`h-14 text-xl font-bold transition-all duration-200 ${
-              number
-                ? "border-2 border-mint bg-cream/50 hover:bg-mint hover:text-deep hover:border-forest active:scale-95 shadow-md"
-                : "invisible"
-            }`}
+            color="default"
+            variant={number ? "bordered" : "light"}
+            size="lg"
+            className={`h-14 text-xl font-bold bg-white border border-primary-400 shadow-sm hover:shadow-md active:scale-95 transition-all ${!number && "invisible"}`}
             onPress={() => number && onNumberClick(number)}
-            disabled={isLoading || !number}
+            isDisabled={isLoading || !number}
           >
             {number}
           </Button>
@@ -77,41 +65,34 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
           variant="bordered"
           size="md"
           onPress={onDelete}
-          disabled={isLoading || pin.length === 0}
-          className="h-12 text-base font-semibold border-2 border-lime bg-lime/20 hover:bg-lime hover:text-deep active:scale-95"
+          isDisabled={isLoading || pin.length === 0}
+          startContent={<Delete className="w-4 h-4" />}
+          className="border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          <Delete className="w-4 h-4 mr-2" />
           {t("eraseButton")}
         </Button>
         <Button
           variant="bordered"
           size="md"
           onPress={onClear}
-          disabled={isLoading || pin.length === 0}
-          className="h-12 text-base font-semibold border-2 border-lime bg-lime/20 hover:bg-lime hover:text-deep active:scale-95"
+          isDisabled={isLoading || pin.length === 0}
+          startContent={<Trash2 className="w-4 h-4" />}
+          className="border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          <Trash2 className="w-4 h-4 mr-2" />
           {t("clearButton")}
         </Button>
       </div>
 
       <Button
+        color="primary"
+        size="lg"
+        className="w-full"
         onPress={onLogin}
-        disabled={isLoading || pin.length === 0}
-        size="md"
-        className="w-full h-14 text-lg font-bold gradient-forest text-white shadow-lg active:scale-95 transition-all duration-200 border-0"
+        isDisabled={pin.length === 0}
+        isLoading={isLoading}
+        startContent={!isLoading && <LogIn className="w-5 h-5" />}
       >
-        {isLoading ? (
-          <div className="flex items-center">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white mr-3" />
-            {t("loading")}
-          </div>
-        ) : (
-          <>
-            <LogIn className="w-5 h-5 mr-2" />
-            {t("loginButton")}
-          </>
-        )}
+        {isLoading ? t("loading") : t("loginButton")}
       </Button>
     </>
   );

--- a/client/src/components/pages/Auth/PinLogin/__tests__/EmployeeSelect.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/EmployeeSelect.test.jsx
@@ -23,7 +23,7 @@ const renderSelect = (props = {}) => render(
 describe("EmployeeSelect", () => {
   it("renders the select label", () => {
     renderSelect();
-    expect(screen.getByText("selectLabel")).toBeInTheDocument();
+    expect(screen.getAllByText("selectLabel")[0]).toBeInTheDocument();
   });
 
   it("renders all employee options", () => {

--- a/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
@@ -44,7 +44,7 @@ describe("PinLogin", () => {
   it("renders all sections: header, employee select and pin pad", async () => {
     await renderPinLogin();
     expect(screen.getByText("Test Store")).toBeInTheDocument();
-    expect(screen.getByText("selectLabel")).toBeInTheDocument();
+    expect(screen.getAllByText("selectLabel")[0]).toBeInTheDocument();
     expect(screen.getByPlaceholderText("----")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Changes:
  - Aligned `PinLogin` styles with the Store design system: HeroUI semantic tokens (`color="primary"`, `color="default"`), `variant="bordered"` secondary buttons, plain `Select` and `Input` without custom classNames, `rounded-lg shadow-lg` card
  - Replaced hardcoded color classes (`bg-mint`, `text-deep`, `gradient-forest`, `border-lime`) with HeroUI tokens (`text-foreground`, `text-default-500`, `bg-primary-100`, `text-danger`)
  - Number pad buttons: white background, green-tinted border, subtle shadow with hover elevation
  - Updated tests to handle HeroUI `Select` rendering label in multiple DOM nodes

<img width="485" height="759" alt="Screenshot 2026-03-19 at 4 01 19 p m" src="https://github.com/user-attachments/assets/2fd8a822-4364-4fda-ac3d-162617f024d3" />
