### PR TITLE
Fix: blank role name validation and required role on user edit

### DIFF
--- a/client/src/components/pages/Store/Users/EditUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/EditUsersModal.jsx
@@ -108,6 +108,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
             />
             <Select
               label={t("users.modal.userRoleLabel")}
+              isRequired
               defaultSelectedKeys={[data.userRole]}
               value={data.userRole}
               onChange={(e) => onChange({ ...data, userRole: e.target.value })}
@@ -132,6 +133,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
                 color="primary"
                 className="bg-green-800"
                 type="submit"
+                isDisabled={!data.userRole}
               >
                 {t("users.modal.editButton")}
               </Button>

--- a/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
@@ -175,6 +175,18 @@ describe("EditUsersModal", () => {
     expect(screen.getByLabelText("users.modal.userNameLabel")).toHaveAttribute("required");
   });
 
+  it("submit button is disabled when role is empty", () => {
+    renderModal({ data: { ...baseData, userRole: "" } });
+
+    expect(screen.getByText("users.modal.editButton").closest("button")).toBeDisabled();
+  });
+
+  it("submit button is enabled when role is selected", () => {
+    renderModal();
+
+    expect(screen.getByText("users.modal.editButton").closest("button")).not.toBeDisabled();
+  });
+
   it("resets role to empty when no roles are available", () => {
     const setData = jest.fn();
     const setEditUsersShowModal = jest.fn();

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -97,6 +97,10 @@ fun Route.roles(
             }
 
             val updatedRole = call.receive<Role>()
+            if (updatedRole.role.isBlank()) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid role data")
+                return@put
+            }
             val isUpdated = roleService.updateRole(id, updatedRole)
 
             if (!isUpdated) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -78,6 +78,10 @@ fun Route.roles(
         post("") {
             val user = call.receive<Role>()
             val id = roleService.addRole(user)
+            if (id == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid role data")
+                return@post
+            }
             call.respond(
                 HttpStatusCode.Created,
                 mapOf("id" to id, "message" to "Role added successfully"),

--- a/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
@@ -28,6 +28,7 @@ class RolesService(
     }
 
     suspend fun addRole(role: Role): String? {
+        if (role.role.isBlank()) return null
         if (roleNameExists(role.role)) {
             logger.error("Role name already exists: ${role.role}")
             return null
@@ -113,6 +114,7 @@ class RolesService(
         sql.append("WHERE id = ?")
 
         if (id == null) return false
+        if (role.role.isBlank()) return false
         if (roleNameExistsExcludingId(role.role, id)) {
             logger.error("Role name already exists: ${role.role}")
             return false

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
@@ -30,6 +30,24 @@ class RoleServiceTest {
     private val mockEnv: ApplicationEnvironment = mock()
 
     @Test
+    fun `addRole returns null if role name is blank`() {
+        runBlocking {
+            val service = RolesService(mockEnv, mockConnection) // Arrange
+            val result = service.addRole(Role(role = "  ")) // Act
+            assertNull(result) // Assert
+        }
+    }
+
+    @Test
+    fun `updateRole returns false if role name is blank`() {
+        runBlocking {
+            val service = RolesService(mockEnv, mockConnection) // Arrange
+            val result = service.updateRole("some-id", Role(role = "  ")) // Act
+            assertFalse(result) // Assert
+        }
+    }
+
+    @Test
     fun `getRoles returns list of roles when found`() {
         runBlocking {
             whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement) // Arrange


### PR DESCRIPTION
Prevents storing blank role names via direct API calls and ensures the role                                                   
  field is required when editing a user.                                     
                                        
  ## Backend
  - `RolesService`: reject blank role names on create and update
  - `Roles.kt`: fix `POST /roles` and `PUT /roles` returning wrong status codes on failure
  - Unit tests added                                                                                                            
                    
  ## Frontend                                                                                                                   
  - `EditUsersModal`: add `isRequired` to role select and disable save button
    when no role is selected (mirrors `AddUsersModal`)                                                                          
  - Unit tests added                                  
