### PR TITLE
feat(install): add EXPOSE_LAN option and initial config writing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,15 +11,20 @@ IFS=$'\n\t'
 # --- Argument validation ---
 AUTO_YES=false
 INSTALL_SYSTEMD=true
+EXPOSE_LAN=false
 
 for arg in "$@"; do
   case $arg in
-    --yes|-y) 
+    --yes|-y)
       AUTO_YES=true
       shift
       ;;
     --no-service)
       INSTALL_SYSTEMD=false
+      shift
+      ;;
+    --expose-lan)
+      EXPOSE_LAN=true
       shift
       ;;
     *)
@@ -229,6 +234,29 @@ AMBROSIA_URL="https://github.com/olympus-btc/ambrosia/releases/download/v${AMBRO
 AMBROSIA_INSTALL_DIR="$HOME/.local/ambrosia"
 AMBROSIA_BIN_DIR="$HOME/.local/bin"
 
+ambrosia_write_initial_config() {
+  local datadir="$HOME/.Ambrosia-POS"
+  local conf_file="$datadir/ambrosia.conf"
+  mkdir -p "$datadir"
+
+  if [[ -f "$conf_file" ]]; then
+    log_info "ambrosia.conf already exists, skipping initial config write."
+    return
+  fi
+
+  local bind_ip="127.0.0.1"
+  if [[ "$EXPOSE_LAN" == "true" ]]; then
+    bind_ip="0.0.0.0"
+    log_info "LAN exposure enabled: http-bind-ip will be set to 0.0.0.0"
+  fi
+
+  cat > "$conf_file" << EOF
+http-bind-ip=$bind_ip
+http-bind-port=9154
+EOF
+  log_info "Wrote initial config to $conf_file"
+}
+
 ambrosia_install() {
   echo "➡️  Starting Ambrosia POS Server installation..."
   if command -v ambrosia >/dev/null 2>&1; then
@@ -241,7 +269,8 @@ ambrosia_install() {
   fi
 
   mkdir -p "$AMBROSIA_BIN_DIR" "$AMBROSIA_INSTALL_DIR"
-  
+  ambrosia_write_initial_config
+
   download_file "${AMBROSIA_URL}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
   download_file "https://raw.githubusercontent.com/olympus-btc/ambrosia/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
   


### PR DESCRIPTION
## Summary

- Adds `--expose-lan` CLI flag to `scripts/install.sh`
- Introduces `ambrosia_write_initial_config()` function that writes an initial `ambrosia.conf` on first install
- When `--expose-lan` is passed, sets `http-bind-ip=0.0.0.0`; otherwise defaults to `127.0.0.1` (localhost only)
- Skips config write if `~/.Ambrosia-POS/ambrosia.conf` already exists, preserving existing user configuration

## Motivation

By default, Ambrosia binds only to localhost. Users running the server on a dedicated machine (e.g., a Raspberry Pi or home server) need to accept connections from other devices on the local network without manually editing the config file after installation.

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | Added `EXPOSE_LAN` flag, `ambrosia_write_initial_config()` function, and call within `ambrosia_install()` |

## Usage

```bash
# Default install (localhost only)
./install.sh

# Install with LAN exposure
./install.sh --expose-lan
```

Generated config (`~/.Ambrosia-POS/ambrosia.conf`):
```
http-bind-ip=0.0.0.0   # with --expose-lan
http-bind-ip=127.0.0.1 # default
http-bind-port=9154
```

## Test plan

- [ ] Run `./install.sh` on a clean machine — verify `ambrosia.conf` is created with `http-bind-ip=127.0.0.1`
- [ ] Run `./install.sh --expose-lan` — verify `ambrosia.conf` is created with `http-bind-ip=0.0.0.0`
- [ ] Run installer a second time on an existing install — verify `ambrosia.conf` is NOT overwritten
- [ ] Verify existing `--yes` and `--no-systemd` flags still work correctly
