### PR TITLE
Chore/update workflows

### DIFF
--- a/.github/workflows/client_linter.yml
+++ b/.github/workflows/client_linter.yml
@@ -2,17 +2,18 @@ name: Client ESLint
 
 on:
   pull_request:
-    branches: ['**']
+    branches:
+      - '**'
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 

--- a/.github/workflows/client_unit_test.yml
+++ b/.github/workflows/client_unit_test.yml
@@ -2,7 +2,8 @@ name: Client Unit Tests
 
 on:
   pull_request:
-    branches: ['**']
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -10,11 +11,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,8 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -12,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/electron_release.yml
+++ b/.github/workflows/electron_release.yml
@@ -43,19 +43,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: |
             client/package-lock.json
             electron/package-lock.json
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -83,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-${{ matrix.artifact_name }}
           path: |
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true
@@ -112,7 +112,7 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create Release & Upload
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           name: Release ${{ github.event.inputs.tag_name || github.ref_name }}

--- a/.github/workflows/server_linter.yml
+++ b/.github/workflows/server_linter.yml
@@ -2,7 +2,8 @@ name: Server Linter Test
 
 on:
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -15,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/server_unit_tests.yml
+++ b/.github/workflows/server_unit_tests.yml
@@ -2,7 +2,8 @@ name: Server Unit Tests
 
 on:
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -15,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -2,7 +2,8 @@ name: Test Installer Script
 
 on:
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -20,18 +21,18 @@ jobs:
     
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
+      - name: Setup Node 24
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Make install script executable
         run: chmod +x scripts/install.sh

--- a/.github/workflows/test_install_from_source.yml
+++ b/.github/workflows/test_install_from_source.yml
@@ -2,7 +2,8 @@ name: Test Install From Source
 
 on:
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
 
   workflow_dispatch:
 
@@ -19,19 +20,19 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
+      - name: Setup Node 24
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Make Gradle wrapper executable
         run: chmod +x server/gradlew


### PR DESCRIPTION
## Changes:
  - Upgrade all GitHub Actions from v4 to v5 across all 8 workflows (checkout, setup-node, setup-java, upload-artifact, download-artifact; action-gh-release v2 → v3)
  - Upgrade Node.js to 24 in all workflows that use it (client linter/tests: 22→24, install test workflows: 20→24, electron release: 22→24)
  - Fix `branches` filter format from scalar string to proper YAML array in all workflows