### PR TITLE
fix(client/wallet): remove doubled message in invoice

### DIFF
--- a/client/src/components/pages/Store/Wallet/TransactionsSendTab.jsx
+++ b/client/src/components/pages/Store/Wallet/TransactionsSendTab.jsx
@@ -23,7 +23,7 @@ export function TransactionsSendTab({ loading, setLoading, setError, fetchInfo, 
   const t = useTranslations("wallet");
   const [payInvoice, setPayInvoice] = useState("");
   const [paymentResult, setPaymentResult] = useState(null);
-  const [invalidInvoice, setInvalidInvoice] = useState(false);
+  const [validationError, setValidationError] = useState("");
 
   const validateBolt11 = (invoice) => {
     if (!invoice || !invoice.trim()) {
@@ -49,8 +49,8 @@ export function TransactionsSendTab({ loading, setLoading, setError, fetchInfo, 
     const validation = validateBolt11(payInvoice);
 
     if (!validation.valid) {
-      setInvalidInvoice(true);
-      setError(validation.error);
+      setValidationError(validation.error);
+      setError("");
       return;
     }
 
@@ -60,7 +60,7 @@ export function TransactionsSendTab({ loading, setLoading, setError, fetchInfo, 
       setPaymentResult(res);
       setPayInvoice("");
       setError("");
-      setInvalidInvoice(false);
+      setValidationError("");
       fetchInfo?.();
       fetchTransactions?.();
       addToast({
@@ -105,13 +105,13 @@ export function TransactionsSendTab({ loading, setLoading, setError, fetchInfo, 
           value={payInvoice}
           onChange={(e) => {
             setPayInvoice(e.target.value);
-            setInvalidInvoice(false);
+            setValidationError("");
             setError("");
           }}
           startContent={<Zap className="w-5 h-5 text-gray-400" />}
           disabled={loading}
-          isInvalid={invalidInvoice}
-          errorMessage={invalidInvoice ? t("payments.send.invalidInvoiceFormat") : ""}
+          isInvalid={Boolean(validationError)}
+          errorMessage={validationError}
         />
         <Button
           onPress={handlePayInvoice}

--- a/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
@@ -279,6 +279,26 @@ describe("StoreWallet Component", () => {
         expect(screen.getByText("loadingMessage")).toBeInTheDocument();
       });
     });
+
+    it("shows BOLT11 validation errors only once", async () => {
+      await authenticateAndWait();
+
+      fireEvent.click(screen.getByText("payments.send.tabTitle"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("payments.send.payInvoiceLabel")).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText("payments.send.payInvoiceLabel"),
+        "random-invalid-text",
+      );
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(screen.getAllByText("payments.send.invalidInvoiceFormat")).toHaveLength(1);
+      });
+    });
   });
 
   describe("Error Handling", () => {

--- a/client/src/components/pages/Store/Wallet/__tests__/TransactionsSendTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/TransactionsSendTab.test.jsx
@@ -95,7 +95,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.noInvoiceToPay");
+        expect(screen.getByText("payments.send.noInvoiceToPay")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
     });
 
@@ -110,7 +111,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.invalidInvoiceFormat");
+        expect(screen.getByText("payments.send.invalidInvoiceFormat")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
     });
 
@@ -167,7 +169,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.invalidInvoiceFormat");
+        expect(screen.getByText("payments.send.invalidInvoiceFormat")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
     });
 
@@ -182,7 +185,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.invalidInvoiceFormat");
+        expect(screen.getByText("payments.send.invalidInvoiceFormat")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
     });
 
@@ -194,7 +198,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.noInvoiceToPay");
+        expect(screen.getByText("payments.send.noInvoiceToPay")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
 
       const invoiceInput = screen.getByLabelText("payments.send.payInvoiceLabel");
@@ -413,7 +418,8 @@ describe("TransactionsSendTab Component", () => {
       fireEvent.click(button);
 
       await waitFor(() => {
-        expect(setError).toHaveBeenCalledWith("payments.send.noInvoiceToPay");
+        expect(screen.getByText("payments.send.noInvoiceToPay")).toBeInTheDocument();
+        expect(setError).toHaveBeenCalledWith("");
       });
     });
   });


### PR DESCRIPTION
This pull request improves how BOLT11 invoice validation errors are handled and displayed in the wallet's send transaction UI. The changes ensure that validation errors are shown more clearly to users, are not duplicated, and that error state management is more robust. The tests are also updated to reflect the new validation logic and error display behavior.

**User Interface and Validation Improvements:**

* Replaced the `invalidInvoice` boolean state with a `validationError` string in `TransactionsSendTab`, allowing for more precise error messaging and better control over error display. Validation errors are now shown using the actual error message, and error states are reset appropriately on input change and successful payment. (`client/src/components/pages/Store/Wallet/TransactionsSendTab.jsx`) [[1]](diffhunk://#diff-ebb594063f8687579e65fedb66168daa84e70d18c83284a0f1529523ca0f0c23L26-R26) [[2]](diffhunk://#diff-ebb594063f8687579e65fedb66168daa84e70d18c83284a0f1529523ca0f0c23L52-R53) [[3]](diffhunk://#diff-ebb594063f8687579e65fedb66168daa84e70d18c83284a0f1529523ca0f0c23L63-R63) [[4]](diffhunk://#diff-ebb594063f8687579e65fedb66168daa84e70d18c83284a0f1529523ca0f0c23L108-R114)

**Testing Updates:**

* Updated tests to check for the presence of error messages in the UI rather than just verifying calls to `setError`, ensuring that validation errors are displayed to the user as expected. (`client/src/components/pages/Store/Wallet/__tests__/TransactionsSendTab.test.jsx`) [[1]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L98-R99) [[2]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L113-R115) [[3]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L170-R173) [[4]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L185-R189) [[5]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L197-R202) [[6]](diffhunk://#diff-248feaa7338d15eaee977a2d34b078cad728ccef350c64ab29999cc222f99ac6L416-R422)
* Added a new test to verify that BOLT11 validation errors are shown only once, preventing duplicate error messages in the UI. (`client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx`)