### PR TITLE
fix(wallet/server-client): fix logout wallet when user close app

### DIFF
--- a/client/src/components/auth/WalletGuard.jsx
+++ b/client/src/components/auth/WalletGuard.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -42,57 +42,15 @@ export default function WalletGuard({
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [authorized, setAuthorized] = useState(false);
-  const expiryKey = "walletAccessExpiry";
-  const expiryTimeoutRef = useRef(null);
-  const fallbackExpiryMs = 8 * 60 * 60 * 1000;
-  const expiryBufferMs = 30 * 1000;
-
-  const scheduleExpiry = useCallback((expiresAtMs) => {
-    try {
-      localStorage.setItem(expiryKey, String(expiresAtMs));
-      if (expiryTimeoutRef.current) clearTimeout(expiryTimeoutRef.current);
-      const msRemaining = Math.max(0, expiresAtMs - Date.now() - expiryBufferMs);
-      expiryTimeoutRef.current = setTimeout(() => {
-        setAuthorized(false);
-        setIsOpen(true);
-      }, msRemaining);
-    } catch {}
-  }, [expiryBufferMs, expiryKey]);
 
   useEffect(() => () => {
     logoutWallet().catch(() => {});
-    try {
-      localStorage.removeItem(expiryKey);
-    } catch {}
-    if (expiryTimeoutRef.current) {
-      clearTimeout(expiryTimeoutRef.current);
-      expiryTimeoutRef.current = null;
-    }
   }, []);
-
-  useEffect(() => {
-    try {
-      const storedExpiry = Number(localStorage.getItem(expiryKey));
-      const now = Date.now();
-      if (Number.isFinite(storedExpiry) && storedExpiry - now > 0) {
-        setAuthorized(true);
-        setIsOpen(false);
-        scheduleExpiry(storedExpiry);
-      }
-    } catch {}
-  }, [scheduleExpiry]);
 
   useEffect(() => {
     const handler = () => {
       setAuthorized(false);
       setIsOpen(true);
-      try {
-        localStorage.removeItem(expiryKey);
-      } catch {}
-      if (expiryTimeoutRef.current) {
-        clearTimeout(expiryTimeoutRef.current);
-        expiryTimeoutRef.current = null;
-      }
     };
     if (typeof window !== "undefined") {
       window.addEventListener("wallet:unauthorized", handler);
@@ -148,15 +106,10 @@ export default function WalletGuard({
     if (!password) return;
     setSubmitting(true);
     try {
-      const result = await loginWallet(password);
+      await loginWallet(password);
       await new Promise((r) => setTimeout(r, 150));
       setAuthorized(true);
       setIsOpen(false);
-      const expiresAt =
-        typeof result?.walletTokenExpiresAt === "number"
-          ? result.walletTokenExpiresAt
-          : Date.now() + fallbackExpiryMs;
-      scheduleExpiry(expiresAt);
       if (onAuthorized) onAuthorized();
     } catch {}
     finally {

--- a/client/src/components/auth/__tests__/WalletGuard.test.jsx
+++ b/client/src/components/auth/__tests__/WalletGuard.test.jsx
@@ -47,9 +47,7 @@ beforeEach(() => {
   localStorageMock.clear();
 
   jest.spyOn(walletService, "logoutWallet").mockResolvedValue({});
-  jest.spyOn(walletService, "loginWallet").mockResolvedValue({
-    walletTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
-  });
+  jest.spyOn(walletService, "loginWallet").mockResolvedValue({});
 });
 
 afterEach(() => {
@@ -103,23 +101,6 @@ describe("WalletGuard — driver.js tour", () => {
 
     expect(driver).toHaveBeenCalledTimes(1);
     expect(driver.mock.results[0].value.drive).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not start the tour when the modal is closed (session restored from localStorage)", async () => {
-    jest.useFakeTimers();
-
-    localStorageMock.setItem("walletAccessExpiry", String(Date.now() + 60 * 60 * 1000));
-    localStorageMock.setItem(WALLET_GUARD_TOUR_KEY, "true");
-
-    await act(async () => {
-      renderWalletGuard();
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(400);
-    });
-
-    expect(driver).not.toHaveBeenCalled();
   });
 
   it("adds a resize event listener when the tour starts", async () => {

--- a/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
@@ -44,10 +44,6 @@ const mockOutgoingTransactions = [
   },
 ];
 
-const mockWalletLoginResponse = {
-  walletTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
-};
-
 function renderStoreWallet() {
   const mockAuthContext = {
     user: { userName: "testuser", userId: 1 },
@@ -155,7 +151,7 @@ beforeEach(() => {
     updateConfig: mockUpdateConfig,
   });
 
-  jest.spyOn(walletService, "loginWallet").mockResolvedValue(mockWalletLoginResponse);
+  jest.spyOn(walletService, "loginWallet").mockResolvedValue({});
   jest.spyOn(walletService, "logoutWallet").mockResolvedValue({});
   jest.spyOn(walletService, "getInfo").mockResolvedValue(mockNodeInfo);
   jest.spyOn(walletService, "getIncomingTransactions").mockResolvedValue(mockIncomingTransactions);
@@ -216,24 +212,13 @@ describe("StoreWallet Component", () => {
       });
     });
 
-    it("stores wallet token expiry in localStorage", async () => {
+    it("does not restore wallet access automatically after mount", async () => {
       await act(async () => {
         renderStoreWallet();
       });
 
-      const passwordInput = screen.getByLabelText("access.passwordLabel");
-      const confirmButton = screen.getByText("access.confirmText");
-
-      await userEvent.type(passwordInput, "password123");
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
-
-      await waitFor(() => {
-        const storedExpiry = localStorage.getItem("walletAccessExpiry");
-        expect(storedExpiry).toBeTruthy();
-        expect(Number(storedExpiry)).toBeGreaterThan(Date.now());
-      });
+      expect(walletService.getInfo).not.toHaveBeenCalled();
+      expect(screen.getByText("access.title")).toBeInTheDocument();
     });
   });
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -14,7 +14,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import io.ktor.util.date.GMTDate
 import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.models.RolePassword
 import pos.ambrosia.models.WalletAuthResponse
@@ -72,7 +71,7 @@ fun Route.wallet(
                         httpOnly = true,
                         secure = isSecureRequest,
                         path = "/",
-                        expires = GMTDate(expiresAt),
+                        extensions = mapOf("SameSite" to "Strict"),
                     ),
                 )
                 call.respond(HttpStatusCode.OK, WalletAuthResponse("Login successful", expiresAt))


### PR DESCRIPTION
This pull request removes the logic for persisting wallet session expiry in `localStorage` on the client, and updates related tests and backend cookie settings to simplify wallet session management. The wallet session is no longer restored automatically from `localStorage`, and the expiry is now managed by the backend via cookies.

**Client-side wallet session management simplification:**

* Removed all logic in `WalletGuard.jsx` for storing and restoring wallet session expiry from `localStorage`, including the use of `useRef`, `useCallback`, and `scheduleExpiry`. Session restoration is now solely handled by backend cookies. [[1]](diffhunk://#diff-ebe2712d7f15d9197f7e1d50765f929151629f3c54546a8cebdcb25fec3d2017L3-R3) [[2]](diffhunk://#diff-ebe2712d7f15d9197f7e1d50765f929151629f3c54546a8cebdcb25fec3d2017L45-L95) [[3]](diffhunk://#diff-ebe2712d7f15d9197f7e1d50765f929151629f3c54546a8cebdcb25fec3d2017L151-L159)
* Updated tests in `WalletGuard.test.jsx` and `StoreWallet.test.jsx` to no longer expect or mock `walletTokenExpiresAt` or check for expiry in `localStorage`. Tests now verify that wallet access is not restored automatically after mount. [[1]](diffhunk://#diff-04df461c6cb06ec6fb21e4d5c685229603881737bd166c4e7236f56825f44ab5L50-R50) [[2]](diffhunk://#diff-04df461c6cb06ec6fb21e4d5c685229603881737bd166c4e7236f56825f44ab5L108-L124) [[3]](diffhunk://#diff-310af4365eb7b0a3606c07912f93eaa65349b6c074405ea61c467e07e589f8b8L47-L50) [[4]](diffhunk://#diff-310af4365eb7b0a3606c07912f93eaa65349b6c074405ea61c467e07e589f8b8L158-R154) [[5]](diffhunk://#diff-310af4365eb7b0a3606c07912f93eaa65349b6c074405ea61c467e07e589f8b8L219-R221)

**Backend cookie handling:**

* Updated the wallet login route in `Wallet.kt` to set the `SameSite=Strict` attribute on the authentication cookie and removed the explicit `expires` attribute, relying on the backend for session expiry management. [[1]](diffhunk://#diff-6cb7d8b06aa87f6a0453d81985dd67e8f66a928fc196a1729b294877b958f7f2L17) [[2]](diffhunk://#diff-6cb7d8b06aa87f6a0453d81985dd67e8f66a928fc196a1729b294877b958f7f2L75-R74)