### PR TITLE
fix(client/locales): solve bad names in roles

### DIFF
--- a/client/src/components/pages/Store/Users/Roles/Roles.jsx
+++ b/client/src/components/pages/Store/Users/Roles/Roles.jsx
@@ -102,8 +102,8 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
       addToast({ title: t("roles.actions.saveSuccess"), color: "success" });
     } catch (error) {
       addToast({
-        title: error?.status === 409 ? t("roles.actions.lastAdminTitle") : t("roles.actions.saveErrorTitle"),
-        description: error?.status == 409 ? t("roles.actions.lastAdminDescription") : t("roles.actions.saveErrorDescription"),
+        title: error?.status === 409 ? t("roles.actions.lastAdminErrorTittle") : t("roles.actions.saveErrorTitle"),
+        description: error?.status == 409 ? t("roles.actions.lastAdminErrorDescription") : t("roles.actions.saveErrorDescription"),
         color: error?.status === 409 ? "warning" : "danger",
       });
     } finally {
@@ -120,8 +120,8 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
       addToast({ title: t("roles.actions.deleteSuccess"), color: "success" });
     } catch (error) {
       addToast({
-        title: error?.status === 409 ? t("roles.actions.lastAdminTitle") : t("roles.actions.saveErrorTitle"),
-        description: error?.status == 409 ? t("roles.actions.lastAdminDescription") : t("roles.actions.saveErrorDescription"),
+        title: error?.status === 409 ? t("roles.actions.lastAdminErrorTittle") : t("roles.actions.saveErrorTitle"),
+        description: error?.status == 409 ? t("roles.actions.lastAdminErrorDescription") : t("roles.actions.saveErrorDescription"),
         color: error?.status === 409 ? "warning" : "danger",
       });
     } finally {

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -97,8 +97,8 @@ const storeEn = {
       deleteConfirmBody: "Are you sure you want to delete the role {name}? Users with this role will have no role assigned.",
       deleteSuccess: "Role deleted successfully",
       deleteError: "Could not delete the role",
-      lastAdminTitle: "Not allowed",
-      lastAdminDescription: "You cannot delete the last role with active admin users",
+      lastAdminErrorTittle: "Not allowed",
+      lastAdminErrorDescription: "You cannot delete the last role with active admin users",
     },
     create: {
       title: "Create role",

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -97,7 +97,7 @@ const storeEs = {
       deleteConfirmBody: "¿Estás seguro de que quieres eliminar el rol {name}? Los usuarios con este rol quedarán sin rol asignado.",
       deleteSuccess: "Rol eliminado correctamente",
       deleteError: "No se pudo eliminar el rol",
-      lastAdminErrorTittle: "No permitiod",
+      lastAdminErrorTittle: "No permitido",
       lastAdminErrorDescription: "No puedes eliminar el último rol con usuarios administradores activos",
     },
     create: {


### PR DESCRIPTION
This pull request addresses error messaging for role deletion and updates localization strings in both English and Spanish. The main focus is on correcting and standardizing the translation keys and their usage for the "last admin" error scenario when deleting roles.

Localization and error messaging improvements:

* Standardized translation keys for the "last admin" error in both the UI logic and the English locale file, changing from `lastAdminTitle`/`lastAdminDescription` to `lastAdminErrorTittle`/`lastAdminErrorDescription` in `Roles.jsx` and `en.js` [[1]](diffhunk://#diff-88441c6f84992611b0af673cafa9cb42f516f4fb7fbd4bc76d362b2c15f372f1L105-R106) [[2]](diffhunk://#diff-88441c6f84992611b0af673cafa9cb42f516f4fb7fbd4bc76d362b2c15f372f1L123-R124) [[3]](diffhunk://#diff-cd6cabb661b4c8b90544c74da065b262bdcc623769c53a5f7b5997be352ee0b9L100-R101).
* Fixed a typo in the Spanish localization for the "last admin" error title, updating from "No permitiod" to "No permitido" in `es.js`.