### PR TITLE
Refactor/ticket printer

### DIFF
--- a/client/src/components/pages/Store/Settings/TicketTemplate/ElementRow.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplate/ElementRow.jsx
@@ -9,7 +9,7 @@ import { resolveValue } from "@/components/pages/Store/hooks/usePreviewElements"
 
 import { TemplateVariablePicker } from "./VariablePicker";
 
-const VARIABLE_PICKER_TYPES = ["HEADER", "TEXT", "FOOTER"];
+const VARIABLE_PICKER_TYPES = ["HEADER", "TEXT", "FOOTER", "TOTAL_ROW"];
 
 const ELEMENT_TYPES = [
   "HEADER",
@@ -18,6 +18,7 @@ const ELEMENT_TYPES = [
   "SEPARATOR",
   "TABLE_HEADER",
   "TABLE_ROW",
+  "TOTAL_ROW",
   "FOOTER",
   "QRCODE",
 ];
@@ -37,7 +38,7 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
   };
 
   const type = element.type;
-  const showValue = ["HEADER", "TEXT", "FOOTER", "TABLE_HEADER", "QRCODE"].includes(type);
+  const showValue = ["HEADER", "TEXT", "FOOTER", "TABLE_HEADER", "TOTAL_ROW", "QRCODE"].includes(type);
   const showVariablePicker = VARIABLE_PICKER_TYPES.includes(type);
   const showStyle = type !== "LINE_BREAK" && type !== "SEPARATOR";
   const showBold = showStyle && type !== "QRCODE";

--- a/client/src/components/pages/Store/hooks/usePreviewElements.js
+++ b/client/src/components/pages/Store/hooks/usePreviewElements.js
@@ -99,6 +99,22 @@ export function useTicketTemplatePreviewElements(elements, config) {
         });
         return;
       }
+      if (element.type === "TOTAL_ROW") {
+        const label = resolveValue(element.value || "", config).trim() || "TOTAL";
+        output.push(
+          <div key={`${element.localId}-total-sep`} className="border-t border-gray-400 my-2" />,
+        );
+        output.push(
+          <div
+            key={`${element.localId}-total`}
+            className={`flex justify-between gap-3 ${className}`}
+          >
+            <span className="font-semibold">{label}</span>
+            <span className="whitespace-nowrap font-semibold">{sampleTicket.total}</span>
+          </div>,
+        );
+        return;
+      }
       output.push(
         <div key={element.localId} className={className}>
           {resolveValue(element.value || "", config)}

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -711,6 +711,7 @@ const storeEn = {
         SEPARATOR: "Separator",
         TABLE_HEADER: "Table header",
         TABLE_ROW: "Table row",
+        TOTAL_ROW: "Total row",
         FOOTER: "Footer",
         QRCODE: "QR code",
       },

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -711,6 +711,7 @@ const storeEs = {
         SEPARATOR: "Separador",
         TABLE_HEADER: "Encabezado tabla",
         TABLE_ROW: "Fila tabla",
+        TOTAL_ROW: "Fila de total",
         FOOTER: "Pie",
         QRCODE: "Codigo QR",
       },

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
@@ -113,15 +113,7 @@ fun Route.printers(
 
             try {
                 val config = configService.getConfig()
-                printService.printTicket(
-                    request.ticketData,
-                    request.templateName,
-                    request.printerType,
-                    config,
-                    request.printerId,
-                    request.broadcast,
-                    request.forceTemplateName,
-                )
+                printService.printTicket(request, config)
                 call.respondText("Print job sent", status = HttpStatusCode.OK)
             } catch (e: Exception) {
                 throw PrintTicketException(e.message ?: "An unknown error occurred during printing.")

--- a/server/app/src/main/kotlin/pos/ambrosia/models/TicketTemplate.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/TicketTemplate.kt
@@ -37,6 +37,7 @@ enum class ElementType {
     SEPARATOR,
     TABLE_HEADER,
     TABLE_ROW,
+    TOTAL_ROW,
     FOOTER,
     QRCODE,
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
@@ -4,6 +4,7 @@ import com.github.anastaciocintra.escpos.EscPos
 import com.github.anastaciocintra.output.PrinterOutputStream
 import pos.ambrosia.logger
 import pos.ambrosia.models.Config
+import pos.ambrosia.models.PrintRequest
 import pos.ambrosia.models.PrinterType
 import pos.ambrosia.models.TicketData
 import pos.ambrosia.models.TicketTemplate
@@ -32,39 +33,34 @@ class PrintService(
     }
 
     suspend fun printTicket(
-        ticketData: TicketData,
-        templateName: String?,
-        type: PrinterType,
+        request: PrintRequest,
         config: Config?,
-        printerId: String?,
-        broadcast: Boolean,
-        forceTemplateName: Boolean,
     ) {
         val configs =
             when {
-                printerId != null -> {
-                    val configById = printerConfigService.getPrinterConfigById(printerId)
+                request.printerId != null -> {
+                    val configById = printerConfigService.getPrinterConfigById(request.printerId)
                     if (configById == null) {
-                        throw IOException("Printer configuration not found for id '$printerId'.")
+                        throw IOException("Printer configuration not found for id '${request.printerId}'.")
                     }
                     listOf(configById)
                 }
 
-                broadcast -> {
-                    printerConfigService.getEnabledByType(type)
+                request.broadcast -> {
+                    printerConfigService.getEnabledByType(request.printerType)
                 }
 
                 else -> {
-                    val defaultConfig = printerConfigService.getDefaultByType(type)
+                    val defaultConfig = printerConfigService.getDefaultByType(request.printerType)
                     if (defaultConfig == null) {
-                        throw IOException("Default printer for type $type not configured.")
+                        throw IOException("Default printer for type ${request.printerType} not configured.")
                     }
                     listOf(defaultConfig)
                 }
             }
 
         if (configs.isEmpty()) {
-            throw IOException("No printers configured for type $type.")
+            throw IOException("No printers configured for type ${request.printerType}.")
         }
 
         val resolvedConfigs =
@@ -79,54 +75,49 @@ class PrintService(
             }
 
         if (resolvedConfigs.isEmpty()) {
-            throw IOException("No configured printers found on this system for type $type.")
+            throw IOException("No configured printers found on this system for type ${request.printerType}.")
         }
 
-        try {
-            val templateCache = mutableMapOf<String, TicketTemplate>()
-            var successCount = 0
+        val templateCache = mutableMapOf<String, TicketTemplate>()
+        var successCount = 0
 
-            resolvedConfigs.forEach { (configItem, printerService) ->
-                try {
-                    val resolvedTemplateName =
-                        if (forceTemplateName && !templateName.isNullOrBlank()) {
-                            templateName
-                        } else {
-                            configItem.templateName ?: templateName
-                        }
-                    if (resolvedTemplateName.isNullOrBlank()) {
-                        throw IOException("Template not configured for printer ${configItem.printerName}.")
+        resolvedConfigs.forEach { (configItem, printerService) ->
+            try {
+                val resolvedTemplateName =
+                    if (request.forceTemplateName && !request.templateName.isNullOrBlank()) {
+                        request.templateName
+                    } else {
+                        configItem.templateName ?: request.templateName
                     }
-                    val template =
-                        templateCache.getOrPut(resolvedTemplateName) {
-                            ticketTemplateService.getTemplateByName(resolvedTemplateName)
-                                ?: throw IOException("Template '$resolvedTemplateName' not found.")
-                        }
+                if (resolvedTemplateName.isNullOrBlank()) {
+                    throw IOException("Template not configured for printer ${configItem.printerName}.")
+                }
+                val template =
+                    templateCache.getOrPut(resolvedTemplateName) {
+                        ticketTemplateService.getTemplateByName(resolvedTemplateName)
+                            ?: throw IOException("Template '$resolvedTemplateName' not found.")
+                    }
 
-                    val printerOutputStream = PrinterOutputStream(printerService)
-                    val escpos = EscPos(printerOutputStream)
-                    escpos.setCharsetName("cp850")
-                    val ticketFactory = TicketFactory(template)
-                    ticketFactory.build(escpos, ticketData, config)
-                    escpos.feed(5).cut(EscPos.CutMode.FULL)
-                    escpos.close()
-                    successCount += 1
-                } catch (e: Exception) {
-                    logger.error("Failed to print ticket to ${printerService.name}: ${e.message}", e)
-                    if (printerId != null || !broadcast) {
-                        throw e
-                    }
+                val printerOutputStream = PrinterOutputStream(printerService)
+                val escpos = EscPos(printerOutputStream)
+                escpos.setCharsetName(TicketFactory.DEFAULT_CHARSET)
+                val ticketFactory = TicketFactory(template)
+                ticketFactory.build(escpos, request.ticketData, config)
+                escpos.feed(TicketFactory.DEFAULT_FEED_LINES).cut(EscPos.CutMode.FULL)
+                escpos.close()
+                successCount += 1
+            } catch (e: Exception) {
+                logger.error("Failed to print ticket to ${printerService.name}: ${e.message}", e)
+                if (request.printerId != null || !request.broadcast) {
+                    throw e
                 }
             }
-
-            if (successCount == 0) {
-                throw IOException("Failed to print ticket to any configured printer.")
-            }
-
-            logger.info("Successfully sent print job to $type printer(s).")
-        } catch (e: Exception) {
-            logger.error("Failed to print ticket: ${e.message}", e)
-            throw IOException("Failed to print ticket: ${e.message}", e)
         }
+
+        if (successCount == 0) {
+            throw IOException("Failed to print ticket to any configured printer.")
+        }
+
+        logger.info("Successfully sent print job to ${request.printerType} printer(s).")
     }
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PrinterConfigService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PrinterConfigService.kt
@@ -5,6 +5,9 @@ import pos.ambrosia.models.PrinterConfig
 import pos.ambrosia.models.PrinterConfigCreateRequest
 import pos.ambrosia.models.PrinterConfigUpdateRequest
 import pos.ambrosia.models.PrinterType
+import pos.ambrosia.util.executeInTransaction
+import pos.ambrosia.util.toBytes
+import pos.ambrosia.util.toUUID
 import java.sql.Connection
 import java.sql.ResultSet
 import java.util.UUID
@@ -88,8 +91,7 @@ open class PrinterConfigService(
         }
 
         val configId = UUID.randomUUID()
-        connection.autoCommit = false
-        try {
+        return executeInTransaction(connection) {
             if (request.isDefault) {
                 clearDefaultForType(request.printerType)
             }
@@ -104,24 +106,16 @@ open class PrinterConfigService(
                 stmt.executeUpdate()
             }
 
-            connection.commit()
             logger.info("Printer config created: ${request.printerType} ${request.printerName}")
-            return configId.toString()
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to create printer config: ${e.message}")
-            return null
-        } finally {
-            connection.autoCommit = true
+            configId.toString()
         }
     }
 
     suspend fun upsertDefaultByTypeName(
         printerType: PrinterType,
         printerName: String,
-    ): String? {
-        connection.autoCommit = false
-        try {
+    ): String? =
+        executeInTransaction(connection) {
             clearDefaultForType(printerType)
 
             val existing = getPrinterConfigByTypeName(printerType, printerName)
@@ -135,30 +129,21 @@ open class PrinterConfigService(
                     stmt.setBytes(6, UUID.fromString(existing.id).toBytes())
                     stmt.executeUpdate()
                 }
-                connection.commit()
-                return existing.id
+                existing.id
+            } else {
+                val configId = UUID.randomUUID()
+                connection.prepareStatement(ADD_PRINTER_CONFIG).use { stmt ->
+                    stmt.setBytes(1, configId.toBytes())
+                    stmt.setString(2, printerType.name)
+                    stmt.setString(3, printerName)
+                    stmt.setString(4, null)
+                    stmt.setBoolean(5, true)
+                    stmt.setBoolean(6, true)
+                    stmt.executeUpdate()
+                }
+                configId.toString()
             }
-
-            val configId = UUID.randomUUID()
-            connection.prepareStatement(ADD_PRINTER_CONFIG).use { stmt ->
-                stmt.setBytes(1, configId.toBytes())
-                stmt.setString(2, printerType.name)
-                stmt.setString(3, printerName)
-                stmt.setString(4, null)
-                stmt.setBoolean(5, true)
-                stmt.setBoolean(6, true)
-                stmt.executeUpdate()
-            }
-            connection.commit()
-            return configId.toString()
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to upsert default printer config: ${e.message}")
-            return null
-        } finally {
-            connection.autoCommit = true
         }
-    }
 
     suspend fun getPrinterConfigs(): List<PrinterConfig> {
         connection.createStatement().use { stmt ->
@@ -255,31 +240,26 @@ open class PrinterConfigService(
             return PrinterConfigUpdateStatus.CONFLICT
         }
 
-        connection.autoCommit = false
-        try {
-            if (newDefault) {
-                clearDefaultForType(newType)
+        val result =
+            executeInTransaction(connection) {
+                if (newDefault) {
+                    clearDefaultForType(newType)
+                }
+
+                connection.prepareStatement(UPDATE_PRINTER_CONFIG).use { stmt ->
+                    stmt.setString(1, newType.name)
+                    stmt.setString(2, newName)
+                    stmt.setString(3, newTemplateName)
+                    stmt.setBoolean(4, newDefault)
+                    stmt.setBoolean(5, newEnabled)
+                    stmt.setBytes(6, configId.toBytes())
+                    stmt.executeUpdate()
+                }
+
+                PrinterConfigUpdateStatus.UPDATED
             }
 
-            connection.prepareStatement(UPDATE_PRINTER_CONFIG).use { stmt ->
-                stmt.setString(1, newType.name)
-                stmt.setString(2, newName)
-                stmt.setString(3, newTemplateName)
-                stmt.setBoolean(4, newDefault)
-                stmt.setBoolean(5, newEnabled)
-                stmt.setBytes(6, configId.toBytes())
-                stmt.executeUpdate()
-            }
-
-            connection.commit()
-            return PrinterConfigUpdateStatus.UPDATED
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to update printer config: ${e.message}")
-            return PrinterConfigUpdateStatus.CONFLICT
-        } finally {
-            connection.autoCommit = true
-        }
+        return result ?: PrinterConfigUpdateStatus.CONFLICT
     }
 
     suspend fun deletePrinterConfig(id: String): Boolean {
@@ -299,22 +279,14 @@ open class PrinterConfigService(
 
     suspend fun setDefault(id: String): Boolean {
         val config = getPrinterConfigById(id) ?: return false
-        connection.autoCommit = false
-        try {
+        return executeInTransaction(connection) {
             clearDefaultForType(config.printerType)
             connection.prepareStatement(SET_DEFAULT_BY_ID).use { stmt ->
                 stmt.setBytes(1, UUID.fromString(id).toBytes())
                 stmt.executeUpdate()
             }
-            connection.commit()
-            return true
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to set default printer config: ${e.message}")
-            return false
-        } finally {
-            connection.autoCommit = true
-        }
+            true
+        } ?: false
     }
 
     private fun mapPrinterConfig(rs: ResultSet): PrinterConfig =

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TicketFactory.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TicketFactory.kt
@@ -19,7 +19,6 @@ import pos.ambrosia.models.FontSize
 import pos.ambrosia.models.ImageSize
 import pos.ambrosia.models.Justification
 import pos.ambrosia.models.TicketData
-import pos.ambrosia.models.TicketDataItem
 import pos.ambrosia.models.TicketTemplate
 import pos.ambrosia.util.formatTicketLine
 import java.awt.image.BufferedImage
@@ -28,18 +27,24 @@ import java.util.EnumMap
 class TicketFactory(
     private val template: TicketTemplate,
 ) {
-    private val qrImageSizeByFontSize =
-        mapOf(
-            FontSize.NORMAL to ImageSize.SMALL,
-            FontSize.LARGE to ImageSize.MEDIUM,
-            FontSize.EXTRA_LARGE to ImageSize.LARGE,
-        )
-    private val qrImageSizePxByImageSize =
-        mapOf(
-            ImageSize.SMALL to 300,
-            ImageSize.MEDIUM to 360,
-            ImageSize.LARGE to 420,
-        )
+    companion object {
+        const val DEFAULT_TICKET_WIDTH = 48
+        const val DEFAULT_FEED_LINES = 5
+        const val DEFAULT_CHARSET = "cp850"
+
+        private val QR_IMAGE_SIZE_BY_FONT_SIZE =
+            mapOf(
+                FontSize.NORMAL to ImageSize.SMALL,
+                FontSize.LARGE to ImageSize.MEDIUM,
+                FontSize.EXTRA_LARGE to ImageSize.LARGE,
+            )
+        private val QR_IMAGE_SIZE_PX =
+            mapOf(
+                ImageSize.SMALL to 300,
+                ImageSize.MEDIUM to 360,
+                ImageSize.LARGE to 420,
+            )
+    }
 
     fun build(
         escpos: EscPos,
@@ -52,7 +57,7 @@ class TicketFactory(
 
             when (element.type) {
                 ElementType.SEPARATOR -> {
-                    escpos.writeLF(style, content.repeat(48))
+                    escpos.writeLF(style, content.repeat(DEFAULT_TICKET_WIDTH))
                 }
 
                 ElementType.TABLE_HEADER -> {
@@ -71,38 +76,17 @@ class TicketFactory(
                     }
                 }
 
+                ElementType.TOTAL_ROW -> {
+                    val label = content.ifEmpty { "TOTAL" }
+                    val row = formatTicketLine(label, data.total.toString())
+                    escpos.writeLF(style, "-".repeat(DEFAULT_TICKET_WIDTH))
+                    escpos.writeLF(style, row)
+                }
+
                 ElementType.QRCODE -> {
                     val qrContent = if (content.isNotBlank()) content else (data.invoice ?: "")
                     if (qrContent.isNotBlank()) {
-                        val imageSize = qrImageSizeByFontSize[element.style?.fontSize ?: FontSize.NORMAL] ?: ImageSize.SMALL
-                        val sizePx = qrImageSizePxByImageSize[imageSize] ?: 300
-                        logger.info("Printing QR image: sizePx=$sizePx, contentLength=${qrContent.length}")
-                        try {
-                            val hints = EnumMap<EncodeHintType, Any>(EncodeHintType::class.java)
-                            hints[EncodeHintType.ERROR_CORRECTION] = ErrorCorrectionLevel.M
-                            hints[EncodeHintType.MARGIN] = 1
-                            val bitMatrix = QRCodeWriter().encode(qrContent, BarcodeFormat.QR_CODE, sizePx, sizePx, hints)
-                            val image = BufferedImage(bitMatrix.width, bitMatrix.height, BufferedImage.TYPE_INT_RGB)
-                            for (x in 0 until bitMatrix.width) {
-                                for (y in 0 until bitMatrix.height) {
-                                    image.setRGB(x, y, if (bitMatrix.get(x, y)) 0x000000 else 0xFFFFFF)
-                                }
-                            }
-                            val escPosImage = EscPosImage(CoffeeImageImpl(image), BitonalThreshold())
-                            val wrapper = RasterBitImageWrapper()
-                            wrapper.setJustification(
-                                when (element.style?.justification ?: Justification.LEFT) {
-                                    Justification.LEFT -> EscPosConst.Justification.Left_Default
-                                    Justification.CENTER -> EscPosConst.Justification.Center
-                                    Justification.RIGHT -> EscPosConst.Justification.Right
-                                },
-                            )
-                            escpos.write(wrapper, escPosImage)
-                            escpos.feed(1)
-                        } catch (e: Exception) {
-                            logger.error("Failed to print QR image: ${e.message}", e)
-                            escpos.writeLF(style, qrContent)
-                        }
+                        writeQrCode(escpos, qrContent, element.style)
                     }
                 }
 
@@ -113,36 +97,76 @@ class TicketFactory(
         }
     }
 
-    private fun resolveValue(
-        value: String,
-        item: TicketDataItem,
-    ): String =
-        value
-            .replace("{{item.quantity}}", item.quantity.toString())
-            .replace("{{item.name}}", item.name)
-            .replace("{{item.price}}", item.price.toString())
+    private fun writeQrCode(
+        escpos: EscPos,
+        content: String,
+        elementStyle: ElementStyle?,
+    ) {
+        val fontSize = elementStyle?.fontSize ?: FontSize.NORMAL
+        val imageSize = QR_IMAGE_SIZE_BY_FONT_SIZE[fontSize] ?: ImageSize.SMALL
+        val sizePx = QR_IMAGE_SIZE_PX[imageSize] ?: 300
+
+        logger.info("Printing QR image: sizePx=$sizePx, contentLength=${content.length}")
+        try {
+            val hints = EnumMap<EncodeHintType, Any>(EncodeHintType::class.java)
+            hints[EncodeHintType.ERROR_CORRECTION] = ErrorCorrectionLevel.M
+            hints[EncodeHintType.MARGIN] = 1
+            val bitMatrix = QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, sizePx, sizePx, hints)
+            val image = BufferedImage(bitMatrix.width, bitMatrix.height, BufferedImage.TYPE_INT_RGB)
+            for (x in 0 until bitMatrix.width) {
+                for (y in 0 until bitMatrix.height) {
+                    image.setRGB(x, y, if (bitMatrix.get(x, y)) 0x000000 else 0xFFFFFF)
+                }
+            }
+            val escPosImage = EscPosImage(CoffeeImageImpl(image), BitonalThreshold())
+            val wrapper = RasterBitImageWrapper()
+            wrapper.setJustification(
+                when (elementStyle?.justification ?: Justification.LEFT) {
+                    Justification.LEFT -> EscPosConst.Justification.Left_Default
+                    Justification.CENTER -> EscPosConst.Justification.Center
+                    Justification.RIGHT -> EscPosConst.Justification.Right
+                },
+            )
+            escpos.write(wrapper, escPosImage)
+            escpos.feed(1)
+        } catch (e: Exception) {
+            logger.error("Failed to print QR image: ${e.message}", e)
+            val fallbackStyle = convertToEscPosStyle(elementStyle)
+            escpos.writeLF(fallbackStyle, content)
+        }
+    }
 
     private fun resolveValue(
         value: String,
         data: TicketData,
         config: Config?,
     ): String {
+        val replacements = buildReplacementMap(data, config)
         var resolved = value
-        config?.let {
-            resolved = resolved.replace("{{config.businessName}}", it.businessName)
-            resolved = resolved.replace("{{config.businessAddress}}", it.businessAddress ?: "")
-            resolved = resolved.replace("{{config.businessPhone}}", it.businessPhone ?: "")
-            resolved = resolved.replace("{{config.businessEmail}}", it.businessEmail ?: "")
+        replacements.forEach { (placeholder, replacement) ->
+            resolved = resolved.replace(placeholder, replacement)
         }
-
         return resolved
-            .replace("{{ticket.id}}", data.ticketId)
-            .replace("{{ticket.tableName}}", data.tableName)
-            .replace("{{ticket.roomName}}", data.roomName)
-            .replace("{{ticket.date}}", data.date)
-            .replace("{{ticket.total}}", data.total.toString())
-            .replace("{{ticket.invoice}}", data.invoice ?: "")
     }
+
+    private fun buildReplacementMap(
+        data: TicketData,
+        config: Config?,
+    ): Map<String, String> =
+        buildMap {
+            put("{{ticket.id}}", data.ticketId)
+            put("{{ticket.tableName}}", data.tableName)
+            put("{{ticket.roomName}}", data.roomName)
+            put("{{ticket.date}}", data.date)
+            put("{{ticket.total}}", data.total.toString())
+            put("{{ticket.invoice}}", data.invoice ?: "")
+            config?.let {
+                put("{{config.businessName}}", it.businessName)
+                put("{{config.businessAddress}}", it.businessAddress ?: "")
+                put("{{config.businessPhone}}", it.businessPhone ?: "")
+                put("{{config.businessEmail}}", it.businessEmail ?: "")
+            }
+        }
 
     private fun convertToEscPosStyle(elementStyle: ElementStyle?): Style {
         val escposStyle = Style()

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TicketPaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TicketPaymentService.kt
@@ -37,7 +37,7 @@ class TicketPaymentService(
         return resultSet.next()
     }
 
-    suspend fun addTicketPayment(ticketPayment: pos.ambrosia.models.TicketPayment): Boolean {
+    suspend fun addTicketPayment(ticketPayment: TicketPayment): Boolean {
         // Validar que los IDs no estén vacíos
         if (ticketPayment.payment_id.isBlank() || ticketPayment.ticket_id.isBlank()) {
             logger.error("Payment ID and ticket ID are required fields")
@@ -73,16 +73,16 @@ class TicketPaymentService(
         }
     }
 
-    suspend fun getTicketPaymentsByTicket(ticketId: String): List<pos.ambrosia.models.TicketPayment>? {
+    suspend fun getTicketPaymentsByTicket(ticketId: String): List<TicketPayment>? {
         if (!ticketExists(ticketId)) return null
         val statement = connection.prepareStatement(GET_TICKET_PAYMENTS_BY_TICKET)
         statement.setString(1, ticketId)
         val resultSet = statement.executeQuery()
-        val ticketPayments = mutableListOf<pos.ambrosia.models.TicketPayment>()
+        val ticketPayments = mutableListOf<TicketPayment>()
 
         while (resultSet.next()) {
             val ticketPayment =
-                pos.ambrosia.models.TicketPayment(
+                TicketPayment(
                     payment_id = resultSet.getString("payment_id"),
                     ticket_id = resultSet.getString("ticket_id"),
                 )
@@ -93,16 +93,16 @@ class TicketPaymentService(
         return ticketPayments
     }
 
-    suspend fun getTicketPaymentsByPayment(paymentId: String): List<pos.ambrosia.models.TicketPayment>? {
+    suspend fun getTicketPaymentsByPayment(paymentId: String): List<TicketPayment>? {
         if (!paymentExists(paymentId)) return null
         val statement = connection.prepareStatement(GET_TICKET_PAYMENTS_BY_PAYMENT)
         statement.setString(1, paymentId)
         val resultSet = statement.executeQuery()
-        val ticketPayments = mutableListOf<pos.ambrosia.models.TicketPayment>()
+        val ticketPayments = mutableListOf<TicketPayment>()
 
         while (resultSet.next()) {
             val ticketPayment =
-                pos.ambrosia.models.TicketPayment(
+                TicketPayment(
                     payment_id = resultSet.getString("payment_id"),
                     ticket_id = resultSet.getString("ticket_id"),
                 )

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TicketPaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TicketPaymentService.kt
@@ -8,7 +8,6 @@ class TicketPaymentService(
     private val connection: Connection,
 ) {
     companion object {
-        // Ticket payment queries
         private const val ADD_TICKET_PAYMENT =
             "INSERT INTO ticket_payments (payment_id, ticket_id) VALUES (?, ?)"
         private const val GET_TICKET_PAYMENTS_BY_TICKET =
@@ -38,19 +37,16 @@ class TicketPaymentService(
     }
 
     suspend fun addTicketPayment(ticketPayment: TicketPayment): Boolean {
-        // Validar que los IDs no estén vacíos
         if (ticketPayment.payment_id.isBlank() || ticketPayment.ticket_id.isBlank()) {
             logger.error("Payment ID and ticket ID are required fields")
             return false
         }
 
-        // Verificar que el ticket exista
         if (!ticketExists(ticketPayment.ticket_id)) {
             logger.error("Ticket ID does not exist: ${ticketPayment.ticket_id}")
             return false
         }
 
-        // Verificar que el payment exista
         if (!paymentExists(ticketPayment.payment_id)) {
             logger.error("Payment ID does not exist: ${ticketPayment.payment_id}")
             return false

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TicketService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TicketService.kt
@@ -39,27 +39,36 @@ class TicketService(
         return resultSet.next()
     }
 
-    private fun isValidStatus(status: Int): Boolean {
-        // Asumiendo que 1 = activo, 0 = inactivo o cancelado
-        return status in 0..1
+    private fun isValidStatus(status: Int): Boolean = status in 0..1
+
+    private fun validateTicket(ticket: Ticket): String? {
+        if (!orderExists(ticket.order_id)) {
+            return "Order does not exist: ${ticket.order_id}"
+        }
+        if (!userExists(ticket.user_id)) {
+            return "User does not exist: ${ticket.user_id}"
+        }
+        if (!isValidStatus(ticket.status)) {
+            return "Invalid ticket status: ${ticket.status}"
+        }
+        return null
     }
 
+    private fun mapResultSetToTicket(rs: java.sql.ResultSet): Ticket =
+        Ticket(
+            id = rs.getString("id"),
+            order_id = rs.getString("order_id"),
+            user_id = rs.getString("user_id"),
+            ticket_date = rs.getString("ticket_date"),
+            status = rs.getInt("status"),
+            total_amount = rs.getDouble("total_amount"),
+            notes = rs.getString("notes"),
+        )
+
     suspend fun addTicket(ticket: Ticket): String? {
-        // Verificar que la orden existe
-        if (!orderExists(ticket.order_id)) {
-            logger.error("Order does not exist: ${ticket.order_id}")
-            return null
-        }
-
-        // Verificar que el usuario existe
-        if (!userExists(ticket.user_id)) {
-            logger.error("User does not exist: ${ticket.user_id}")
-            return null
-        }
-
-        // Validar status
-        if (!isValidStatus(ticket.status)) {
-            logger.error("Invalid ticket status: ${ticket.status}")
+        val validationError = validateTicket(ticket)
+        if (validationError != null) {
+            logger.error(validationError)
             return null
         }
 
@@ -100,17 +109,7 @@ class TicketService(
         val resultSet = statement.executeQuery()
         val tickets = mutableListOf<Ticket>()
         while (resultSet.next()) {
-            val ticket =
-                Ticket(
-                    id = resultSet.getString("id"),
-                    order_id = resultSet.getString("order_id"),
-                    user_id = resultSet.getString("user_id"),
-                    ticket_date = resultSet.getString("ticket_date"),
-                    status = resultSet.getInt("status"),
-                    total_amount = resultSet.getDouble("total_amount"),
-                    notes = resultSet.getString("notes"),
-                )
-            tickets.add(ticket)
+            tickets.add(mapResultSetToTicket(resultSet))
         }
         logger.info("Retrieved ${tickets.size} tickets")
         return tickets
@@ -121,15 +120,7 @@ class TicketService(
         statement.setString(1, id)
         val resultSet = statement.executeQuery()
         return if (resultSet.next()) {
-            Ticket(
-                id = resultSet.getString("id"),
-                order_id = resultSet.getString("order_id"),
-                user_id = resultSet.getString("user_id"),
-                ticket_date = resultSet.getString("ticket_date"),
-                status = resultSet.getInt("status"),
-                total_amount = resultSet.getDouble("total_amount"),
-                notes = resultSet.getString("notes"),
-            )
+            mapResultSetToTicket(resultSet)
         } else {
             logger.warn("Ticket not found with ID: $id")
             null
@@ -142,17 +133,7 @@ class TicketService(
         val resultSet = statement.executeQuery()
         val tickets = mutableListOf<Ticket>()
         while (resultSet.next()) {
-            val ticket =
-                Ticket(
-                    id = resultSet.getString("id"),
-                    order_id = resultSet.getString("order_id"),
-                    user_id = resultSet.getString("user_id"),
-                    ticket_date = resultSet.getString("ticket_date"),
-                    status = resultSet.getInt("status"),
-                    total_amount = resultSet.getDouble("total_amount"),
-                    notes = resultSet.getString("notes"),
-                )
-            tickets.add(ticket)
+            tickets.add(mapResultSetToTicket(resultSet))
         }
         logger.info("Retrieved ${tickets.size} tickets for order: $orderId")
         return tickets
@@ -164,17 +145,7 @@ class TicketService(
         val resultSet = statement.executeQuery()
         val tickets = mutableListOf<Ticket>()
         while (resultSet.next()) {
-            val ticket =
-                Ticket(
-                    id = resultSet.getString("id"),
-                    order_id = resultSet.getString("order_id"),
-                    user_id = resultSet.getString("user_id"),
-                    ticket_date = resultSet.getString("ticket_date"),
-                    status = resultSet.getInt("status"),
-                    total_amount = resultSet.getDouble("total_amount"),
-                    notes = resultSet.getString("notes"),
-                )
-            tickets.add(ticket)
+            tickets.add(mapResultSetToTicket(resultSet))
         }
         logger.info("Retrieved ${tickets.size} tickets for user: $userId")
         return tickets
@@ -186,21 +157,9 @@ class TicketService(
             return false
         }
 
-        // Verificar que la orden existe
-        if (!orderExists(ticket.order_id)) {
-            logger.error("Order does not exist: ${ticket.order_id}")
-            return false
-        }
-
-        // Verificar que el usuario existe
-        if (!userExists(ticket.user_id)) {
-            logger.error("User does not exist: ${ticket.user_id}")
-            return false
-        }
-
-        // Validar status
-        if (!isValidStatus(ticket.status)) {
-            logger.error("Invalid ticket status: ${ticket.status}")
+        val validationError = validateTicket(ticket)
+        if (validationError != null) {
+            logger.error(validationError)
             return false
         }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TicketTemplateService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TicketTemplateService.kt
@@ -8,6 +8,9 @@ import pos.ambrosia.models.Justification
 import pos.ambrosia.models.TicketElement
 import pos.ambrosia.models.TicketTemplate
 import pos.ambrosia.models.TicketTemplateRequest
+import pos.ambrosia.util.executeInTransaction
+import pos.ambrosia.util.toBytes
+import pos.ambrosia.util.toUUID
 import java.sql.Connection
 import java.sql.ResultSet
 import java.util.UUID
@@ -26,8 +29,8 @@ open class TicketTemplateService(
         private const val CHECK_TEMPLATE_NAME_EXISTS_EXCLUDING_ID = "SELECT id FROM ticket_templates WHERE name = ? AND id != ?"
 
         private const val ADD_ELEMENT = """
-            INSERT INTO ticket_template_elements 
-            (id, template_id, element_order, type, value, style_bold, style_justification, style_font_size) 
+            INSERT INTO ticket_template_elements
+            (id, template_id, element_order, type, value, style_bold, style_justification, style_font_size)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """
         private const val GET_ELEMENTS_BY_TEMPLATE_ID = """
@@ -56,6 +59,25 @@ open class TicketTemplateService(
         }
     }
 
+    private fun insertElements(
+        templateId: UUID,
+        elements: List<pos.ambrosia.models.TicketElementCreateRequest>,
+    ) {
+        elements.forEachIndexed { index, elementRequest ->
+            connection.prepareStatement(ADD_ELEMENT).use { stmt ->
+                stmt.setBytes(1, UUID.randomUUID().toBytes())
+                stmt.setBytes(2, templateId.toBytes())
+                stmt.setInt(3, index)
+                stmt.setString(4, elementRequest.type.name)
+                stmt.setString(5, elementRequest.value)
+                stmt.setBoolean(6, elementRequest.style?.bold ?: false)
+                stmt.setString(7, (elementRequest.style?.justification ?: Justification.LEFT).name)
+                stmt.setString(8, (elementRequest.style?.fontSize ?: FontSize.NORMAL).name)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
     suspend fun addTemplate(request: TicketTemplateRequest): String? {
         if (templateNameExists(request.name)) {
             logger.error("Template name already exists: ${request.name}")
@@ -63,36 +85,17 @@ open class TicketTemplateService(
         }
 
         val templateId = UUID.randomUUID()
-        connection.autoCommit = false
-        try {
+        return executeInTransaction(connection) {
             connection.prepareStatement(ADD_TEMPLATE).use { stmt ->
                 stmt.setBytes(1, templateId.toBytes())
                 stmt.setString(2, request.name)
                 stmt.executeUpdate()
             }
 
-            request.elements.forEachIndexed { index, elementRequest ->
-                connection.prepareStatement(ADD_ELEMENT).use { stmt ->
-                    stmt.setBytes(1, UUID.randomUUID().toBytes())
-                    stmt.setBytes(2, templateId.toBytes())
-                    stmt.setInt(3, index)
-                    stmt.setString(4, elementRequest.type.name)
-                    stmt.setString(5, elementRequest.value)
-                    stmt.setBoolean(6, elementRequest.style?.bold ?: false)
-                    stmt.setString(7, (elementRequest.style?.justification ?: Justification.LEFT).name)
-                    stmt.setString(8, (elementRequest.style?.fontSize ?: FontSize.NORMAL).name)
-                    stmt.executeUpdate()
-                }
-            }
-            connection.commit()
+            insertElements(templateId, request.elements)
+
             logger.info("Template created successfully with ID: $templateId")
-            return templateId.toString()
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to create template: ${e.message}")
-            return null
-        } finally {
-            connection.autoCommit = true
+            templateId.toString()
         }
     }
 
@@ -157,8 +160,7 @@ open class TicketTemplateService(
             return false
         }
 
-        connection.autoCommit = false
-        try {
+        return executeInTransaction(connection) {
             connection.prepareStatement(UPDATE_TEMPLATE).use { stmt ->
                 stmt.setString(1, request.name)
                 stmt.setBytes(2, templateId.toBytes())
@@ -170,29 +172,11 @@ open class TicketTemplateService(
                 stmt.executeUpdate()
             }
 
-            request.elements.forEachIndexed { index, elementRequest ->
-                connection.prepareStatement(ADD_ELEMENT).use { stmt ->
-                    stmt.setBytes(1, UUID.randomUUID().toBytes())
-                    stmt.setBytes(2, templateId.toBytes())
-                    stmt.setInt(3, index)
-                    stmt.setString(4, elementRequest.type.name)
-                    stmt.setString(5, elementRequest.value)
-                    stmt.setBoolean(6, elementRequest.style?.bold ?: false)
-                    stmt.setString(7, (elementRequest.style?.justification ?: Justification.LEFT).name)
-                    stmt.setString(8, (elementRequest.style?.fontSize ?: FontSize.NORMAL).name)
-                    stmt.executeUpdate()
-                }
-            }
-            connection.commit()
+            insertElements(templateId, request.elements)
+
             logger.info("Template updated successfully: $id")
-            return true
-        } catch (e: Exception) {
-            connection.rollback()
-            logger.error("Failed to update template $id: ${e.message}")
-            return false
-        } finally {
-            connection.autoCommit = true
-        }
+            true
+        } ?: false
     }
 
     suspend fun deleteTemplate(id: String): Boolean {
@@ -252,19 +236,4 @@ open class TicketTemplateService(
                     fontSize = FontSize.valueOf(rs.getString("style_font_size")),
                 ),
         )
-}
-
-fun UUID.toBytes(): ByteArray {
-    val byteArray = ByteArray(16)
-    val bb = java.nio.ByteBuffer.wrap(byteArray)
-    bb.putLong(this.mostSignificantBits)
-    bb.putLong(this.leastSignificantBits)
-    return byteArray
-}
-
-fun ByteArray.toUUID(): UUID {
-    val bb = java.nio.ByteBuffer.wrap(this)
-    val mostSigBits = bb.getLong()
-    val leastSigBits = bb.getLong()
-    return UUID(mostSigBits, leastSigBits)
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/util/TransactionHelper.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/TransactionHelper.kt
@@ -1,0 +1,22 @@
+package pos.ambrosia.util
+
+import pos.ambrosia.logger
+import java.sql.Connection
+
+inline fun <T> executeInTransaction(
+    connection: Connection,
+    block: () -> T,
+): T? {
+    connection.autoCommit = false
+    return try {
+        val result = block()
+        connection.commit()
+        result
+    } catch (e: Exception) {
+        connection.rollback()
+        logger.error("Transaction failed: ${e.message}")
+        null
+    } finally {
+        connection.autoCommit = true
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/util/UuidExtensions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/UuidExtensions.kt
@@ -1,0 +1,18 @@
+package pos.ambrosia.util
+
+import java.util.UUID
+
+fun UUID.toBytes(): ByteArray {
+    val byteArray = ByteArray(16)
+    val bb = java.nio.ByteBuffer.wrap(byteArray)
+    bb.putLong(this.mostSignificantBits)
+    bb.putLong(this.leastSignificantBits)
+    return byteArray
+}
+
+fun ByteArray.toUUID(): UUID {
+    val bb = java.nio.ByteBuffer.wrap(this)
+    val mostSigBits = bb.getLong()
+    val leastSigBits = bb.getLong()
+    return UUID(mostSigBits, leastSigBits)
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PrintServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PrintServiceTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import pos.ambrosia.models.PrintRequest
 import pos.ambrosia.models.PrinterType
 import pos.ambrosia.models.TicketData
 import pos.ambrosia.services.PrintService
@@ -41,15 +42,16 @@ class PrintServiceTest {
         runBlocking {
             doReturn(null).whenever(printerConfigService).getDefaultByType(PrinterType.KITCHEN)
             assertFailsWith<IOException> {
-                printService.printTicket(
-                    ticketData,
-                    "Default",
-                    PrinterType.KITCHEN,
-                    null,
-                    null,
-                    false,
-                    false,
-                )
+                val request =
+                    PrintRequest(
+                        templateName = "Default",
+                        ticketData = ticketData,
+                        printerType = PrinterType.KITCHEN,
+                        printerId = null,
+                        broadcast = false,
+                        forceTemplateName = false,
+                    )
+                printService.printTicket(request, null)
             }
         }
     }


### PR DESCRIPTION
This pull request introduces support for a new "TOTAL_ROW" element type in the ticket template system, allowing tickets to display a total row with a label and value. Additionally, the pull request refactors the printer configuration service to use a more robust transaction management utility, and improves maintainability by centralizing ticket printing constants. Below are the most important changes:

---

**Ticket Template Enhancements:**

* Added "TOTAL_ROW" as a supported element type throughout the frontend and backend, allowing users to include a total row in ticket templates (`ElementRow.jsx`, `usePreviewElements.js`, `TicketTemplate.kt`, translations). [[1]](diffhunk://#diff-f36760892304d4ab49ace7569b00385f798190f957a027493cf9860093ca4bdfL12-R12) [[2]](diffhunk://#diff-f36760892304d4ab49ace7569b00385f798190f957a027493cf9860093ca4bdfR21) [[3]](diffhunk://#diff-f36760892304d4ab49ace7569b00385f798190f957a027493cf9860093ca4bdfL40-R41) [[4]](diffhunk://#diff-ad75d7f22c5eea8a1ef6c6ed0526996fb3d4ce5b5cfcb542da3bbe6650280687R102-R117) [[5]](diffhunk://#diff-cd6cabb661b4c8b90544c74da065b262bdcc623769c53a5f7b5997be352ee0b9R714) [[6]](diffhunk://#diff-0f917a2928a34900c8f92c10bf21b0ab2d161d381bf8d29e56e3209ab3e5647aR714) [[7]](diffhunk://#diff-7c90037db9522255b4794fcd22b5f93e6bee050175c18da5324626e8122b5295R40)

* Updated the ticket preview and rendering logic to display the total row with a label and the sample ticket total, including a separator line.

**Printing Logic and Configuration Refactor:**

* Refactored the `PrintService.printTicket` method to accept a `PrintRequest` object instead of multiple parameters, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-cd5f6b9af77a1a3a4a8d02f8266c2b87ab66aae5eccfa14d2379e8e63825c64fL116-R116) [[2]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877R7) [[3]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877L35-R63) [[4]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877L82-R90) [[5]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877L108-R111) [[6]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877L126-R121)

* Centralized ticket printing constants (such as default charset and feed lines) in the `TicketFactory` companion object and updated usages accordingly. [[1]](diffhunk://#diff-72b6aaa0033994dece51679907c66d693725a6a98de38f039b84b515dd20b475L31-R47) [[2]](diffhunk://#diff-72b6aaa0033994dece51679907c66d693725a6a98de38f039b84b515dd20b475L55-R60) [[3]](diffhunk://#diff-622c8afc5f71b98b88db12bcbaabdbd878be318c78def423fede427fa3d76877L108-R111)

**Printer Configuration Service Improvements:**

* Replaced manual transaction management in `PrinterConfigService` with a new `executeInTransaction` utility, reducing boilerplate and improving error handling for create, update, and set default operations. [[1]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eR8-R10) [[2]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL91-R94) [[3]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL107-R118) [[4]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL138-R133) [[5]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL152-R144) [[6]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL258-R244) [[7]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL274-R262) [[8]](diffhunk://#diff-9abcf7a1626169204bee2b9496f1ee5b9cf416257036e7f89753ced7eb1d4f0eL302-R289)

---

These changes make the ticket templating system more flexible and robust, while also improving the reliability and maintainability of printer configuration and ticket printing operations.

---

**Screnshot:**
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/aa2a1356-afa4-41b6-b4fd-643550c52443" />
