### PR TITLE
Feat(WS): SSE payment proxy

### DIFF
--- a/client/__tests__/api.config.test.js
+++ b/client/__tests__/api.config.test.js
@@ -6,41 +6,35 @@ async function loadConfigModule() {
 }
 
 describe("api config", () => {
-  const spies = [];
-
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env.NEXT_PUBLIC_API_URL;
-    delete process.env.NEXT_PUBLIC_PORT_API;
-    delete process.env.NEXT_PUBLIC_WS_URL;
-  });
-
-  afterEach(() => {
-    spies.forEach((s) => s.mockRestore());
-    spies.length = 0;
+    delete process.env.NEXT_PUBLIC_ELECTRON;
   });
 
   afterAll(() => {
     process.env = ORIGINAL_ENV;
   });
 
-  it("builds the websocket URL from the browser host and published API port", async () => {
-    process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9154";
-    process.env.NEXT_PUBLIC_PORT_API = "9155";
-    const { getWsUrl } = await loadConfigModule();
-
-    expect(getWsUrl({ hostname: "caja-1.local", protocol: "http:" })).toBe(
-      "ws://caja-1.local:9155/ws/payments",
-    );
+  it("returns default API URL when no env var is set", async () => {
+    const { API_URL } = await loadConfigModule();
+    expect(API_URL).toBe("http://localhost:9154");
   });
 
-  it("prefers an explicit websocket URL when provided", async () => {
-    process.env.NEXT_PUBLIC_WS_URL = "wss://payments.example.com/ws/payments";
-    process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9154";
-    process.env.NEXT_PUBLIC_PORT_API = "9155";
+  it("uses NEXT_PUBLIC_API_URL when set", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9155";
+    const { API_URL } = await loadConfigModule();
+    expect(API_URL).toBe("http://ambrosia:9155");
+  });
 
-    const { getWsUrl } = await loadConfigModule();
+  it("detects electron environment", async () => {
+    process.env.NEXT_PUBLIC_ELECTRON = "true";
+    const { IS_ELECTRON } = await loadConfigModule();
+    expect(IS_ELECTRON).toBe(true);
+  });
 
-    expect(getWsUrl()).toBe("wss://payments.example.com/ws/payments");
+  it("detects non-electron environment", async () => {
+    const { IS_ELECTRON } = await loadConfigModule();
+    expect(IS_ELECTRON).toBe(false);
   });
 });

--- a/client/__tests__/api.config.test.js
+++ b/client/__tests__/api.config.test.js
@@ -9,7 +9,6 @@ describe("api config", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env.NEXT_PUBLIC_API_URL;
-    delete process.env.NEXT_PUBLIC_ELECTRON;
   });
 
   afterAll(() => {
@@ -25,16 +24,5 @@ describe("api config", () => {
     process.env.NEXT_PUBLIC_API_URL = "http://ambrosia:9155";
     const { API_URL } = await loadConfigModule();
     expect(API_URL).toBe("http://ambrosia:9155");
-  });
-
-  it("detects electron environment", async () => {
-    process.env.NEXT_PUBLIC_ELECTRON = "true";
-    const { IS_ELECTRON } = await loadConfigModule();
-    expect(IS_ELECTRON).toBe(true);
-  });
-
-  it("detects non-electron environment", async () => {
-    const { IS_ELECTRON } = await loadConfigModule();
-    expect(IS_ELECTRON).toBe(false);
   });
 });

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,7 +22,8 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-qr-code": "^2.0.18",
-        "serwist": "^9.5.7"
+        "serwist": "^9.5.7",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.28.3",
@@ -4115,9 +4116,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4133,9 +4131,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4153,9 +4148,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4171,9 +4163,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4191,9 +4180,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4209,9 +4195,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4229,9 +4212,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4248,9 +4228,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4266,9 +4243,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4292,9 +4266,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4316,9 +4287,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4342,9 +4310,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4366,9 +4331,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4392,9 +4354,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4417,9 +4376,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4441,9 +4397,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5282,9 +5235,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5300,9 +5250,6 @@
       "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5320,9 +5267,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5338,9 +5282,6 @@
       "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5553,9 +5494,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5513,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5599,9 +5534,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5621,9 +5553,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5645,9 +5574,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5667,9 +5593,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7399,9 +7322,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7417,9 +7337,6 @@
       "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7437,9 +7354,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7455,9 +7369,6 @@
       "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7475,9 +7386,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7493,9 +7401,6 @@
       "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -17097,7 +17002,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-qr-code": "^2.0.18",
-    "serwist": "^9.5.7"
+    "serwist": "^9.5.7",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",

--- a/client/src/app/api/ws-payments/route.js
+++ b/client/src/app/api/ws-payments/route.js
@@ -1,0 +1,55 @@
+import WebSocket from "ws";
+
+import { API_URL } from "@/config/api";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  const backendWsUrl = `${API_URL.replace(/^http/i, "ws")}/ws/payments`;
+  const cookies = request.headers.get("cookie") || "";
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+
+      const ws = new WebSocket(backendWsUrl, {
+        headers: { cookie: cookies },
+      });
+
+      ws.on("open", () => {
+        ws.on("message", (raw) => {
+          const message = typeof raw === "string" ? raw : raw.toString();
+          try {
+            controller.enqueue(encoder.encode(`data: ${message}\n\n`));
+          } catch {}
+        });
+      });
+
+      ws.on("error", () => {
+        try {
+          controller.close();
+        } catch {}
+      });
+
+      ws.on("close", () => {
+        try {
+          controller.close();
+        } catch {}
+      });
+
+      request.signal.addEventListener("abort", () => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.close();
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -4,9 +4,4 @@ export function getApiUrl() {
   return process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
 }
 
-export function isElectronEnv() {
-  return process.env.NEXT_PUBLIC_ELECTRON === "true";
-}
-
 export const API_URL = getApiUrl();
-export const IS_ELECTRON = isElectronEnv();

--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -1,44 +1,7 @@
 const DEFAULT_API_URL = "http://localhost:9154";
-const DEFAULT_API_PORT = "9154";
 
 export function getApiUrl() {
   return process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
-}
-
-function getApiPort() {
-  if (process.env.NEXT_PUBLIC_PORT_API) {
-    return process.env.NEXT_PUBLIC_PORT_API;
-  }
-
-  if (process.env.NEXT_PUBLIC_API_URL) {
-    try {
-      const apiUrl = new URL(process.env.NEXT_PUBLIC_API_URL);
-      return apiUrl.port || DEFAULT_API_PORT;
-    } catch {}
-  }
-
-  return DEFAULT_API_PORT;
-}
-
-export function getWsUrl(loc) {
-  if (process.env.NEXT_PUBLIC_WS_URL) {
-    return process.env.NEXT_PUBLIC_WS_URL;
-  }
-
-  const location = loc || (typeof window !== "undefined" ? window.location : null);
-
-  if (location) {
-    const host = location.hostname;
-    const port = getApiPort();
-    const protocol = location.protocol === "https:" ? "wss:" : "ws:";
-    return `${protocol}//${host}:${port}/ws/payments`;
-  }
-
-  if (process.env.NEXT_PUBLIC_API_URL) {
-    return `${process.env.NEXT_PUBLIC_API_URL.replace(/^http/i, "ws")}/ws/payments`;
-  }
-
-  return `ws://localhost:${DEFAULT_API_PORT}/ws/payments`;
 }
 
 export function isElectronEnv() {
@@ -46,5 +9,4 @@ export function isElectronEnv() {
 }
 
 export const API_URL = getApiUrl();
-export const WS_URL = getWsUrl();
 export const IS_ELECTRON = isElectronEnv();

--- a/client/src/hooks/__tests__/usePaymentWebsocket.test.js
+++ b/client/src/hooks/__tests__/usePaymentWebsocket.test.js
@@ -137,11 +137,11 @@ describe("usePaymentWebsocket", () => {
 
     it("closes the EventSource on unmount", () => {
       const { unmount } = renderHook(() => usePaymentWebsocket());
-      const es = MockEventSource.latest();
+      const mockEventSource = MockEventSource.latest();
 
       unmount();
 
-      expect(es.readyState).toBe(MockEventSource.CLOSED);
+      expect(mockEventSource.readyState).toBe(MockEventSource.CLOSED);
     });
   });
 

--- a/client/src/hooks/__tests__/usePaymentWebsocket.test.js
+++ b/client/src/hooks/__tests__/usePaymentWebsocket.test.js
@@ -2,44 +2,38 @@ import { act, renderHook } from "@testing-library/react";
 
 import { usePaymentWebsocket } from "../usePaymentWebsocket";
 
-jest.mock("@/config/api", () => ({
-  getWsUrl: () => "ws://localhost:9154/ws/payments",
-}));
-
-class MockWebSocket {
+class MockEventSource {
   constructor(url) {
     this.url = url;
-    this.readyState = MockWebSocket.CONNECTING;
+    this.readyState = MockEventSource.CONNECTING;
     this.onopen = null;
-    this.onclose = null;
     this.onerror = null;
     this.onmessage = null;
-    MockWebSocket.instances.push(this);
+    MockEventSource.instances.push(this);
   }
 
   close() {
-    this.readyState = MockWebSocket.CLOSED;
+    this.readyState = MockEventSource.CLOSED;
   }
 
   static CONNECTING = 0;
   static OPEN = 1;
-  static CLOSING = 2;
-  static CLOSED = 3;
+  static CLOSED = 2;
   static instances = [];
 
   static reset() {
-    MockWebSocket.instances = [];
+    MockEventSource.instances = [];
   }
 
   static latest() {
-    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    return MockEventSource.instances[MockEventSource.instances.length - 1];
   }
 }
 
 describe("usePaymentWebsocket", () => {
   beforeEach(() => {
-    MockWebSocket.reset();
-    global.WebSocket = MockWebSocket;
+    MockEventSource.reset();
+    global.EventSource = MockEventSource;
     jest.clearAllMocks();
     jest.spyOn(console, "warn").mockImplementation(() => {});
   });
@@ -54,37 +48,37 @@ describe("usePaymentWebsocket", () => {
       expect(result.current.connected).toBe(false);
     });
 
-    it("sets connected to true when WebSocket opens", () => {
+    it("sets connected to true when EventSource opens", () => {
       const { result } = renderHook(() => usePaymentWebsocket());
 
       act(() => {
-        MockWebSocket.latest().readyState = MockWebSocket.OPEN;
-        MockWebSocket.latest().onopen?.();
+        MockEventSource.latest().readyState = MockEventSource.OPEN;
+        MockEventSource.latest().onopen?.();
       });
 
       expect(result.current.connected).toBe(true);
     });
 
-    it("sets connected to false when WebSocket closes", () => {
+    it("sets connected to false on error", () => {
       const { result } = renderHook(() => usePaymentWebsocket());
 
       act(() => {
-        MockWebSocket.latest().readyState = MockWebSocket.OPEN;
-        MockWebSocket.latest().onopen?.();
+        MockEventSource.latest().readyState = MockEventSource.OPEN;
+        MockEventSource.latest().onopen?.();
       });
 
       expect(result.current.connected).toBe(true);
 
       act(() => {
-        MockWebSocket.latest().onclose?.();
+        MockEventSource.latest().onerror?.();
       });
 
       expect(result.current.connected).toBe(false);
     });
 
-    it("connects to the URL returned by getWsUrl", () => {
+    it("connects to /api/ws-payments", () => {
       renderHook(() => usePaymentWebsocket());
-      expect(MockWebSocket.latest().url).toBe("ws://localhost:9154/ws/payments");
+      expect(MockEventSource.latest().url).toBe("/api/ws-payments");
     });
   });
 
@@ -97,26 +91,26 @@ describe("usePaymentWebsocket", () => {
       jest.useRealTimers();
     });
 
-    it("reconnects after 3 seconds when WebSocket closes", async () => {
+    it("reconnects after 3 seconds on error", async () => {
       renderHook(() => usePaymentWebsocket());
-      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(MockEventSource.instances).toHaveLength(1);
 
       act(() => {
-        MockWebSocket.latest().onclose?.();
+        MockEventSource.latest().onerror?.();
       });
 
       await act(async () => {
         await jest.runAllTimersAsync();
       });
 
-      expect(MockWebSocket.instances).toHaveLength(2);
+      expect(MockEventSource.instances).toHaveLength(2);
     });
 
     it("calls /api/auth/refresh before reconnecting", async () => {
       renderHook(() => usePaymentWebsocket());
 
       act(() => {
-        MockWebSocket.latest().onclose?.();
+        MockEventSource.latest().onerror?.();
       });
 
       await act(async () => {
@@ -130,7 +124,7 @@ describe("usePaymentWebsocket", () => {
 
     it("does not reconnect after unmount", async () => {
       const { unmount } = renderHook(() => usePaymentWebsocket());
-      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(MockEventSource.instances).toHaveLength(1);
 
       unmount();
 
@@ -138,21 +132,16 @@ describe("usePaymentWebsocket", () => {
         await jest.runAllTimersAsync();
       });
 
-      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(MockEventSource.instances).toHaveLength(1);
     });
 
-    it("closes the WebSocket on unmount if it is open", () => {
+    it("closes the EventSource on unmount", () => {
       const { unmount } = renderHook(() => usePaymentWebsocket());
-      const ws = MockWebSocket.latest();
-
-      act(() => {
-        ws.readyState = MockWebSocket.OPEN;
-        ws.onopen?.();
-      });
+      const es = MockEventSource.latest();
 
       unmount();
 
-      expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+      expect(es.readyState).toBe(MockEventSource.CLOSED);
     });
   });
 
@@ -167,7 +156,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "abc" }),
         });
       });
@@ -187,7 +176,7 @@ describe("usePaymentWebsocket", () => {
       const paymentData = { type: "payment_received", paymentHash: "abc123" };
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({ data: JSON.stringify(paymentData) });
+        MockEventSource.latest().onmessage?.({ data: JSON.stringify(paymentData) });
       });
 
       expect(listener).toHaveBeenCalledWith(paymentData);
@@ -204,7 +193,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "matching-hash" }),
         });
       });
@@ -226,7 +215,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "other-hash" }),
         });
       });
@@ -243,7 +232,7 @@ describe("usePaymentWebsocket", () => {
       renderHook(() => usePaymentWebsocket());
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "some-hash" }),
         });
       });
@@ -265,7 +254,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "other_event", paymentHash: "abc" }),
         });
       });
@@ -280,7 +269,7 @@ describe("usePaymentWebsocket", () => {
 
       expect(() => {
         act(() => {
-          MockWebSocket.latest().onmessage?.({ data: "not-valid-json{{" });
+          MockEventSource.latest().onmessage?.({ data: "not-valid-json{{" });
         });
       }).not.toThrow();
     });
@@ -301,7 +290,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "abc" }),
         });
       });
@@ -320,7 +309,7 @@ describe("usePaymentWebsocket", () => {
       });
 
       act(() => {
-        MockWebSocket.latest().onmessage?.({
+        MockEventSource.latest().onmessage?.({
           data: JSON.stringify({ type: "payment_received", paymentHash: "abc" }),
         });
       });

--- a/client/src/hooks/usePaymentWebsocket.js
+++ b/client/src/hooks/usePaymentWebsocket.js
@@ -1,8 +1,6 @@
 "use client";
 import { useEffect, useRef, useState, useCallback } from "react";
 
-import { getWsUrl } from "@/config/api";
-
 export function usePaymentWebsocket() {
   const [connected, setConnected] = useState(false);
   const invoiceHashRef = useRef(null);
@@ -27,18 +25,17 @@ export function usePaymentWebsocket() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    let ws;
+    let es;
     let shouldReconnect = true;
 
     const connect = () => {
-      const url = getWsUrl();
-      ws = new WebSocket(url);
+      es = new EventSource("/api/ws-payments");
 
-      ws.onopen = () => {
+      es.onopen = () => {
         setConnected(true);
       };
 
-      ws.onmessage = (event) => {
+      es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
           if (data?.type === "payment_received") {
@@ -59,16 +56,13 @@ export function usePaymentWebsocket() {
             }
           }
         } catch (err) {
-          console.warn("WS payments mensaje no procesado", err);
+          console.warn("SSE payments mensaje no procesado", err);
         }
       };
 
-      ws.onerror = (err) => {
-        console.warn("WS payments error", err);
-      };
-
-      ws.onclose = () => {
+      es.onerror = () => {
         setConnected(false);
+        es.close();
         if (shouldReconnect) {
           setTimeout(async () => {
             try {
@@ -84,9 +78,7 @@ export function usePaymentWebsocket() {
 
     return () => {
       shouldReconnect = false;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.close();
-      }
+      if (es) es.close();
     };
   }, []);
 

--- a/client/src/hooks/usePaymentWebsocket.js
+++ b/client/src/hooks/usePaymentWebsocket.js
@@ -25,17 +25,17 @@ export function usePaymentWebsocket() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    let es;
+    let eventSource;
     let shouldReconnect = true;
 
     const connect = () => {
-      es = new EventSource("/api/ws-payments");
+      eventSource = new EventSource("/api/ws-payments");
 
-      es.onopen = () => {
+      eventSource.onopen = () => {
         setConnected(true);
       };
 
-      es.onmessage = (event) => {
+      eventSource.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
           if (data?.type === "payment_received") {
@@ -49,10 +49,10 @@ export function usePaymentWebsocket() {
               data.paymentHash &&
               data.paymentHash === invoiceHashRef.current
             ) {
-              const evt = new CustomEvent("wallet:invoicePaid", {
+              const customEvent = new CustomEvent("wallet:invoicePaid", {
                 detail: { paymentHash: data.paymentHash },
               });
-              window.dispatchEvent(evt);
+              window.dispatchEvent(customEvent);
             }
           }
         } catch (err) {
@@ -60,9 +60,9 @@ export function usePaymentWebsocket() {
         }
       };
 
-      es.onerror = () => {
+      eventSource.onerror = () => {
         setConnected(false);
-        es.close();
+        eventSource.close();
         if (shouldReconnect) {
           setTimeout(async () => {
             try {
@@ -78,7 +78,7 @@ export function usePaymentWebsocket() {
 
     return () => {
       shouldReconnect = false;
-      if (es) es.close();
+      if (eventSource) eventSource.close();
     };
   }, []);
 

--- a/client/src/modules/cashier/Wallet.js
+++ b/client/src/modules/cashier/Wallet.js
@@ -128,16 +128,16 @@ function WalletInner() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    let es;
+    let eventSource;
     let shouldReconnect = true;
     const connect = () => {
-      es = new EventSource("/api/ws-payments");
+      eventSource = new EventSource("/api/ws-payments");
 
-      es.onopen = () => {
+      eventSource.onopen = () => {
         console.warn("SSE payments conectado");
       };
 
-      es.onmessage = (event) => {
+      eventSource.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
           if (data?.type === "payment_received") {
@@ -155,8 +155,8 @@ function WalletInner() {
         }
       };
 
-      es.onerror = () => {
-        es.close();
+      eventSource.onerror = () => {
+        eventSource.close();
         if (shouldReconnect) {
           setTimeout(connect, 3000);
         }
@@ -167,7 +167,7 @@ function WalletInner() {
 
     return () => {
       shouldReconnect = false;
-      if (es) es.close();
+      if (eventSource) eventSource.close();
     };
   }, [fetchInfo]);
 

--- a/client/src/modules/cashier/Wallet.js
+++ b/client/src/modules/cashier/Wallet.js
@@ -38,7 +38,6 @@ import {
 } from "lucide-react";
 import { QRCode } from "react-qr-code";
 
-import { getWsUrl } from "@/config/api";
 import {
   createInvoice,
   getIncomingTransactions,
@@ -129,17 +128,16 @@ function WalletInner() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    let ws;
+    let es;
     let shouldReconnect = true;
     const connect = () => {
-      const url = getWsUrl();
-      ws = new WebSocket(url);
+      es = new EventSource("/api/ws-payments");
 
-      ws.onopen = () => {
-        console.warn("WS payments conectado", url);
+      es.onopen = () => {
+        console.warn("SSE payments conectado");
       };
 
-      ws.onmessage = (event) => {
+      es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
           if (data?.type === "payment_received") {
@@ -153,15 +151,12 @@ function WalletInner() {
             fetchInfo();
           }
         } catch (err) {
-          console.warn("WS payments mensaje no procesado", err);
+          console.warn("SSE payments mensaje no procesado", err);
         }
       };
 
-      ws.onerror = (err) => {
-        console.warn("WS payments error", err);
-      };
-
-      ws.onclose = () => {
+      es.onerror = () => {
+        es.close();
         if (shouldReconnect) {
           setTimeout(connect, 3000);
         }
@@ -172,9 +167,7 @@ function WalletInner() {
 
     return () => {
       shouldReconnect = false;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.close();
-      }
+      if (es) es.close();
     };
   }, [fetchInfo]);
 

--- a/client/src/modules/cashier/Wallet.js
+++ b/client/src/modules/cashier/Wallet.js
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import { QRCode } from "react-qr-code";
 
+import { usePaymentWebsocket } from "@/hooks/usePaymentWebsocket";
 import {
   createInvoice,
   getIncomingTransactions,
@@ -125,51 +126,21 @@ function WalletInner() {
     fetchTransactionsRef.current = fetchTransactions;
   }, [fetchTransactions]);
 
+  const { onPayment } = usePaymentWebsocket();
+
   useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    let eventSource;
-    let shouldReconnect = true;
-    const connect = () => {
-      eventSource = new EventSource("/api/ws-payments");
-
-      eventSource.onopen = () => {
-        console.warn("SSE payments conectado");
-      };
-
-      eventSource.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          if (data?.type === "payment_received") {
-            addToast({
-              title: "Pago recibido",
-              description: `Hash: ${data.paymentHash || ""}`,
-              variant: "solid",
-              color: "success",
-            });
-            fetchTransactionsRef.current?.();
-            fetchInfo();
-          }
-        } catch (err) {
-          console.warn("SSE payments mensaje no procesado", err);
-        }
-      };
-
-      eventSource.onerror = () => {
-        eventSource.close();
-        if (shouldReconnect) {
-          setTimeout(connect, 3000);
-        }
-      };
-    };
-
-    connect();
-
-    return () => {
-      shouldReconnect = false;
-      if (eventSource) eventSource.close();
-    };
-  }, [fetchInfo]);
+    const cleanup = onPayment(() => {
+      addToast({
+        title: "Pago recibido",
+        description: "",
+        variant: "solid",
+        color: "success",
+      });
+      fetchTransactionsRef.current?.();
+      fetchInfo();
+    });
+    return cleanup;
+  }, [fetchInfo, onPayment]);
 
   const handleCreateInvoice = async () => {
     if (!invoiceAmount) {


### PR DESCRIPTION
This pull request refactors how WebSocket URLs are constructed and used in the client, simplifies the related configuration, and introduces a new API route for streaming WebSocket events via server-sent events (SSE). It also adds the `ws` package as a dependency and cleans up some platform-specific fields in `package-lock.json`.

**WebSocket and API configuration refactor:**

* Refactored `client/src/config/api.js` to remove the `getWsUrl` logic and related environment variable handling, simplifying the configuration to only export `API_URL`. The logic for constructing WebSocket URLs based on environment variables and browser location has been removed.
* Updated the test file `client/__tests__/api.config.test.js` to match the new configuration logic, now only testing `API_URL` and removing tests related to WebSocket URL construction.

**New API route for streaming payments events:**

* Added `client/src/app/api/ws-payments/route.js`, which creates a serverless API route that connects to the backend WebSocket using the `ws` package and streams messages to the client as server-sent events (SSE). This route handles connection, message forwarding, and cleanup on client disconnect.

**Dependency updates:**

* Added the `ws` package (`^8.18.0`) to `dependencies` in `client/package.json` and `client/package-lock.json` to enable server-side WebSocket connections. [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL41-R42) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL25-R26) [[3]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL17100)

**Package lock cleanup:**

* Removed various `"libc"` fields from platform-specific dependencies in `client/package-lock.json` to reduce lockfile noise and improve cross-platform compatibility. [[1]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4118-L4120) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4137-L4139) [[3]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4156-L4158) [[4]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4175-L4177) [[5]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4194-L4196) [[6]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4213-L4215) [[7]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4232-L4234) [[8]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4251-L4253) [[9]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4270-L4272) [[10]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4295-L4297) [[11]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4320-L4322) [[12]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4345-L4347) [[13]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4370-L4372) [[14]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4395-L4397) [[15]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4420-L4422) [[16]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4445-L4447) [[17]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5285-L5287) [[18]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5304-L5306) [[19]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5323-L5325) [[20]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5342-L5344) [[21]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5556-L5558) [[22]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5579-L5581) [[23]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5602-L5604) [[24]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5625-L5627) [[25]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5648-L5650) [[26]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL5671-L5673) [[27]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7402-L7404) [[28]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7421-L7423) [[29]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7440-L7442) [[30]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7459-L7461) [[31]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7478-L7480) [[32]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL7497-L7499)

Let me know if you want to discuss how to use the new API route or have questions about the refactor!