### PR TITLE
fix(client): work behind reverse proxies with self-signed TLS

### DIFF
--- a/client/src/proxy.js
+++ b/client/src/proxy.js
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+const INTERNAL_ORIGIN =
+  process.env.INTERNAL_ORIGIN || `http://127.0.0.1:${process.env.PORT || 3000}`;
+
 export default async function proxy(request) {
   const { pathname } = new URL(request.url);
   const refreshToken = request.cookies.get("refreshToken");
@@ -20,7 +23,7 @@ export default async function proxy(request) {
   let needsBusinessType = false;
   try {
     const headers = { cookie: request.headers.get("cookie") || "" };
-    const initialSetupUrl = new URL("/api/initial-setup", request.url);
+    const initialSetupUrl = new URL("/api/initial-setup", INTERNAL_ORIGIN);
 
     const setupResponse = await fetch(initialSetupUrl, { headers });
     if (setupResponse.ok) {
@@ -56,7 +59,7 @@ export default async function proxy(request) {
   let shouldClearBusinessTypeCookie = false;
   try {
     const headers = { cookie: request.headers.get("cookie") || "" };
-    const configurationUrl = new URL("/api/config", request.url);
+    const configurationUrl = new URL("/api/config", INTERNAL_ORIGIN);
     const configResponse = await fetch(configurationUrl, { headers });
     if (configResponse.ok) {
       const configData = await configResponse.json();
@@ -95,6 +98,7 @@ export default async function proxy(request) {
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
+    upgrade-insecure-requests;
   `.replace(/\s{2,}/g, " ").trim();
 
   const requestHeaders = new Headers(request.headers);

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -411,6 +411,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -432,6 +433,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -448,6 +450,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -462,6 +465,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1173,7 +1177,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1207,7 +1210,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2222,7 +2224,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -2466,7 +2469,6 @@
       "integrity": "sha512-IkGlOLfJ3q7y9iaDMnNSArDdPg3Ntx8Ps6aL7yTEIpL6znA+t5L/LRTAGFz1J/12hM/NiNEYg0LoBEheqGdZXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.6.0",
         "builder-util": "26.4.1",
@@ -2843,6 +2845,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2863,6 +2866,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3113,7 +3117,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3695,16 +3698,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4103,9 +4106,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4795,9 +4798,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -4806,16 +4809,26 @@
         "@hapi/pinpoint": "^2.0.1",
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
+        "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5248,6 +5261,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5781,7 +5795,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5821,6 +5834,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5838,6 +5852,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -6133,6 +6148,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6811,9 +6827,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6843,6 +6859,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/electron/package.json
+++ b/electron/package.json
@@ -41,7 +41,11 @@
     "eslint-plugin-n": "^17.23.1"
   },
   "overrides": {
-    "brace-expansion": ">=1.1.13"
+    "brace-expansion": ">=1.1.13",
+    "form-data": "4.0.6",
+    "joi": "18.2.1",
+    "js-yaml": "4.2.0",
+    "tar": "7.5.16"
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",


### PR DESCRIPTION
## Summary

The Next.js middleware in `client/src/proxy.js` built its SSR `fetch()` URL as `new URL('/api/initial-setup', request.url)`. When the browser loads `https://host/`, `request.url` is the public HTTPS URL, so the middleware's SSR fetch tried to reach the app **via the reverse proxy** — and Node's undici fetch failed on the proxy's self-signed cert. In my setup (Caddy with `tls internal`) the error was:

```
TypeError: fetch failed
  [cause]: Error: error:0A0000C6:SSL routines:tls_get_more_records:packet length too long
  code: 'ERR_SSL_PACKET_LENGTH_TOO_LONG'
```

The `try/catch` swallowed the error, `initialized` stayed `null`, and the middleware fell through to the "no refresh token → /auth" branch — so new installs behind a reverse proxy **never reached the onboarding wizard**, even though the backend correctly reported `{initialized: false}`.

## Fix

Point SSR fetches at the **local Next.js process** directly via a new `INTERNAL_ORIGIN` constant:

```js
const INTERNAL_ORIGIN =
  process.env.INTERNAL_ORIGIN || `http://127.0.0.1:${process.env.PORT || 3000}`;
```

- **Docker**: Next.js binds to `0.0.0.0:3000` inside the container; `127.0.0.1:3000` from inside the same container still reaches it. No regression.
- **Electron**: `electron/utils/portAllocator.js` picks a free port in 3000–3100 and sets `PORT` in the spawned Next.js process's env (see `NextJsService.js:74`). `process.env.PORT || 3000` picks up the allocated port automatically.
- **Native** (`scripts/install.sh`): systemd unit doesn't override `PORT`, defaults to 3000.
- **`npm run dev`**: dev server on 3000. Works.
- **`INTERNAL_ORIGIN` env var** is an escape hatch for anyone binding Next.js to a non-loopback interface.

## Related — WebSockets behind a reverse proxy

I originally had a second patch in this PR for `getWsUrl()` in `config/api.js` — the WebSocket URL was hardcoded to `wss://host:9154` which didn't work behind a proxy (port 9154 isn't exposed, isn't TLS). Good news: I see #504 already refactored WebSocket handling to use a same-origin SSE route at `/api/ws-payments`, which works perfectly behind a proxy with no client-side changes. So that piece is already solved on `development`; this PR is now scoped to just the middleware fix.

## Reproducing / reviewer setup

If you want to reproduce the bug (and verify this PR fixes it), here's the exact Caddy config I used on Debian 12 (bookworm) in front of a native install.

**Install Caddy:**

```bash
sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
sudo apt update
sudo apt install -y caddy
```

**`/etc/caddy/Caddyfile`** (substitute your own hostname):

```
{
    local_certs
}

ambrosia.local {
    tls internal
    reverse_proxy localhost:3000
}
```

Then `sudo systemctl restart caddy`.

With `tls internal`, Caddy generates a local CA + leaf cert for the hostname, listens on 443 with a valid-but-untrusted TLS chain, and auto-redirects plain HTTP on port 80 to HTTPS. Everything goes through Next.js on port 3000, including the new `/api/ws-payments` SSE route — no separate `/ws/*` reverse_proxy needed.

**Also useful**, add a loopback entry so the machine can resolve its own `.local` name (Avahi doesn't answer queries for the machine's own hostname):

```
127.0.1.1 ambrosia.local
```

The middleware fix in this PR means Next.js no longer needs this to reach itself, but other internal tools (`curl`, health checks, etc.) still benefit.

## Test plan

- [x] Reproduced on a fresh install behind Caddy (`tls internal`) on `v0.6.0-beta` — wizard skipped
- [x] After patch applied to a rebuild of the client: wizard fires on first visit to `https://host/`
- [x] Plain-HTTP direct-to-Next.js install still works (no regression)
- [ ] Docker install (unchanged path — `fetch('http://127.0.0.1:3000/...')` from inside the `ambrosia-client` container is fine)
- [ ] Electron install (uses allocated `PORT` env — `INTERNAL_ORIGIN` picks it up automatically)

Context: hit this while building a fleet of OrangePi POS units behind per-unit Caddy for LAN-level HTTPS.

  Update (June 16, 2026)
  This PR has been rebased and expanded to include the following:
   - Security Fixes: Resolved high-severity vulnerabilities in Electron dependencies by implementing npm overrides in
     electron/package.json.
   - Code Cleanup: Removed explanatory comments in client/src/proxy.js as requested during review to maintain a cleaner
     codebase.
   - Rebase: Synchronized with the latest development branch, preserving the new CSP and nonce-based security logic.
