### PR TITLE
fix(client): resolve websocket URL from published API port

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage
 FROM node:22-slim AS builder
 WORKDIR /app
+ARG NEXT_PUBLIC_PORT_API=9154
+ENV NEXT_PUBLIC_PORT_API=${NEXT_PUBLIC_PORT_API}
 COPY package*.json ./
 COPY . .
 RUN npm i

--- a/client/__tests__/api.config.test.js
+++ b/client/__tests__/api.config.test.js
@@ -6,12 +6,18 @@ async function loadConfigModule() {
 }
 
 describe("api config", () => {
+  const spies = [];
+
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.NEXT_PUBLIC_PORT_API;
     delete process.env.NEXT_PUBLIC_WS_URL;
-    window.history.replaceState({}, "", "http://localhost:3000");
+  });
+
+  afterEach(() => {
+    spies.forEach((s) => s.mockRestore());
+    spies.length = 0;
   });
 
   afterAll(() => {
@@ -21,11 +27,11 @@ describe("api config", () => {
   it("builds the websocket URL from the browser host and published API port", async () => {
     process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9154";
     process.env.NEXT_PUBLIC_PORT_API = "9155";
-    window.history.replaceState({}, "", "http://caja-1.local:3001");
-
     const { getWsUrl } = await loadConfigModule();
 
-    expect(getWsUrl()).toBe("ws://caja-1.local:9155/ws/payments");
+    expect(getWsUrl({ hostname: "caja-1.local", protocol: "http:" })).toBe(
+      "ws://caja-1.local:9155/ws/payments",
+    );
   });
 
   it("prefers an explicit websocket URL when provided", async () => {

--- a/client/__tests__/api.config.test.js
+++ b/client/__tests__/api.config.test.js
@@ -1,0 +1,40 @@
+const ORIGINAL_ENV = process.env;
+
+async function loadConfigModule() {
+  jest.resetModules();
+  return await import("../src/config/api");
+}
+
+describe("api config", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.NEXT_PUBLIC_PORT_API;
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    window.history.replaceState({}, "", "http://localhost:3000");
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("builds the websocket URL from the browser host and published API port", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9154";
+    process.env.NEXT_PUBLIC_PORT_API = "9155";
+    window.history.replaceState({}, "", "http://caja-1.local:3001");
+
+    const { getWsUrl } = await loadConfigModule();
+
+    expect(getWsUrl()).toBe("ws://caja-1.local:9155/ws/payments");
+  });
+
+  it("prefers an explicit websocket URL when provided", async () => {
+    process.env.NEXT_PUBLIC_WS_URL = "wss://payments.example.com/ws/payments";
+    process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9154";
+    process.env.NEXT_PUBLIC_PORT_API = "9155";
+
+    const { getWsUrl } = await loadConfigModule();
+
+    expect(getWsUrl()).toBe("wss://payments.example.com/ws/payments");
+  });
+});

--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -1,7 +1,23 @@
 const DEFAULT_API_URL = "http://localhost:9154";
+const DEFAULT_API_PORT = "9154";
 
 export function getApiUrl() {
   return process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
+}
+
+function getApiPort() {
+  if (process.env.NEXT_PUBLIC_PORT_API) {
+    return process.env.NEXT_PUBLIC_PORT_API;
+  }
+
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    try {
+      const apiUrl = new URL(process.env.NEXT_PUBLIC_API_URL);
+      return apiUrl.port || DEFAULT_API_PORT;
+    } catch {}
+  }
+
+  return DEFAULT_API_PORT;
 }
 
 export function getWsUrl() {
@@ -9,18 +25,18 @@ export function getWsUrl() {
     return process.env.NEXT_PUBLIC_WS_URL;
   }
 
-  if (process.env.NEXT_PUBLIC_API_URL) {
-    return `${process.env.NEXT_PUBLIC_API_URL.replace(/^http/i, "ws")}/ws/payments`;
-  }
-
   if (typeof window !== "undefined") {
     const host = window.location.hostname;
-    const port = process.env.NEXT_PUBLIC_PORT_API || "9154";
+    const port = getApiPort();
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     return `${protocol}//${host}:${port}/ws/payments`;
   }
 
-  return `ws://localhost:9154/ws/payments`;
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return `${process.env.NEXT_PUBLIC_API_URL.replace(/^http/i, "ws")}/ws/payments`;
+  }
+
+  return `ws://localhost:${DEFAULT_API_PORT}/ws/payments`;
 }
 
 export function isElectronEnv() {

--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -20,15 +20,17 @@ function getApiPort() {
   return DEFAULT_API_PORT;
 }
 
-export function getWsUrl() {
+export function getWsUrl(loc) {
   if (process.env.NEXT_PUBLIC_WS_URL) {
     return process.env.NEXT_PUBLIC_WS_URL;
   }
 
-  if (typeof window !== "undefined") {
-    const host = window.location.hostname;
+  const location = loc || (typeof window !== "undefined" ? window.location : null);
+
+  if (location) {
+    const host = location.hostname;
     const port = getApiPort();
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const protocol = location.protocol === "https:" ? "wss:" : "ws:";
     return `${protocol}//${host}:${port}/ws/payments`;
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,10 @@ services:
       - phoenixd
 
   ambrosia-client:
-    build: client/
+    build:
+      context: client/
+      args:
+        NEXT_PUBLIC_PORT_API: "9154"
     image: ambrosia-client
     container_name: ambrosia-client
     restart: unless-stopped
@@ -41,7 +44,7 @@ services:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://ambrosia:9154
-      NEXT_PUBLIC_WS_URL: ws://localhost:9154/ws/payments
+      NEXT_PUBLIC_PORT_API: "9154"
 
 volumes:
   phoenixd_datadir: 


### PR DESCRIPTION
This pull request updates how the client application determines the API and WebSocket ports, making the configuration more flexible and robust. The main improvements include introducing a new environment variable for the API port, updating the logic for building the WebSocket URL, and adding tests to ensure the configuration works as expected.

**Configuration and Environment Variable Improvements:**

* Added support for a new `NEXT_PUBLIC_PORT_API` environment variable in the client Docker build and `docker-compose.yml`, allowing the API port to be explicitly set and passed to the frontend (`client/Dockerfile`, `docker-compose.yml`). [[1]](diffhunk://#diff-c0a19429aa475a5c4fba2e72499771095a4d55a72adf8271238b2a402928b475R4-R5) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L30-R33) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L44-R47)

**WebSocket URL Resolution Enhancements:**

* Refactored `getWsUrl` in `client/src/config/api.js` to use the new port variable and improved logic for determining the correct WebSocket URL, including better fallback behavior and protocol handling.

**Testing:**

* Added tests for the API configuration logic to verify correct WebSocket URL generation under different environment variable scenarios (`client/__tests__/api.config.test.js`).