### PR TITLE
Fix/cart invoice

### DIFF
--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useBitcoinInvoice.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useBitcoinInvoice.test.jsx
@@ -13,7 +13,7 @@ jest.mock("@/services/bitcoinPriceService", () => jest.fn().mockImplementation((
 );
 
 jest.mock("@/services/walletService", () => ({
-  createInvoice: (...args) => mockCreateInvoice(...args),
+  createInvoiceForCart: (...args) => mockCreateInvoice(...args),
 }));
 
 let latestState = {};

--- a/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import BitcoinPriceService from "@/services/bitcoinPriceService";
-import { createInvoice } from "@/services/walletService";
+import { createInvoiceForCart } from "@/services/walletService";
 
 const priceService = new BitcoinPriceService();
 
@@ -37,7 +37,7 @@ export function useBitcoinInvoice({
         currencyAcronym.toLowerCase(),
       );
       const fallbackDescription = paymentId || `btc-${Date.now()}`;
-      const createdInvoice = await createInvoice(
+      const createdInvoice = await createInvoiceForCart(
         sats,
         invoiceDescription || fallbackDescription,
       );

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -1,0 +1,271 @@
+jest.mock("@/lib/http/httpClient", () => ({
+  httpClient: jest.fn(),
+}));
+
+jest.mock("@/lib/http/parseJsonResponse", () => ({
+  parseJsonResponse: jest.fn(),
+}));
+
+import { httpClient } from "@/lib/http/httpClient";
+import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
+
+import {
+  loginWallet,
+  logoutWallet,
+  getInfo,
+  createInvoiceForCart,
+  createInvoice,
+  payInvoiceFromService,
+  getIncomingTransactions,
+  getOutgoingTransactions,
+  getSeed,
+  closeChannel,
+} from "../walletService";
+
+function makeResponse(status, ok = true) {
+  return { status, ok };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("walletService", () => {
+  describe("loginWallet", () => {
+    it("calls /wallet/auth with password in body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ token: "abc" });
+
+      await loginWallet("secret");
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: "secret" }),
+      });
+    });
+
+    it("returns parsed response", async () => {
+      const data = { token: "abc" };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(data);
+
+      const result = await loginWallet("secret");
+
+      expect(result).toEqual(data);
+    });
+  });
+
+  describe("logoutWallet", () => {
+    it("calls /wallet/logout with POST", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(null);
+
+      await logoutWallet();
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/logout", { method: "POST" });
+    });
+  });
+
+  describe("getInfo", () => {
+    it("calls /wallet/getinfo", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ nodeId: "abc" });
+
+      await getInfo();
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/getinfo");
+    });
+
+    it("returns node info", async () => {
+      const info = { nodeId: "abc123", channels: [] };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(info);
+
+      const result = await getInfo();
+
+      expect(result).toEqual(info);
+    });
+  });
+
+  describe("createInvoiceForCart", () => {
+    it("calls /wallet/invoice with correct body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ serialized: "lnbc..." });
+
+      await createInvoiceForCart(1000, "Order #42");
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/invoice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "Order #42", amountSat: 1000 }),
+      });
+    });
+
+    it("parses amountSat as integer", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(null);
+
+      await createInvoiceForCart("500", "desc");
+
+      const body = JSON.parse(httpClient.mock.calls[0][1].body);
+      expect(body.amountSat).toBe(500);
+    });
+
+    it("returns the created invoice", async () => {
+      const invoice = { serialized: "lnbc...", paymentHash: "hash-abc" };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(invoice);
+
+      const result = await createInvoiceForCart(1000, "desc");
+
+      expect(result).toEqual(invoice);
+    });
+  });
+
+  describe("createInvoice", () => {
+    it("calls /wallet/createinvoice with correct body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ serialized: "lnbc..." });
+
+      await createInvoice(2000, "Wallet invoice");
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/createinvoice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "Wallet invoice", amountSat: 2000 }),
+      });
+    });
+
+    it("returns the created invoice", async () => {
+      const invoice = { serialized: "lnbc...", paymentHash: "hash-xyz" };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(invoice);
+
+      const result = await createInvoice(2000, "desc");
+
+      expect(result).toEqual(invoice);
+    });
+  });
+
+  describe("payInvoiceFromService", () => {
+    it("calls /wallet/payinvoice with trimmed invoice", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({});
+
+      await payInvoiceFromService("  lnbc...  ");
+
+      const body = JSON.parse(httpClient.mock.calls[0][1].body);
+      expect(body.invoice).toBe("lnbc...");
+    });
+
+    it("uses POST method", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({});
+
+      await payInvoiceFromService("lnbc...");
+
+      expect(httpClient.mock.calls[0][1].method).toBe("POST");
+    });
+  });
+
+  describe("getIncomingTransactions", () => {
+    it("calls /wallet/payments/incoming", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue([]);
+
+      await getIncomingTransactions();
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/payments/incoming");
+    });
+
+    it("returns transactions list", async () => {
+      const txs = [{ paymentId: "1" }, { paymentId: "2" }];
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(txs);
+
+      const result = await getIncomingTransactions();
+
+      expect(result).toEqual(txs);
+    });
+
+    it("returns empty array when response is null", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(null);
+
+      const result = await getIncomingTransactions();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getOutgoingTransactions", () => {
+    it("calls /wallet/payments/outgoing", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue([]);
+
+      await getOutgoingTransactions();
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/payments/outgoing");
+    });
+
+    it("returns empty array when response is null", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(null);
+
+      const result = await getOutgoingTransactions();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getSeed", () => {
+    it("calls /wallet/seed", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ seed: "word1 word2" });
+
+      await getSeed();
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/seed");
+    });
+  });
+
+  describe("closeChannel", () => {
+    it("calls /wallet/closechannel with correct body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({});
+
+      await closeChannel("ch-1", "bc1qxyz", 5);
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/closechannel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channelId: "ch-1", address: "bc1qxyz", feerateSatByte: 5 }),
+      });
+    });
+
+    it("throws with server message when response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(400, false));
+      parseJsonResponse.mockResolvedValue({ message: "Channel not found" });
+
+      await expect(closeChannel("ch-1", "bc1qxyz", 5)).rejects.toThrow("Channel not found");
+    });
+
+    it("throws fallback message when server provides no message", async () => {
+      httpClient.mockResolvedValue(makeResponse(500, false));
+      parseJsonResponse.mockResolvedValue({});
+
+      await expect(closeChannel("ch-1", "bc1qxyz", 5)).rejects.toThrow("Failed to close channel");
+    });
+
+    it("returns result when response is ok", async () => {
+      const result = { status: "closed" };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(result);
+
+      const res = await closeChannel("ch-1", "bc1qxyz", 5);
+
+      expect(res).toEqual(result);
+    });
+  });
+});

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -22,6 +22,20 @@ export async function getInfo() {
   return await parseJsonResponse(response, null);
 }
 
+export async function createInvoiceForCart(invoiceAmount, invoiceDesc) {
+  const response = await httpClient("/wallet/invoice", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      description: invoiceDesc,
+      amountSat: parseInt(invoiceAmount),
+    }),
+  });
+  return await parseJsonResponse(response, null);
+}
+
 export async function createInvoice(invoiceAmount, invoiceDesc) {
   const response = await httpClient("/wallet/createinvoice", {
     method: "POST",

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -45,6 +45,13 @@ fun Route.wallet(
     tokenService: TokenService,
     authService: AuthService,
 ) {
+    authenticate("auth-jwt") {
+        post("/invoice") {
+            val request = call.receive<CreateInvoiceRequest>()
+            val invoice = phoenixService.createInvoice(request)
+            call.respond(HttpStatusCode.OK, invoice)
+        }
+    }
     authenticateAdmin {
         post("/auth") {
             val isSecureRequest =


### PR DESCRIPTION
## Changes:
  - Add `POST /wallet/invoice` endpoint under `auth-jwt` so cashiers and waiters can generate Lightning invoices from the cart without requiring wallet password
  - Add `createInvoiceForCart` to `walletService` calling the new endpoint, keeping `createInvoice` for the Wallet page (requires `auth-jwt-wallet`)
  - Update `useBitcoinInvoice` to use `createInvoiceForCart`
  - Add unit tests for `walletService` covering all endpoints including the new `createInvoiceForCart`