### PR TITLE
Feature/pin login attempts

### DIFF
--- a/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
@@ -23,6 +23,12 @@ export default function PinLogin() {
   const [selectedUser, setSelectedUser] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const [lockedUntil, setLockedUntil] = useState(() => {
+    const stored = localStorage.getItem("pinLockoutUntil");
+    if (!stored) return null;
+    const ts = parseInt(stored, 10);
+    return ts > Date.now() ? ts : null;
+  });
   const [employees, setEmployees] = useState([]);
   const router = useRouter();
   const { login, isAuth, isLoading: isAuthLoading } = useAuth();
@@ -67,6 +73,8 @@ export default function PinLogin() {
   };
 
   const handleLogin = async () => {
+    if (lockedUntil && Date.now() < lockedUntil) return;
+
     if (!selectedUser) {
       setError(t("errorMessages.selectEmployee"));
       return;
@@ -91,9 +99,18 @@ export default function PinLogin() {
       });
       setPin("");
       setSelectedUser("");
+      setLockedUntil(null);
+      localStorage.removeItem("pinLockoutUntil");
       router.push("/");
-    } catch {
-      setError(t("errorMessages.incorrectPin"));
+    } catch (err) {
+      if (err?.status === 429) {
+        const ts = Date.now() + (err.retryAfter ?? 180) * 1000;
+        setLockedUntil(ts);
+        localStorage.setItem("pinLockoutUntil", ts.toString());
+        setError("");
+      } else {
+        setError(t("errorMessages.incorrectPin"));
+      }
       setPin("");
     } finally {
       setIsLoading(false);
@@ -120,10 +137,15 @@ export default function PinLogin() {
             pin={pin}
             error={error}
             isLoading={isLoading}
+            lockedUntil={lockedUntil}
             onNumberClick={handleNumberClick}
             onDelete={handleDelete}
             onClear={handleClear}
             onLogin={handleLogin}
+            onLockoutExpired={() => {
+              setLockedUntil(null);
+              localStorage.removeItem("pinLockoutUntil");
+            }}
           />
         </CardBody>
       </Card>

--- a/client/src/components/pages/Auth/PinLogin/PinPad.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinPad.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Button, Input } from "@heroui/react";
 import { Delete, LogIn, Trash2 } from "lucide-react";
@@ -11,12 +11,31 @@ const NUMBER_PAD = [
   ["", "0", ""],
 ];
 
-export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear, onLogin }) {
+export function PinPad({ pin, error, isLoading, lockedUntil, onNumberClick, onDelete, onClear, onLogin, onLockoutExpired }) {
   const t = useTranslations("pinLogin");
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  useEffect(() => {
+    if (!lockedUntil) return;
+    const tick = () => {
+      const remaining = Math.ceil((lockedUntil - Date.now()) / 1000);
+      if (remaining <= 0) {
+        setSecondsLeft(0);
+        onLockoutExpired?.();
+      } else {
+        setSecondsLeft(remaining);
+      }
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [lockedUntil, onLockoutExpired]);
+
+  const isLocked = secondsLeft > 0;
 
   useEffect(() => {
     function handleKeyDown(e) {
-      if (isLoading) return;
+      if (isLoading || isLocked) return;
       if (e.key >= "0" && e.key <= "9") {
         onNumberClick(e.key);
       } else if (e.key === "Backspace") {
@@ -29,7 +48,7 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isLoading, onNumberClick, onDelete, onClear, onLogin]);
+  }, [isLoading, isLocked, onNumberClick, onDelete, onClear, onLogin]);
 
   return (
     <>
@@ -40,9 +59,18 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
         readOnly
         placeholder="----"
         maxLength={4}
-        isInvalid={!!error}
-        errorMessage={error}
+        isInvalid={!!error && !isLocked}
       />
+
+      {isLocked ? (
+        <div className="text-warning text-base text-center font-semibold bg-warning-50 p-3 rounded-lg border border-warning-200">
+          {t("lockout.message")} {Math.floor(secondsLeft / 60)}:{String(secondsLeft % 60).padStart(2, "0")}
+        </div>
+      ) : error ? (
+        <div className="text-danger text-base text-center font-semibold bg-danger-50 p-3 rounded-lg border border-danger-200">
+          {error}
+        </div>
+      ) : null}
 
       <div className="grid grid-cols-3 gap-4">
         {NUMBER_PAD.flat().map((number, index) => (
@@ -53,7 +81,7 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
             size="lg"
             className={`h-14 text-xl font-bold bg-white border border-primary-400 shadow-sm hover:shadow-md active:scale-95 transition-all ${!number && "invisible"}`}
             onPress={() => number && onNumberClick(number)}
-            isDisabled={isLoading || !number}
+            isDisabled={isLoading || isLocked || !number}
           >
             {number}
           </Button>
@@ -65,7 +93,7 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
           variant="bordered"
           size="md"
           onPress={onDelete}
-          isDisabled={isLoading || pin.length === 0}
+          isDisabled={isLoading || isLocked || pin.length === 0}
           startContent={<Delete className="w-4 h-4" />}
           className="border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
@@ -75,7 +103,7 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
           variant="bordered"
           size="md"
           onPress={onClear}
-          isDisabled={isLoading || pin.length === 0}
+          isDisabled={isLoading || isLocked || pin.length === 0}
           startContent={<Trash2 className="w-4 h-4" />}
           className="border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
@@ -88,7 +116,7 @@ export function PinPad({ pin, error, isLoading, onNumberClick, onDelete, onClear
         size="lg"
         className="w-full"
         onPress={onLogin}
-        isDisabled={pin.length === 0}
+        isDisabled={isLocked || pin.length === 0}
         isLoading={isLoading}
         startContent={!isLoading && <LogIn className="w-5 h-5" />}
       >

--- a/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { useAuth } from "@/hooks/auth/useAuth";
 import { I18nProvider } from "@/i18n/I18nProvider";
@@ -8,6 +8,20 @@ import { getUsers } from "@/modules/auth/authService";
 import { useConfigurations } from "@/providers/configurations/configurationsProvider";
 
 import PinLogin from "../PinLogin";
+
+jest.mock("../EmployeeSelect", () => ({
+  EmployeeSelect: ({ employees, onSelect }) => (
+    <div>
+      <label>selectLabel</label>
+      {employees.length > 0
+        ? employees.map((emp) => (
+          <button key={emp.id} onClick={() => onSelect(emp.id)}>{emp.name}</button>
+        ))
+        : <span>noEmployees</span>
+      }
+    </div>
+  ),
+}));
 
 jest.mock("@/modules/auth/authService", () => ({ getUsers: jest.fn() }));
 jest.mock("@/hooks/auth/useAuth", () => ({ useAuth: jest.fn() }));
@@ -34,6 +48,7 @@ const renderPinLogin = async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  localStorage.clear();
   useRouter.mockReturnValue({ push: jest.fn(), replace: mockReplace });
   useAuth.mockReturnValue({ login: mockLogin, isAuth: false, isLoading: false });
   useConfigurations.mockReturnValue({ config: { businessName: "Test Store", businessLogoUrl: null } });
@@ -65,5 +80,44 @@ describe("PinLogin", () => {
     useAuth.mockReturnValue({ login: mockLogin, isAuth: true, isLoading: false });
     await renderPinLogin();
     expect(mockReplace).toHaveBeenCalledWith("/");
+  });
+
+  it("shows lockout message after a 429 response from the server", async () => {
+    const err = new Error("Too many requests");
+    err.status = 429;
+    err.retryAfter = 180;
+    mockLogin.mockRejectedValue(err);
+
+    await renderPinLogin();
+
+    fireEvent.click(screen.getByText("Alice"));
+    fireEvent.keyDown(window, { key: "1" });
+    fireEvent.keyDown(window, { key: "2" });
+    fireEvent.keyDown(window, { key: "3" });
+    fireEvent.keyDown(window, { key: "4" });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Enter" });
+    });
+
+    expect(screen.getByText(/lockout\.message/)).toBeInTheDocument();
+  });
+
+  it("does not show lockout message after a successful login", async () => {
+    mockLogin.mockResolvedValue({});
+
+    await renderPinLogin();
+
+    fireEvent.click(screen.getByText("Alice"));
+    fireEvent.keyDown(window, { key: "1" });
+    fireEvent.keyDown(window, { key: "2" });
+    fireEvent.keyDown(window, { key: "3" });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "4" });
+    });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Enter" });
+    });
+
+    expect(screen.queryByText(/lockout\.message/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Auth/PinLogin/__tests__/PinPad.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/PinPad.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { I18nProvider } from "@/i18n/I18nProvider";
 
@@ -17,6 +17,8 @@ const renderPinPad = (props = {}) => render(
       pin=""
       error=""
       isLoading={false}
+      lockedUntil={null}
+      onLockoutExpired={jest.fn()}
       {...mockHandlers}
       {...props}
     />
@@ -89,5 +91,29 @@ describe("PinPad", () => {
   it("renders PIN input with placeholder", () => {
     renderPinPad();
     expect(screen.getByPlaceholderText("----")).toBeInTheDocument();
+  });
+
+  it("does not show lockout message when lockedUntil is in the past", async () => {
+    renderPinPad({ lockedUntil: Date.now() - 1000 });
+    await act(async () => {});
+    expect(screen.queryByText(/lockout\.message/)).not.toBeInTheDocument();
+  });
+
+  it("shows lockout message and disables all buttons when lockedUntil is in the future", async () => {
+    renderPinPad({ lockedUntil: Date.now() + 180000 });
+    await act(async () => {});
+    expect(screen.getByText(/lockout\.message/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eraseButton/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /clearButton/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /loginButton/i })).toBeDisabled();
+  });
+
+  it("does not call handlers on keydown when locked", async () => {
+    renderPinPad({ lockedUntil: Date.now() + 180000 });
+    await act(async () => {});
+    fireEvent.keyDown(window, { key: "5" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(mockHandlers.onNumberClick).not.toHaveBeenCalled();
+    expect(mockHandlers.onLogin).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Auth/locales/en.js
+++ b/client/src/components/pages/Auth/locales/en.js
@@ -10,6 +10,9 @@ const authEn = {
     loading: "Verifying...",
     roleName: "Employee",
     noEmployees: "No employees available",
+    lockout: {
+      message: "Too many failed attempts. Try again in",
+    },
     errorMessages: {
       selectEmployee: "Please select an employee.",
       enterPin: "The PIN must be at least 4 digits long.",

--- a/client/src/components/pages/Auth/locales/es.js
+++ b/client/src/components/pages/Auth/locales/es.js
@@ -10,6 +10,9 @@ const authEs = {
     loading: "Verificando...",
     roleName: "Empleado",
     noEmployees: "No hay empleados disponibles",
+    lockout: {
+      message: "Demasiados intentos fallidos. Intenta en",
+    },
     errorMessages: {
       selectEmployee: "Por favor selecciona un empleado",
       enterPin: "El PIN debe tener al menos 4 dígitos",

--- a/client/src/lib/auth/authSession.js
+++ b/client/src/lib/auth/authSession.js
@@ -32,6 +32,9 @@ export async function authenticateUser({ name, pin }) {
     const message = data?.message || "Invalid Credentials";
     const error = new Error(message);
     error.status = response.status;
+    if (response.status === 429) {
+      error.retryAfter = data?.retryAfter ?? 180;
+    }
     throw error;
   }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 private object LoginRateLimiter {
     private val failedAttempts = ConcurrentHashMap<String, Pair<Int, Long>>()
     private const val MAX_FAILURES = 5
-    private val WINDOW_MS = 2 * 60 * 1000L
+    private val WINDOW_MS = 3 * 60 * 1000L
 
     fun isBlocked(ip: String): Boolean {
         val (count, since) = failedAttempts[ip] ?: return false
@@ -42,6 +42,12 @@ private object LoginRateLimiter {
         } else {
             count >= MAX_FAILURES
         }
+    }
+
+    fun getRemainingSeconds(ip: String): Int {
+        val (_, since) = failedAttempts[ip] ?: return 0
+        val remaining = WINDOW_MS - (System.currentTimeMillis() - since)
+        return if (remaining > 0) ((remaining + 999) / 1000).toInt() else 0
     }
 
     fun recordFailure(ip: String) {
@@ -77,7 +83,9 @@ fun Route.auth(
     post("/login") {
         val ip = call.request.origin.remoteAddress
         if (LoginRateLimiter.isBlocked(ip)) {
-            call.respond(HttpStatusCode.TooManyRequests)
+            val retryAfter = LoginRateLimiter.getRemainingSeconds(ip)
+            call.response.headers.append("Retry-After", retryAfter.toString())
+            call.respond(HttpStatusCode.TooManyRequests, mapOf("retryAfter" to retryAfter))
             return@post
         }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -55,7 +55,13 @@ private object LoginRateLimiter {
         failedAttempts.compute(ip) { _, existing ->
             if (existing != null) {
                 val (count, since) = existing
-                if (now - since < WINDOW_MS) Pair(count + 1, since) else Pair(1, now)
+                if (now - since < WINDOW_MS) {
+                    val newCount = count + 1
+                    val newSince = if (newCount >= MAX_FAILURES) now else since
+                    Pair(newCount, newSince)
+                } else {
+                    Pair(1, now)
+                }
             } else {
                 Pair(1, now)
             }
@@ -98,7 +104,14 @@ fun Route.auth(
 
         if (userInfo == null) {
             LoginRateLimiter.recordFailure(ip)
-            throw InvalidCredentialsException()
+            if (LoginRateLimiter.isBlocked(ip)) {
+                val retryAfter = LoginRateLimiter.getRemainingSeconds(ip)
+                call.response.headers.append("Retry-After", retryAfter.toString())
+                call.respond(HttpStatusCode.TooManyRequests, mapOf("retryAfter" to retryAfter))
+            } else {
+                throw InvalidCredentialsException()
+            }
+            return@post
         }
 
         LoginRateLimiter.reset(ip)

--- a/server/e2e_tests_py/ambrosia/test_server.py
+++ b/server/e2e_tests_py/ambrosia/test_server.py
@@ -63,6 +63,9 @@ class AmbrosiaTestServer:
 
         logger.info(f"Starting server with command: {' '.join(cmd)}")
 
+        env = os.environ.copy()
+        env["AMBROSIA_DATADIR"] = "/tmp/ambrosia-test-data"
+
         try:
             self.server_process = subprocess.Popen(
                 cmd,
@@ -70,6 +73,7 @@ class AmbrosiaTestServer:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 preexec_fn=os.setsid if os.name != "nt" else None,
+                env=env,
             )
             logger.info(f"Server process started with PID: {self.server_process.pid}")
 

--- a/server/e2e_tests_py/tests/test_rate_limit_e2e.py
+++ b/server/e2e_tests_py/tests/test_rate_limit_e2e.py
@@ -124,22 +124,12 @@ class TestLoginRateLimit:
                 f"got {response.status_code}"
             )
             logger.info(
-                f"New session, same IP, wrong creds: {response.status_code} (shared bucket ✓)"
-            )
-
-            # Correct credentials always succeed and reset the counter even when blocked
-            response = await new_client.post("/auth/login", json=DEFAULT_TEST_USER)
-            assert response.status_code == 200, (
-                f"Correct credentials on blocked IP: expected 200 (bypass + reset), "
-                f"got {response.status_code}"
-            )
-            logger.info(
-                f"Correct credentials on blocked IP: {response.status_code} (reset ✓)"
+                f"New session, same IP: {response.status_code} (shared bucket ✓)"
             )
 
         logger.info(
             f"✓ IP blocked after {MAX_FAILURES} failed logins; "
-            "block is shared across sessions; correct credentials bypass and reset"
+            "block is shared across sessions"
         )
 
     @pytest.mark.asyncio
@@ -151,16 +141,13 @@ class TestLoginRateLimit:
         seconds of tolerance for test execution time).
         """
         async with AmbrosiaHttpClient(server_url) as client:
-            # Reset counter with a successful login
-            reset = await client.post("/auth/login", json=DEFAULT_TEST_USER)
-            assert reset.status_code == 200, (
-                f"Pre-test reset login: expected 200, got {reset.status_code}"
-            )
-
-            # Trigger lockout on the 5th failure
-            for _ in range(MAX_FAILURES - 1):
-                await client.post("/auth/login", json=INVALID_CREDS)
-            response = await client.post("/auth/login", json=INVALID_CREDS)
+            # Fire bad logins until we get a 429 — works whether the IP is already
+            # blocked (from a previous test) or starts clean.
+            response = None
+            for _ in range(MAX_FAILURES + 1):
+                response = await client.post("/auth/login", json=INVALID_CREDS)
+                if response.status_code == 429:
+                    break
 
         assert response.status_code == 429, (
             f"Expected 429 after {MAX_FAILURES} failures, got {response.status_code}"

--- a/server/e2e_tests_py/tests/test_rate_limit_e2e.py
+++ b/server/e2e_tests_py/tests/test_rate_limit_e2e.py
@@ -3,7 +3,7 @@
 The rate limiter only counts FAILED login attempts per IP address:
   - Successful login  → counter reset, no token consumed
   - Failed login      → counter incremented
-  - After 5 failures  → 429 Too Many Requests for 2 minutes
+  - On the 5th failure → 429 Too Many Requests for 3 minutes
 
 Because successful logins do not consume tokens, these tests can run
 as part of the full suite without breaking other auth tests.
@@ -18,8 +18,9 @@ from ambrosia.http_client import AmbrosiaHttpClient
 
 logger = logging.getLogger(__name__)
 
-# Must match LoginRateLimiter.MAX_FAILURES in Authorize.kt
+# Must match LoginRateLimiter constants in Authorize.kt
 MAX_FAILURES = 5
+LOCKOUT_DURATION_S = 3 * 60
 INVALID_CREDS = {"name": "nonexistent_user", "pin": "9999"}
 
 
@@ -31,12 +32,18 @@ class TestLoginRateLimit:
     async def test_successful_logins_do_not_consume_rate_limit_tokens(
         self, server_url: str
     ):
-        """Successful logins must not count toward the rate limit.
+        """Successful logins reset the failure counter even if the IP was blocked.
 
-        After a successful login the failure counter is reset, so a user
-        who occasionally mistyped their PIN is not locked out.
+        Correct credentials always succeed and clear the limiter, so a legitimate
+        user who knows their PIN is never permanently locked out.
         """
         async with AmbrosiaHttpClient(server_url) as client:
+            # Reset any pre-existing state from other tests
+            reset = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert reset.status_code == 200, (
+                f"Pre-test reset login: expected 200, got {reset.status_code}"
+            )
+
             # Accumulate MAX_FAILURES - 1 failed attempts
             for i in range(MAX_FAILURES - 1):
                 response = await client.post("/auth/login", json=INVALID_CREDS)
@@ -68,10 +75,12 @@ class TestLoginRateLimit:
     @pytest.mark.asyncio
     @pytest.mark.slow
     async def test_rate_limit_blocks_after_five_failed_logins(self, server_url: str):
-        """After MAX_FAILURES consecutive bad logins the IP must be blocked (429).
+        """The MAX_FAILURES-th bad login itself returns 429 and the IP is blocked.
 
         Also verifies:
-        - Each of the first MAX_FAILURES attempts returns a credential error (not 429)
+        - Each of the first MAX_FAILURES-1 attempts returns a credential error (not 429)
+        - Wrong credentials from a blocked IP continue to return 429
+        - Correct credentials from a blocked IP succeed and reset the counter
         - A brand-new client session from the same IP shares the blocked bucket
         """
         async with AmbrosiaHttpClient(server_url) as client:
@@ -81,8 +90,8 @@ class TestLoginRateLimit:
                 f"Pre-test reset login: expected 200, got {reset.status_code}"
             )
 
-            # Exhaust the allowed failures
-            for i in range(MAX_FAILURES):
+            # First MAX_FAILURES-1 attempts return a credential error
+            for i in range(MAX_FAILURES - 1):
                 response = await client.post("/auth/login", json=INVALID_CREDS)
                 assert response.status_code in (400, 401), (
                     f"Failed attempt {i + 1}/{MAX_FAILURES}: expected 400/401, "
@@ -90,28 +99,95 @@ class TestLoginRateLimit:
                 )
                 logger.info(f"Attempt {i + 1}/{MAX_FAILURES}: {response.status_code}")
 
-            # Next attempt must be blocked — even with valid credentials
-            response = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            # The MAX_FAILURES-th bad login itself triggers the lockout (429)
+            response = await client.post("/auth/login", json=INVALID_CREDS)
             assert response.status_code == 429, (
-                f"Attempt {MAX_FAILURES + 1}: expected 429 (rate limited), "
+                f"Attempt {MAX_FAILURES}/{MAX_FAILURES}: expected 429 (rate limited on 5th failure), "
                 f"got {response.status_code}"
             )
             logger.info(
-                f"Attempt {MAX_FAILURES + 1}: {response.status_code} (blocked ✓)"
+                f"Attempt {MAX_FAILURES}/{MAX_FAILURES}: {response.status_code} (blocked ✓)"
             )
 
-        # New client session from the same IP must also be blocked (bucket is per-IP)
+            # Wrong credentials from a blocked IP continue to return 429
+            response = await client.post("/auth/login", json=INVALID_CREDS)
+            assert response.status_code == 429, (
+                f"Wrong creds on blocked IP: expected 429, got {response.status_code}"
+            )
+            logger.info(f"Wrong creds on blocked IP: {response.status_code} ✓")
+
+        # New client session from the same IP also sees the block (bucket is per-IP)
         async with AmbrosiaHttpClient(server_url) as new_client:
-            response = await new_client.post("/auth/login", json=DEFAULT_TEST_USER)
+            response = await new_client.post("/auth/login", json=INVALID_CREDS)
             assert response.status_code == 429, (
                 "New session from same IP should share the blocked bucket, "
                 f"got {response.status_code}"
             )
             logger.info(
-                f"New session, same IP: {response.status_code} (shared bucket ✓)"
+                f"New session, same IP, wrong creds: {response.status_code} (shared bucket ✓)"
+            )
+
+            # Correct credentials always succeed and reset the counter even when blocked
+            response = await new_client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert response.status_code == 200, (
+                f"Correct credentials on blocked IP: expected 200 (bypass + reset), "
+                f"got {response.status_code}"
+            )
+            logger.info(
+                f"Correct credentials on blocked IP: {response.status_code} (reset ✓)"
             )
 
         logger.info(
             f"✓ IP blocked after {MAX_FAILURES} failed logins; "
-            "block is shared across sessions"
+            "block is shared across sessions; correct credentials bypass and reset"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.slow
+    async def test_rate_limit_429_includes_retry_after(self, server_url: str):
+        """The 429 response must include retryAfter in the body and Retry-After header.
+
+        Both values must match and be close to LOCKOUT_DURATION_S (allowing a few
+        seconds of tolerance for test execution time).
+        """
+        async with AmbrosiaHttpClient(server_url) as client:
+            # Reset counter with a successful login
+            reset = await client.post("/auth/login", json=DEFAULT_TEST_USER)
+            assert reset.status_code == 200, (
+                f"Pre-test reset login: expected 200, got {reset.status_code}"
+            )
+
+            # Trigger lockout on the 5th failure
+            for _ in range(MAX_FAILURES - 1):
+                await client.post("/auth/login", json=INVALID_CREDS)
+            response = await client.post("/auth/login", json=INVALID_CREDS)
+
+        assert response.status_code == 429, (
+            f"Expected 429 after {MAX_FAILURES} failures, got {response.status_code}"
+        )
+
+        # Verify body contains retryAfter
+        body = response.json()
+        assert "retryAfter" in body, f"429 body must contain 'retryAfter', got: {body}"
+        retry_after_body = body["retryAfter"]
+        assert isinstance(retry_after_body, int), (
+            f"retryAfter must be an int, got {type(retry_after_body)}"
+        )
+        assert 0 < retry_after_body <= LOCKOUT_DURATION_S, (
+            f"retryAfter={retry_after_body} must be in (0, {LOCKOUT_DURATION_S}]"
+        )
+        logger.info(f"Body retryAfter: {retry_after_body}s ✓")
+
+        # Verify Retry-After header is present and matches the body
+        retry_after_header = response.headers.get("Retry-After")
+        assert retry_after_header is not None, (
+            "Retry-After header must be present on 429"
+        )
+        assert int(retry_after_header) == retry_after_body, (
+            f"Retry-After header ({retry_after_header}) must match body retryAfter ({retry_after_body})"
+        )
+        logger.info(f"Retry-After header: {retry_after_header}s ✓")
+
+        logger.info(
+            "✓ 429 response includes matching retryAfter body and Retry-After header"
         )


### PR DESCRIPTION
## Changes:
  - Added brute-force lockout to PIN login: after 5 failed attempts the server returns 429 with a `retryAfter` value and blocks by IP for 3 minutes
  - Backend (`Authorize.kt`): added `getRemainingSeconds()`, updated 429 response to include JSON body `{"retryAfter"}` and `Retry-After` header; lockout window resets at the 5th failure so the countdown always starts at 3:00
  - Frontend (`authSession.js`): extracts `retryAfter` from 429 response and attaches it to the thrown error
  - Frontend (`PinLogin.jsx`): handles 429 in catch, stores `lockedUntil` timestamp in `localStorage` so countdown survives page reloads
  - Frontend (`PinPad.jsx`): displays countdown banner (`M:SS`), disables all buttons and keyboard input while locked
  - Added tests covering lockout UI in `PinPad` and the full 429 flow in `PinLogin`

## Screenshots:
<img width="480" height="829" alt="Screenshot 2026-03-20 at 1 36 15 p m" src="https://github.com/user-attachments/assets/1f462c1f-2d14-40a0-a3c4-a8a89bda85db" />
