### PR TITLE
Feature/tours

### DIFF
--- a/client/src/components/auth/WalletGuard.jsx
+++ b/client/src/components/auth/WalletGuard.jsx
@@ -163,7 +163,7 @@ export default function WalletGuard({
               variant="bordered"
               type="button"
               className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              onPress={() => (onCancel ? onCancel() : router.back())}
+              onPress={() => (onCancel ? onCancel() : router.push("/store"))}
             >
               {cancelText}
             </Button>

--- a/client/src/components/pages/Store/Settings/Seed/Seed.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/Seed.jsx
@@ -24,6 +24,14 @@ export function Seed() {
     key: SEED_SETTINGS_TOUR_KEY,
     condition: !showAccess,
     delay: 500,
+    onBeforeStart: () => {
+      const el = document.getElementById("settings-seed-card");
+      if (el) {
+        el.style.scrollMarginTop = "80px";
+        el.scrollIntoView({ behavior: "instant", block: "start" });
+        el.style.scrollMarginTop = "";
+      }
+    },
     driverOptions: {
       allowClose: false,
       overlayOpacity: 0.5,

--- a/client/src/components/pages/Store/Settings/Seed/Seed.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/Seed.jsx
@@ -5,15 +5,47 @@ import { useState } from "react";
 import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { useTour } from "@/hooks/tour/useTour";
 import { getSeed } from "@/services/walletService";
 
 import { SeedCardLocked } from "./SeedCardLocked";
 import { SeedCardUnlocked } from "./SeedCardUnlocked";
 
+const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
+export const SEED_SEEN_KEY = "ambrosia:tour:seed-seen";
+
 export function Seed() {
   const t = useTranslations("settings");
+  const tTour = useTranslations("seedTour");
   const [showAccess, setShowAccess] = useState(false);
   const [seed, setSeed] = useState(null);
+
+  useTour({
+    key: SEED_SETTINGS_TOUR_KEY,
+    condition: !showAccess,
+    delay: 500,
+    driverOptions: {
+      allowClose: false,
+      overlayOpacity: 0.5,
+      steps: [
+        {
+          element: "#settings-seed-card",
+          popover: {
+            title: tTour("settingsTitle"),
+            description: tTour.raw("settingsDescription"),
+            side: "bottom",
+            align: "start",
+            nextBtnText: tTour("settingsButton"),
+            showButtons: ["next"],
+          },
+        },
+      ],
+      onDestroyStarted: () => {
+        localStorage.setItem(SEED_SEEN_KEY, "true");
+        window.dispatchEvent(new Event("seed-tour:seen"));
+      },
+    },
+  });
 
   const handleAuthorized = async () => {
     try {

--- a/client/src/components/pages/Store/Settings/Seed/SeedCardLocked.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/SeedCardLocked.jsx
@@ -5,7 +5,7 @@ import { AlertTriangle } from "lucide-react";
 
 export function SeedCardLocked({ onReveal, t }) {
   return (
-    <Card shadow="none" className="rounded-lg p-6 shadow-lg">
+    <Card id="settings-seed-card" shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
         <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
           {t("cardSeed.title")}

--- a/client/src/components/pages/Store/Settings/Seed/__tests__/Seed.test.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/__tests__/Seed.test.jsx
@@ -17,7 +17,7 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => ({
-  useTranslations: () => (key) => key,
+  useTranslations: () => Object.assign((key) => key, { raw: (key) => key }),
 }));
 
 jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children, onAuthorized, onCancel }) {

--- a/client/src/components/pages/Store/Settings/Tutorials/Tutorials.jsx
+++ b/client/src/components/pages/Store/Settings/Tutorials/Tutorials.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useTranslations } from "next-intl";
 
@@ -9,24 +9,45 @@ import { TutorialsCard } from "./TutorialsCard";
 const WALLET_TOUR_KEY = "ambrosia:tour:wallet-channel";
 const WALLET_GUARD_TOUR_KEY = "ambrosia:tour:wallet-guard";
 const WALLET_RECEIVE_TOUR_KEY = "ambrosia:tour:wallet-receive";
+const SEED_TOUR_KEY = "ambrosia:tour:seed";
+const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
+const SEED_SEEN_KEY = "ambrosia:tour:seed-seen";
 
 export function Tutorials({ onNavigate = (url) => window.location.assign(url) }) {
   const t = useTranslations("settings");
   const [walletTourSeen] = useState(
-    () => typeof window !== "undefined" && Boolean(localStorage.getItem(WALLET_TOUR_KEY)),
+    () => typeof window !== "undefined" && localStorage.getItem(WALLET_TOUR_KEY) === "visited",
+  );
+  const [seedTourSeen, setSeedTourSeen] = useState(
+    () => typeof window !== "undefined" && Boolean(localStorage.getItem(SEED_SEEN_KEY)),
   );
 
+  useEffect(() => {
+    const handler = () => setSeedTourSeen(true);
+    window.addEventListener("seed-tour:seen", handler);
+    return () => window.removeEventListener("seed-tour:seen", handler);
+  }, []);
+
   const handleResetWalletTour = () => {
-    localStorage.removeItem(WALLET_TOUR_KEY);
     localStorage.removeItem(WALLET_GUARD_TOUR_KEY);
     localStorage.removeItem(WALLET_RECEIVE_TOUR_KEY);
+    localStorage.setItem(WALLET_TOUR_KEY, "true");
+    localStorage.setItem(SEED_TOUR_KEY, "true");
+    onNavigate("/store");
+  };
+
+  const handleResetSeedTour = () => {
+    localStorage.removeItem(SEED_TOUR_KEY);
+    localStorage.removeItem(SEED_SETTINGS_TOUR_KEY);
     onNavigate("/store");
   };
 
   return (
     <TutorialsCard
       walletTourSeen={walletTourSeen}
-      onReplay={handleResetWalletTour}
+      seedTourSeen={seedTourSeen}
+      onReplayWallet={handleResetWalletTour}
+      onReplaySeed={handleResetSeedTour}
       t={t}
     />
   );

--- a/client/src/components/pages/Store/Settings/Tutorials/TutorialsCard.jsx
+++ b/client/src/components/pages/Store/Settings/Tutorials/TutorialsCard.jsx
@@ -2,7 +2,34 @@
 
 import { Button, Card, CardBody, CardHeader, Chip } from "@heroui/react";
 
-export function TutorialsCard({ walletTourSeen, onReplay, t }) {
+function TourRow({ name, description, seen, onReplay, t }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm sm:text-base font-semibold text-gray-700">{name}</div>
+        <div className="text-xs sm:text-sm text-gray-500">{description}</div>
+      </div>
+      <div className="flex items-center gap-3 shrink-0">
+        <Chip
+          className={seen ? "bg-green-200 text-xs text-green-800 border border-green-300" : "bg-amber-100 text-amber-800 border border-amber-200"}
+          size="sm"
+          variant="flat"
+        >
+          {seen ? t("cardTours.seen") : t("cardTours.pending")}
+        </Chip>
+        <Button
+          color="primary"
+          className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+          onPress={onReplay}
+        >
+          {t("cardTours.replayButton")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function TutorialsCard({ walletTourSeen, seedTourSeen, onReplayWallet, onReplaySeed, t }) {
   return (
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
@@ -14,31 +41,21 @@ export function TutorialsCard({ walletTourSeen, onReplay, t }) {
       <CardBody>
         <div className="flex flex-col max-w-2xl space-y-2">
           <p className="text-sm text-gray-500 mb-2">{t("cardTours.subtitle")}</p>
-          <div className="flex flex-col gap-3">
-            <div>
-              <div className="text-sm sm:text-base font-semibold text-gray-700">
-                {t("cardTours.walletTour.name")}
-              </div>
-              <div className="text-xs sm:text-sm text-gray-500">
-                {t("cardTours.walletTour.description")}
-              </div>
-            </div>
-            <div className="flex items-center gap-3 shrink-0">
-              <Chip
-                className={walletTourSeen ? "bg-green-200 text-xs text-green-800 border border-green-300" : "bg-amber-100 text-amber-800 border border-amber-200"}
-                size="sm"
-                variant="flat"
-              >
-                {walletTourSeen ? t("cardTours.seen") : t("cardTours.pending")}
-              </Chip>
-              <Button
-                color="primary"
-                className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
-                onPress={onReplay}
-              >
-                {t("cardTours.replayButton")}
-              </Button>
-            </div>
+          <div className="flex flex-col gap-6">
+            <TourRow
+              name={t("cardTours.walletTour.name")}
+              description={t("cardTours.walletTour.description")}
+              seen={walletTourSeen}
+              onReplay={onReplayWallet}
+              t={t}
+            />
+            <TourRow
+              name={t("cardTours.seedTour.name")}
+              description={t("cardTours.seedTour.description")}
+              seen={seedTourSeen}
+              onReplay={onReplaySeed}
+              t={t}
+            />
           </div>
         </div>
       </CardBody>

--- a/client/src/components/pages/Store/Settings/Tutorials/__tests__/Tutorials.test.jsx
+++ b/client/src/components/pages/Store/Settings/Tutorials/__tests__/Tutorials.test.jsx
@@ -19,6 +19,8 @@ jest.mock("next-intl", () => ({
 const WALLET_TOUR_KEY = "ambrosia:tour:wallet-channel";
 const WALLET_GUARD_TOUR_KEY = "ambrosia:tour:wallet-guard";
 const WALLET_RECEIVE_TOUR_KEY = "ambrosia:tour:wallet-receive";
+const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
+const SEED_SEEN_KEY = "ambrosia:tour:seed-seen";
 
 beforeEach(() => {
   localStorage.clear();
@@ -34,51 +36,113 @@ function renderTutorials(props = {}) {
 
 describe("Tutorials", () => {
   describe("Initial state", () => {
-    it("shows 'pending' when WALLET_TOUR_KEY is absent", () => {
+    it("shows 'pending' for wallet when WALLET_TOUR_KEY is absent", () => {
       renderTutorials();
-      expect(screen.getByText("cardTours.pending")).toBeInTheDocument();
+      expect(screen.getAllByText("cardTours.pending")[0]).toBeInTheDocument();
     });
 
-    it("shows 'seen' when WALLET_TOUR_KEY is present", () => {
-      localStorage.setItem(WALLET_TOUR_KEY, "true");
+    it("shows 'seen' for wallet when WALLET_TOUR_KEY is visited", () => {
+      localStorage.setItem(WALLET_TOUR_KEY, "visited");
       renderTutorials();
       expect(screen.getByText("cardTours.seen")).toBeInTheDocument();
     });
-  });
 
-  describe("Replay action", () => {
-    it("clears WALLET_TOUR_KEY when replay is pressed", async () => {
+    it("shows 'pending' for wallet when WALLET_TOUR_KEY is only started (not completed)", () => {
       localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderTutorials();
-      await act(async () => {
-        fireEvent.click(screen.getByText("cardTours.replayButton"));
-      });
-      expect(localStorage.getItem(WALLET_TOUR_KEY)).toBeNull();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(2);
     });
 
-    it("clears WALLET_GUARD_TOUR_KEY when replay is pressed", async () => {
+    it("shows 'pending' for seed when SEED_SEEN_KEY is absent", () => {
+      renderTutorials();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(2);
+    });
+
+    it("shows 'seen' for seed when SEED_SEEN_KEY is present", () => {
+      localStorage.setItem(SEED_SEEN_KEY, "true");
+      renderTutorials();
+      expect(screen.getAllByText("cardTours.seen")).toHaveLength(1);
+    });
+
+    it("updates seed status to seen when seed-tour:seen event fires", () => {
+      renderTutorials();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(2);
+      act(() => {
+        window.dispatchEvent(new Event("seed-tour:seen"));
+      });
+      expect(screen.getAllByText("cardTours.seen")).toHaveLength(1);
+    });
+  });
+
+  describe("Wallet replay action", () => {
+    it("sets WALLET_TOUR_KEY to 'true' when wallet replay is pressed", async () => {
+      renderTutorials();
+      await act(async () => {
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
+      });
+      expect(localStorage.getItem(WALLET_TOUR_KEY)).toBe("true");
+    });
+
+    it("sets SEED_TOUR_KEY to 'true' when wallet replay is pressed (prevents seed tour re-run)", async () => {
+      renderTutorials();
+      await act(async () => {
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
+      });
+      expect(localStorage.getItem("ambrosia:tour:seed")).toBe("true");
+    });
+
+    it("clears WALLET_GUARD_TOUR_KEY when wallet replay is pressed", async () => {
       localStorage.setItem(WALLET_GUARD_TOUR_KEY, "true");
       renderTutorials();
       await act(async () => {
-        fireEvent.click(screen.getByText("cardTours.replayButton"));
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
       });
       expect(localStorage.getItem(WALLET_GUARD_TOUR_KEY)).toBeNull();
     });
 
-    it("clears WALLET_RECEIVE_TOUR_KEY when replay is pressed", async () => {
+    it("clears WALLET_RECEIVE_TOUR_KEY when wallet replay is pressed", async () => {
       localStorage.setItem(WALLET_RECEIVE_TOUR_KEY, "true");
       renderTutorials();
       await act(async () => {
-        fireEvent.click(screen.getByText("cardTours.replayButton"));
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
       });
       expect(localStorage.getItem(WALLET_RECEIVE_TOUR_KEY)).toBeNull();
     });
 
-    it("calls onNavigate with /store when replay is pressed", async () => {
+    it("calls onNavigate with /store when wallet replay is pressed", async () => {
       const onNavigate = jest.fn();
       renderTutorials({ onNavigate });
       await act(async () => {
-        fireEvent.click(screen.getByText("cardTours.replayButton"));
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
+      });
+      expect(onNavigate).toHaveBeenCalledWith("/store");
+    });
+  });
+
+  describe("Seed replay action", () => {
+    it("clears SEED_TOUR_KEY when seed replay is pressed", async () => {
+      localStorage.setItem("ambrosia:tour:seed", "true");
+      renderTutorials();
+      await act(async () => {
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[1]);
+      });
+      expect(localStorage.getItem("ambrosia:tour:seed")).toBeNull();
+    });
+
+    it("clears SEED_SETTINGS_TOUR_KEY when seed replay is pressed", async () => {
+      localStorage.setItem(SEED_SETTINGS_TOUR_KEY, "true");
+      renderTutorials();
+      await act(async () => {
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[1]);
+      });
+      expect(localStorage.getItem(SEED_SETTINGS_TOUR_KEY)).toBeNull();
+    });
+
+    it("calls onNavigate with /store when seed replay is pressed", async () => {
+      const onNavigate = jest.fn();
+      renderTutorials({ onNavigate });
+      await act(async () => {
+        fireEvent.click(screen.getAllByText("cardTours.replayButton")[1]);
       });
       expect(onNavigate).toHaveBeenCalledWith("/store");
     });

--- a/client/src/components/pages/Store/Settings/Tutorials/__tests__/TutorialsCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Tutorials/__tests__/TutorialsCard.test.jsx
@@ -18,7 +18,9 @@ function renderCard(props = {}) {
   return render(
     <TutorialsCard
       walletTourSeen={false}
-      onReplay={jest.fn()}
+      seedTourSeen={false}
+      onReplayWallet={jest.fn()}
+      onReplaySeed={jest.fn()}
       t={t}
       {...props}
     />,
@@ -43,23 +45,35 @@ describe("TutorialsCard", () => {
       expect(screen.getByText("cardTours.walletTour.description")).toBeInTheDocument();
     });
 
-    it("renders the replay button", () => {
+    it("renders the seed tour name and description", () => {
       renderCard();
-      expect(screen.getByText("cardTours.replayButton")).toBeInTheDocument();
+      expect(screen.getByText("cardTours.seedTour.name")).toBeInTheDocument();
+      expect(screen.getByText("cardTours.seedTour.description")).toBeInTheDocument();
+    });
+
+    it("renders two replay buttons", () => {
+      renderCard();
+      expect(screen.getAllByText("cardTours.replayButton")).toHaveLength(2);
     });
   });
 
-  describe("Tour status badge", () => {
-    it("shows 'pending' badge when walletTourSeen is false", () => {
-      renderCard({ walletTourSeen: false });
-      expect(screen.getByText("cardTours.pending")).toBeInTheDocument();
+  describe("Tour status badges", () => {
+    it("shows two 'pending' badges when both tours unseen", () => {
+      renderCard({ walletTourSeen: false, seedTourSeen: false });
       expect(screen.queryByText("cardTours.seen")).not.toBeInTheDocument();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(2);
     });
 
-    it("shows 'seen' badge when walletTourSeen is true", () => {
-      renderCard({ walletTourSeen: true });
+    it("shows 'seen' for wallet when walletTourSeen is true", () => {
+      renderCard({ walletTourSeen: true, seedTourSeen: false });
       expect(screen.getByText("cardTours.seen")).toBeInTheDocument();
-      expect(screen.queryByText("cardTours.pending")).not.toBeInTheDocument();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(1);
+    });
+
+    it("shows 'seen' for seed when seedTourSeen is true", () => {
+      renderCard({ walletTourSeen: false, seedTourSeen: true });
+      expect(screen.getByText("cardTours.seen")).toBeInTheDocument();
+      expect(screen.getAllByText("cardTours.pending")).toHaveLength(1);
     });
 
     it("renders 'seen' badge with green style", () => {
@@ -68,17 +82,24 @@ describe("TutorialsCard", () => {
     });
 
     it("renders 'pending' badge with amber style", () => {
-      renderCard({ walletTourSeen: false });
-      expect(screen.getByText("cardTours.pending").className).toContain("bg-amber-100");
+      renderCard();
+      expect(screen.getAllByText("cardTours.pending")[0].className).toContain("bg-amber-100");
     });
   });
 
   describe("Interaction", () => {
-    it("calls onReplay when replay button is pressed", () => {
-      const onReplay = jest.fn();
-      renderCard({ onReplay });
-      fireEvent.click(screen.getByText("cardTours.replayButton"));
-      expect(onReplay).toHaveBeenCalledTimes(1);
+    it("calls onReplayWallet when wallet replay button is pressed", () => {
+      const onReplayWallet = jest.fn();
+      renderCard({ onReplayWallet });
+      fireEvent.click(screen.getAllByText("cardTours.replayButton")[0]);
+      expect(onReplayWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onReplaySeed when seed replay button is pressed", () => {
+      const onReplaySeed = jest.fn();
+      renderCard({ onReplaySeed });
+      fireEvent.click(screen.getAllByText("cardTours.replayButton")[1]);
+      expect(onReplaySeed).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
+++ b/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
@@ -59,7 +59,7 @@ export function SidebarContent({
             availableNavigation.map((item, index) => (
               <NavBarButton
                 key={`${item.path}-${index}`}
-                id={withTourIds && item.label === "wallet" ? "nav-wallet" : undefined}
+                id={withTourIds ? item.tourId : undefined}
                 text={t(item.label)}
                 icon={item.icon}
                 href={item.path}

--- a/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
+++ b/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
@@ -44,8 +44,8 @@ export function SidebarContent({
             src={logoSrc || ambrosia}
             alt="ambrosia"
             width={160}
-            height={48}
-            className="object-contain"
+            height={160}
+            className="object-contain max-h-40 w-auto"
           />
         </Link>
         <p className="text-slate-100 text-center mt-4">

--- a/client/src/components/pages/Store/StoreLayout/StoreLayout.jsx
+++ b/client/src/components/pages/Store/StoreLayout/StoreLayout.jsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 import { ShiftWidget } from "@/components/turn/ShiftWidget";
+import { useSeedTour } from "@/hooks/tour/useSeedTour";
 import { useWalletTour } from "@/hooks/tour/useWalletTour";
 import { storedAssetUrl } from "@components/utils/storedAssetUrl";
 import { useModules } from "@hooks/useModules";
@@ -24,6 +25,7 @@ export function StoreLayout({ children }) {
   const logoSrc = storedAssetUrl(config?.businessLogoUrl);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  useSeedTour(isAuth);
   useWalletTour(isAuth);
 
   const bottomNavItems = availableNavigation

--- a/client/src/components/pages/Store/StoreLayout/__tests__/Sidebar.test.jsx
+++ b/client/src/components/pages/Store/StoreLayout/__tests__/Sidebar.test.jsx
@@ -81,7 +81,7 @@ describe("SidebarContent", () => {
 
   it("adds nav-wallet id to wallet item when withTourIds is true", () => {
     const navWithWallet = [
-      { path: "/store/wallet", label: "wallet", icon: "users", showInNavbar: true },
+      { path: "/store/wallet", label: "wallet", icon: "users", showInNavbar: true, tourId: "nav-wallet" },
     ];
     renderSidebar({ availableNavigation: navWithWallet, withTourIds: true });
     expect(screen.getByText("wallet").closest("a")).toHaveAttribute("id", "nav-wallet");

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -9,6 +9,7 @@ import { useTranslations } from "next-intl";
 import { useTour } from "@/hooks/tour/useTour";
 
 const WALLET_RECEIVE_TOUR_KEY = "ambrosia:tour:wallet-receive";
+const WALLET_TOUR_KEY = "ambrosia:tour:wallet-channel";
 
 import { HistoryTab } from "./HistoryTab";
 import { ReceiveTab } from "./ReceiveTab";
@@ -64,6 +65,9 @@ export function Transactions({
           },
         },
       ],
+      onDestroyStarted: () => {
+        localStorage.setItem(WALLET_TOUR_KEY, "visited");
+      },
     },
     onBeforeStart: () => {
       document.getElementById("wallet-receive-amount")?.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -32,7 +32,7 @@ export function Transactions({
     key: WALLET_RECEIVE_TOUR_KEY,
     delay: 500,
     driverOptions: {
-      allowClose: true,
+      allowClose: false,
       overlayOpacity: 0.5,
       showProgress: true,
       steps: [

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -12,6 +12,16 @@ const storeEn = {
     orders: "Orders",
     reports: "Reports",
   },
+  seedTour: {
+    title: "Protect your SEED Phrase!",
+    description: "Your <b>SEED Phrase</b> is the master key to your Bitcoin wallet. It lets you recover all your funds if you lose access. <b>Write it on paper and keep it somewhere safe, never share it.</b>",
+    clickSettings: "Go to Settings to view and back up your SEED Phrase.",
+    nextButton: "Go to Settings",
+    mobileGoToSettings: "Go to Settings",
+    settingsTitle: "SEED Phrase",
+    settingsDescription: "Here you can view your SEED Phrase. These are the words that let you recover your Bitcoin wallet. <b>Write them on paper and keep them in a safe place.</b> Never save them digitally or share them with anyone.",
+    settingsButton: "Got it",
+  },
   walletTour: {
     title: "Before you start!",
     description: "To receive <b>Bitcoin payments</b> you need to open a <b>Lightning channel</b>.",
@@ -808,6 +818,10 @@ const storeEn = {
       walletTour: {
         name: "Lightning Channel",
         description: "Learn how to create your Lightning channel and receive Bitcoin payments.",
+      },
+      seedTour: {
+        name: "SEED Phrase",
+        description: "Learn what your SEED Phrase is and how to keep it safe.",
       },
     },
   },

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -14,12 +14,12 @@ const storeEn = {
   },
   seedTour: {
     title: "Protect your SEED Phrase!",
-    description: "Your <b>SEED Phrase</b> is the master key to your Bitcoin wallet. It lets you recover all your funds if you lose access. <b>Write it on paper and keep it somewhere safe, never share it.</b>",
+    description: "Your SEED Phrase is the <b>master key</b> to your Bitcoin wallet. If you lose access to the app, it's the only way to recover your funds.",
     clickSettings: "Go to Settings to view and back up your SEED Phrase.",
     nextButton: "Go to Settings",
     mobileGoToSettings: "Go to Settings",
-    settingsTitle: "SEED Phrase",
-    settingsDescription: "Here you can view your SEED Phrase. These are the words that let you recover your Bitcoin wallet. <b>Write them on paper and keep them in a safe place.</b> Never save them digitally or share them with anyone.",
+    settingsTitle: "Back up your SEED Phrase",
+    settingsDescription: "Write down all <b>12 words in order</b> on paper and store them somewhere safe — offline.",
     settingsButton: "Got it",
   },
   walletTour: {

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -12,6 +12,16 @@ const storeEs = {
     orders: "Ordenes",
     reports: "Reportes",
   },
+  seedTour: {
+    title: "¡Protege tu SEED Phrase!",
+    description: "Tu <b>SEED Phrase</b> es la clave maestra de tu wallet Bitcoin. Con ella puedes recuperar todos tus fondos si pierdes acceso. <b>Escríbela en papel y guárdala en un lugar seguro, nunca la compartas.</b>",
+    clickSettings: "Ve a Configuración para ver y respaldar tu SEED Phrase.",
+    nextButton: "Ir a Configuración",
+    mobileGoToSettings: "Ir a Configuración",
+    settingsTitle: "SEED Phrase",
+    settingsDescription: "Aquí puedes ver tu SEED Phrase. Son las palabras clave que te permiten recuperar tu wallet Bitcoin. <b>Escríbelas en papel y guárdalas en un lugar seguro.</b> Nunca las guardes en formato digital ni las compartas con nadie.",
+    settingsButton: "Entendido",
+  },
   walletTour: {
     title: "¡Antes de comenzar!",
     description: "Para recibir <b>pagos con Bitcoin</b> necesitas abrir un <b>canal Lightning</b>.",
@@ -808,6 +818,10 @@ const storeEs = {
       walletTour: {
         name: "Canal de Lightning",
         description: "Aprende a crear tu canal Lightning y recibir pagos con Bitcoin.",
+      },
+      seedTour: {
+        name: "SEED Phrase",
+        description: "Aprende qué es tu SEED Phrase y cómo protegerla correctamente.",
       },
     },
   },

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -14,12 +14,12 @@ const storeEs = {
   },
   seedTour: {
     title: "¡Protege tu SEED Phrase!",
-    description: "Tu <b>SEED Phrase</b> es la clave maestra de tu wallet Bitcoin. Con ella puedes recuperar todos tus fondos si pierdes acceso. <b>Escríbela en papel y guárdala en un lugar seguro, nunca la compartas.</b>",
+    description: "Tu SEED Phrase es la <b>clave maestra</b> de tu wallet Bitcoin. Si pierdes acceso a la app, es la única forma de recuperar tus fondos.",
     clickSettings: "Ve a Configuración para ver y respaldar tu SEED Phrase.",
     nextButton: "Ir a Configuración",
     mobileGoToSettings: "Ir a Configuración",
-    settingsTitle: "SEED Phrase",
-    settingsDescription: "Aquí puedes ver tu SEED Phrase. Son las palabras clave que te permiten recuperar tu wallet Bitcoin. <b>Escríbelas en papel y guárdalas en un lugar seguro.</b> Nunca las guardes en formato digital ni las compartas con nadie.",
+    settingsTitle: "Respalda tu SEED Phrase",
+    settingsDescription: "Escribe las <b>12 palabras en orden</b> en papel y guárdalas en un lugar seguro — sin conexión a internet.",
     settingsButton: "Entendido",
   },
   walletTour: {

--- a/client/src/hooks/tour/__tests__/useSeedTour.test.js
+++ b/client/src/hooks/tour/__tests__/useSeedTour.test.js
@@ -197,10 +197,14 @@ describe("useSeedTour", () => {
       expect(capturedConfig.steps[0].element).toBeUndefined();
     });
 
-    it("has onDestroyStarted on mobile to set SEED_SETTINGS_TOUR_KEY", () => {
+    it("has onDestroyStarted on mobile to destroy the driver", () => {
       renderHook(() => useSeedTour(true));
       expect(capturedConfig.onDestroyStarted).toBeDefined();
-      capturedConfig.onDestroyStarted();
+    });
+
+    it("sets SEED_SETTINGS_TOUR_KEY when timer fires on mobile", () => {
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
       expect(setItemSpy).toHaveBeenCalledWith(SEED_SETTINGS_TOUR_KEY, "true");
     });
   });

--- a/client/src/hooks/tour/__tests__/useSeedTour.test.js
+++ b/client/src/hooks/tour/__tests__/useSeedTour.test.js
@@ -1,0 +1,207 @@
+import { renderHook } from "@testing-library/react";
+
+import { useSeedTour } from "../useSeedTour";
+
+const mockDrive = jest.fn();
+const mockDestroy = jest.fn();
+let capturedConfig = {};
+
+jest.mock("driver.js", () => ({
+  driver: jest.fn((config) => {
+    capturedConfig = config;
+    return { drive: mockDrive, destroy: mockDestroy };
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/store"),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => {
+    const fn = (key) => key;
+    fn.raw = (key) => key;
+    return fn;
+  },
+}));
+
+const SEED_TOUR_KEY = "ambrosia:tour:seed";
+const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
+
+function setDesktop() {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 1024 });
+}
+
+function setMobile() {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+}
+
+let setItemSpy;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  localStorage.clear();
+  capturedConfig = {};
+  setDesktop();
+  setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+  const { usePathname } = require("next/navigation");
+  usePathname.mockReturnValue("/store");
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  setItemSpy.mockRestore();
+});
+
+describe("useSeedTour", () => {
+  describe("tour initialization", () => {
+    it("does not start tour when not authenticated", () => {
+      renderHook(() => useSeedTour(false));
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("does not start tour when SEED_TOUR_KEY is already set", () => {
+      localStorage.setItem(SEED_TOUR_KEY, "true");
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("does not start tour when not on /store", () => {
+      const { usePathname } = require("next/navigation");
+      usePathname.mockReturnValue("/store/settings");
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("starts tour when authenticated, on /store, and SEED_TOUR_KEY is absent", () => {
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
+      expect(mockDrive).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call drive() before timer fires", () => {
+      renderHook(() => useSeedTour(true));
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("sets SEED_TOUR_KEY to 'true' in localStorage when timer fires", () => {
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
+      expect(localStorage.getItem(SEED_TOUR_KEY)).toBe("true");
+    });
+  });
+
+  describe("pathname effect — timer reset", () => {
+    it("resets the pending timer when returning to /store without key", () => {
+      const { usePathname } = require("next/navigation");
+      usePathname.mockReturnValue("/store/settings");
+      const { rerender } = renderHook(() => useSeedTour(true));
+
+      usePathname.mockReturnValue("/store");
+      rerender();
+
+      jest.runAllTimers();
+      expect(mockDrive).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reset timer when returning to /store if SEED_TOUR_KEY is already set", () => {
+      localStorage.setItem(SEED_TOUR_KEY, "true");
+      const { usePathname } = require("next/navigation");
+      usePathname.mockReturnValue("/store/settings");
+      const { rerender } = renderHook(() => useSeedTour(true));
+
+      usePathname.mockReturnValue("/store");
+      rerender();
+
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pathname effect — driver cleanup", () => {
+    it("destroys the driver when navigating away from /store", () => {
+      const { usePathname } = require("next/navigation");
+      usePathname.mockReturnValue("/store");
+      const { rerender } = renderHook(() => useSeedTour(true));
+
+      usePathname.mockReturnValue("/store/settings");
+      rerender();
+
+      expect(mockDestroy).toHaveBeenCalled();
+    });
+
+    it("does not destroy driver when staying on /store", () => {
+      renderHook(() => useSeedTour(true));
+      jest.runAllTimers();
+      expect(mockDestroy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("desktop tour (>= 768px)", () => {
+    it("creates 2 steps on desktop", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps).toHaveLength(2);
+    });
+
+    it("first step has next button", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[0].popover.showButtons).toEqual(["next"]);
+    });
+
+    it("second step targets #nav-settings", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[1].element).toBe("#nav-settings");
+    });
+
+    it("sets SEED_SETTINGS_TOUR_KEY onHighlighted", () => {
+      renderHook(() => useSeedTour(true));
+      capturedConfig.steps[1].onHighlighted();
+      expect(setItemSpy).toHaveBeenCalledWith(SEED_SETTINGS_TOUR_KEY, "true");
+    });
+
+    it("does not have onDestroyStarted on desktop", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.onDestroyStarted).toBeUndefined();
+    });
+  });
+
+  describe("mobile tour (< 768px)", () => {
+    beforeEach(() => setMobile());
+
+    it("creates 1 step on mobile", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps).toHaveLength(1);
+    });
+
+    it("single step has close button", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[0].popover.showButtons).toEqual(["close"]);
+    });
+
+    it("mobile step description includes a link to /store/settings", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[0].popover.description).toContain("/store/settings");
+    });
+
+    it("mobile step description includes the button label", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[0].popover.description).toContain("mobileGoToSettings");
+    });
+
+    it("does not target any element on mobile", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.steps[0].element).toBeUndefined();
+    });
+
+    it("has onDestroyStarted on mobile to set SEED_SETTINGS_TOUR_KEY", () => {
+      renderHook(() => useSeedTour(true));
+      expect(capturedConfig.onDestroyStarted).toBeDefined();
+      capturedConfig.onDestroyStarted();
+      expect(setItemSpy).toHaveBeenCalledWith(SEED_SETTINGS_TOUR_KEY, "true");
+    });
+  });
+});

--- a/client/src/hooks/tour/__tests__/useWalletTour.test.js
+++ b/client/src/hooks/tour/__tests__/useWalletTour.test.js
@@ -57,14 +57,14 @@ afterEach(() => {
 
 describe("useWalletTour", () => {
   describe("wallet pathname effect", () => {
-    it("sets guard and receive keys on first wallet visit (WALLET_TOUR_KEY = 'true')", () => {
+    it("does not set guard/receive keys on wallet visit (keys are set by tour events, not pathname)", () => {
       localStorage.setItem(WALLET_TOUR_KEY, "true");
       const { usePathname } = require("next/navigation");
       usePathname.mockReturnValue("/store/wallet");
       renderHook(() => useWalletTour(false));
-      expect(setItemSpy).toHaveBeenCalledWith(WALLET_GUARD_TOUR_KEY, "true");
-      expect(setItemSpy).toHaveBeenCalledWith(WALLET_RECEIVE_TOUR_KEY, "true");
-      expect(setItemSpy).toHaveBeenCalledWith(WALLET_TOUR_KEY, "visited");
+      expect(setItemSpy).not.toHaveBeenCalledWith(WALLET_GUARD_TOUR_KEY, "true");
+      expect(setItemSpy).not.toHaveBeenCalledWith(WALLET_RECEIVE_TOUR_KEY, "true");
+      expect(setItemSpy).not.toHaveBeenCalledWith(WALLET_TOUR_KEY, "visited");
     });
 
     it("does not set guard/receive keys on subsequent wallet visits (WALLET_TOUR_KEY = 'visited')", () => {
@@ -131,17 +131,17 @@ describe("useWalletTour", () => {
       expect(capturedConfig.steps[1].element).toBe("#nav-wallet");
     });
 
-    it("sets guard, receive and visited keys onHighlighted", () => {
+    it("sets guard and receive keys onHighlighted (not visited)", () => {
       renderHook(() => useWalletTour(true));
       capturedConfig.steps[1].onHighlighted();
-      expect(setItemSpy).toHaveBeenCalledWith(WALLET_TOUR_KEY, "visited");
+      expect(setItemSpy).not.toHaveBeenCalledWith(WALLET_TOUR_KEY, "visited");
       expect(setItemSpy).toHaveBeenCalledWith(WALLET_GUARD_TOUR_KEY, "true");
       expect(setItemSpy).toHaveBeenCalledWith(WALLET_RECEIVE_TOUR_KEY, "true");
     });
 
-    it("does not have onDestroyed on desktop", () => {
+    it("does not have onDestroyStarted on desktop", () => {
       renderHook(() => useWalletTour(true));
-      expect(capturedConfig.onDestroyed).toBeUndefined();
+      expect(capturedConfig.onDestroyStarted).toBeUndefined();
     });
 
     it("sets nextBtnText without arrow", () => {
@@ -184,9 +184,20 @@ describe("useWalletTour", () => {
       expect(capturedConfig.steps[0].element).toBeUndefined();
     });
 
-    it("does not have onDestroyed on mobile (keys set via pathname effect)", () => {
+    it("has onDestroyStarted on mobile to set guard and receive keys", () => {
       renderHook(() => useWalletTour(true));
-      expect(capturedConfig.onDestroyed).toBeUndefined();
+      expect(capturedConfig.onDestroyStarted).toBeDefined();
+      capturedConfig.onDestroyStarted();
+      expect(setItemSpy).toHaveBeenCalledWith(WALLET_GUARD_TOUR_KEY, "true");
+      expect(setItemSpy).toHaveBeenCalledWith(WALLET_RECEIVE_TOUR_KEY, "true");
+    });
+  });
+
+  describe("desktop tour (>= 768px) — onDestroyStarted", () => {
+    it("does not have onDestroyStarted on desktop", () => {
+      Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 1024 });
+      renderHook(() => useWalletTour(true));
+      expect(capturedConfig.onDestroyStarted).toBeUndefined();
     });
   });
 });

--- a/client/src/hooks/tour/__tests__/useWalletTour.test.js
+++ b/client/src/hooks/tour/__tests__/useWalletTour.test.js
@@ -92,30 +92,51 @@ describe("useWalletTour", () => {
 
   describe("tour initialization", () => {
     it("does not start tour when not authenticated", () => {
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderHook(() => useWalletTour(false));
+      jest.runAllTimers();
       expect(mockDrive).not.toHaveBeenCalled();
     });
 
-    it("starts tour when authenticated for the first time", () => {
+    it("does not start tour without WALLET_TOUR_KEY", () => {
+      renderHook(() => useWalletTour(true));
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("does not start tour when WALLET_TOUR_KEY is 'visited'", () => {
+      localStorage.setItem(WALLET_TOUR_KEY, "visited");
+      renderHook(() => useWalletTour(true));
+      jest.runAllTimers();
+      expect(mockDrive).not.toHaveBeenCalled();
+    });
+
+    it("starts tour when WALLET_TOUR_KEY is 'true' and authenticated", () => {
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderHook(() => useWalletTour(true));
       jest.runAllTimers();
       expect(mockDrive).toHaveBeenCalledTimes(1);
     });
 
-    it("does not start tour if already seen", () => {
+    it("does not call drive() before timer fires", () => {
       localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderHook(() => useWalletTour(true));
       expect(mockDrive).not.toHaveBeenCalled();
     });
 
-    it("sets WALLET_TOUR_KEY in localStorage when starting", () => {
+    it("removes WALLET_TOUR_KEY from localStorage when timer fires", () => {
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderHook(() => useWalletTour(true));
       jest.runAllTimers();
-      expect(setItemSpy).toHaveBeenCalledWith(WALLET_TOUR_KEY, "true");
+      expect(localStorage.getItem(WALLET_TOUR_KEY)).toBeNull();
     });
   });
 
   describe("desktop tour (>= 768px)", () => {
+    beforeEach(() => {
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
+    });
+
     it("creates 2 steps on desktop", () => {
       renderHook(() => useWalletTour(true));
       expect(capturedConfig.steps).toHaveLength(2);
@@ -152,7 +173,10 @@ describe("useWalletTour", () => {
   });
 
   describe("mobile tour (< 768px)", () => {
-    beforeEach(() => setMobile());
+    beforeEach(() => {
+      setMobile();
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
+    });
 
     it("creates 1 step on mobile", () => {
       renderHook(() => useWalletTour(true));
@@ -196,6 +220,7 @@ describe("useWalletTour", () => {
   describe("desktop tour (>= 768px) — onDestroyStarted", () => {
     it("does not have onDestroyStarted on desktop", () => {
       Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 1024 });
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
       renderHook(() => useWalletTour(true));
       expect(capturedConfig.onDestroyStarted).toBeUndefined();
     });

--- a/client/src/hooks/tour/__tests__/useWalletTour.test.js
+++ b/client/src/hooks/tour/__tests__/useWalletTour.test.js
@@ -41,6 +41,7 @@ let setItemSpy;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.useFakeTimers();
   localStorage.clear();
   capturedConfig = {};
   setDesktop();
@@ -50,6 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   setItemSpy.mockRestore();
 });
 
@@ -96,6 +98,7 @@ describe("useWalletTour", () => {
 
     it("starts tour when authenticated for the first time", () => {
       renderHook(() => useWalletTour(true));
+      jest.runAllTimers();
       expect(mockDrive).toHaveBeenCalledTimes(1);
     });
 
@@ -107,6 +110,7 @@ describe("useWalletTour", () => {
 
     it("sets WALLET_TOUR_KEY in localStorage when starting", () => {
       renderHook(() => useWalletTour(true));
+      jest.runAllTimers();
       expect(setItemSpy).toHaveBeenCalledWith(WALLET_TOUR_KEY, "true");
     });
   });

--- a/client/src/hooks/tour/useSeedTour.js
+++ b/client/src/hooks/tour/useSeedTour.js
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { usePathname } from "next/navigation";
+
+import { driver } from "driver.js";
+import { useTranslations } from "next-intl";
+
+const SEED_TOUR_KEY = "ambrosia:tour:seed";
+const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
+
+export function useSeedTour(isAuth) {
+  const pathname = usePathname();
+  const tTour = useTranslations("seedTour");
+  const driverRef = useRef(null);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (pathname === "/store" && !localStorage.getItem(SEED_TOUR_KEY)) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    if (pathname === "/store") return;
+    if (driverRef.current) {
+      driverRef.current.destroy();
+      driverRef.current = null;
+    }
+  }, [pathname]);
+
+  const tourTitle = tTour("title");
+  const tourDescription = tTour.raw("description");
+  const tourClickSettings = tTour("clickSettings");
+  const tourNextButton = tTour("nextButton");
+  const tourMobileGoToSettings = tTour("mobileGoToSettings");
+
+  useEffect(() => {
+    if (!isAuth || timerRef.current) return;
+    if (localStorage.getItem(SEED_TOUR_KEY)) return;
+    if (pathname !== "/store") return;
+
+    const isMobile = window.innerWidth < 768;
+    const settingsLink = `<br/><br/><a href="/store/settings" style="display:inline-block;margin-top:4px;padding:8px 16px;background:#166534;color:#fff;border-radius:8px;text-decoration:none;font-size:14px">${tourMobileGoToSettings}</a>`;
+
+    const driverObj = driver({
+      allowClose: true,
+      overlayOpacity: 0.5,
+      nextBtnText: tourNextButton,
+      ...(isMobile && {
+        onDestroyStarted: () => {
+          localStorage.setItem(SEED_SETTINGS_TOUR_KEY, "true");
+          driverObj.destroy();
+        },
+      }),
+      steps: isMobile
+        ? [
+            {
+              popover: {
+                title: tourTitle,
+                description: `${tourDescription}${settingsLink}`,
+                showButtons: ["close"],
+              },
+            },
+          ]
+        : [
+            {
+              popover: {
+                title: tourTitle,
+                description: tourDescription,
+                showButtons: ["next"],
+              },
+            },
+            {
+              element: "#nav-settings",
+              popover: {
+                description: tourClickSettings,
+                side: "right",
+                align: "center",
+                showButtons: ["close"],
+              },
+              onHighlighted: () => {
+                localStorage.setItem(SEED_SETTINGS_TOUR_KEY, "true");
+              },
+            },
+          ],
+    });
+
+    driverRef.current = driverObj;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      localStorage.setItem(SEED_TOUR_KEY, "true");
+      driverObj.drive();
+    }, 800);
+  }, [isAuth, pathname, tourTitle, tourDescription, tourClickSettings, tourNextButton, tourMobileGoToSettings]);
+
+  useEffect(() => () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+}

--- a/client/src/hooks/tour/useSeedTour.js
+++ b/client/src/hooks/tour/useSeedTour.js
@@ -53,7 +53,6 @@ export function useSeedTour(isAuth) {
       nextBtnText: tourNextButton,
       ...(isMobile && {
         onDestroyStarted: () => {
-          localStorage.setItem(SEED_SETTINGS_TOUR_KEY, "true");
           driverObj.destroy();
         },
       }),
@@ -94,6 +93,7 @@ export function useSeedTour(isAuth) {
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       localStorage.setItem(SEED_TOUR_KEY, "true");
+      if (isMobile) localStorage.setItem(SEED_SETTINGS_TOUR_KEY, "true");
       driverObj.drive();
     }, 800);
   }, [isAuth, pathname, tourTitle, tourDescription, tourClickSettings, tourNextButton, tourMobileGoToSettings]);

--- a/client/src/hooks/tour/useTour.js
+++ b/client/src/hooks/tour/useTour.js
@@ -17,11 +17,13 @@ export function useTour({ key, condition = true, delay = 0, driverOptions, onBef
     if (!condition) return;
     if (!localStorage.getItem(key)) return;
 
+    let driverObj = null;
+
     const timer = setTimeout(() => {
       const options = driverOptionsRef.current;
       const teardown = onBeforeStartRef.current?.();
 
-      const driverObj = driver({
+      driverObj = driver({
         ...options,
         onDestroyStarted: () => {
           teardown?.();
@@ -34,6 +36,9 @@ export function useTour({ key, condition = true, delay = 0, driverOptions, onBef
       driverObj.drive();
     }, delay);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (driverObj) driverObj.destroy();
+    };
   }, [condition, key, delay]);
 }

--- a/client/src/hooks/tour/useWalletTour.js
+++ b/client/src/hooks/tour/useWalletTour.js
@@ -30,11 +30,6 @@ export function useWalletTour(isAuth) {
 
   useEffect(() => {
     if (!pathname.startsWith("/store/wallet")) return;
-    if (localStorage.getItem(WALLET_TOUR_KEY) === "true") {
-      localStorage.setItem(WALLET_TOUR_KEY, "visited");
-      localStorage.setItem(WALLET_GUARD_TOUR_KEY, "true");
-      localStorage.setItem(WALLET_RECEIVE_TOUR_KEY, "true");
-    }
     if (driverRef.current) {
       driverRef.current.destroy();
       driverRef.current = null;
@@ -64,6 +59,13 @@ export function useWalletTour(isAuth) {
       allowClose: true,
       overlayOpacity: 0.5,
       nextBtnText: tourNextButton,
+      ...(isMobile && {
+        onDestroyStarted: () => {
+          localStorage.setItem(WALLET_GUARD_TOUR_KEY, "true");
+          localStorage.setItem(WALLET_RECEIVE_TOUR_KEY, "true");
+          driverObj.destroy();
+        },
+      }),
       steps: isMobile
         ? [
             {
@@ -91,7 +93,6 @@ export function useWalletTour(isAuth) {
                 showButtons: ["close"],
               },
               onHighlighted: () => {
-                localStorage.setItem(WALLET_TOUR_KEY, "visited");
                 localStorage.setItem(WALLET_GUARD_TOUR_KEY, "true");
                 localStorage.setItem(WALLET_RECEIVE_TOUR_KEY, "true");
               },

--- a/client/src/hooks/tour/useWalletTour.js
+++ b/client/src/hooks/tour/useWalletTour.js
@@ -15,18 +15,7 @@ export function useWalletTour(isAuth) {
   const pathname = usePathname();
   const tTour = useTranslations("walletTour");
   const driverRef = useRef(null);
-  const tourStartedRef = useRef(false);
   const timerRef = useRef(null);
-
-  useEffect(() => {
-    if (pathname === "/store" && !localStorage.getItem(WALLET_TOUR_KEY)) {
-      tourStartedRef.current = false;
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    }
-  }, [pathname]);
 
   useEffect(() => {
     if (!pathname.startsWith("/store/wallet")) return;
@@ -50,7 +39,7 @@ export function useWalletTour(isAuth) {
 
   useEffect(() => {
     if (!isAuth || timerRef.current) return;
-    if (localStorage.getItem(WALLET_TOUR_KEY)) return;
+    if (localStorage.getItem(WALLET_TOUR_KEY) !== "true") return;
 
     const isMobile = window.innerWidth < 768;
     const walletButton = `<br/><br/><a href="/store/wallet" style="display:inline-block;margin-top:4px;padding:8px 16px;background:#166534;color:#fff;border-radius:8px;text-decoration:none;font-size:14px">${tourMobileGoToWallet}</a>`;
@@ -103,13 +92,15 @@ export function useWalletTour(isAuth) {
     driverRef.current = driverObj;
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
-      localStorage.setItem(WALLET_TOUR_KEY, "true");
-      tourStartedRef.current = true;
+      localStorage.removeItem(WALLET_TOUR_KEY);
       driverObj.drive();
     }, 800);
   }, [isAuth, tourTitle, tourDescription, tourClickWallet, tourNextButton, tourMobileGoToWallet]);
 
   useEffect(() => () => {
-    if (timerRef.current) clearTimeout(timerRef.current);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
   }, []);
 }

--- a/client/src/hooks/tour/useWalletTour.js
+++ b/client/src/hooks/tour/useWalletTour.js
@@ -16,6 +16,17 @@ export function useWalletTour(isAuth) {
   const tTour = useTranslations("walletTour");
   const driverRef = useRef(null);
   const tourStartedRef = useRef(false);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (pathname === "/store" && !localStorage.getItem(WALLET_TOUR_KEY)) {
+      tourStartedRef.current = false;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [pathname]);
 
   useEffect(() => {
     if (!pathname.startsWith("/store/wallet")) return;
@@ -43,11 +54,8 @@ export function useWalletTour(isAuth) {
   const tourMobileGoToWallet = tTour("mobileGoToWallet");
 
   useEffect(() => {
-    if (!isAuth || tourStartedRef.current) return;
+    if (!isAuth || timerRef.current) return;
     if (localStorage.getItem(WALLET_TOUR_KEY)) return;
-
-    tourStartedRef.current = true;
-    localStorage.setItem(WALLET_TOUR_KEY, "true");
 
     const isMobile = window.innerWidth < 768;
     const walletButton = `<br/><br/><a href="/store/wallet" style="display:inline-block;margin-top:4px;padding:8px 16px;background:#166534;color:#fff;border-radius:8px;text-decoration:none;font-size:14px">${tourMobileGoToWallet}</a>`;
@@ -92,6 +100,15 @@ export function useWalletTour(isAuth) {
     });
 
     driverRef.current = driverObj;
-    driverObj.drive();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      localStorage.setItem(WALLET_TOUR_KEY, "true");
+      tourStartedRef.current = true;
+      driverObj.drive();
+    }, 800);
   }, [isAuth, tourTitle, tourDescription, tourClickWallet, tourNextButton, tourMobileGoToWallet]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
 }

--- a/client/src/lib/modules.js
+++ b/client/src/lib/modules.js
@@ -255,6 +255,7 @@ export const modules = {
         label: "wallet",
         icon: "wallet",
         showInNavbar: true,
+        tourId: "nav-wallet",
       },
       {
         path: "/store/reports",
@@ -267,6 +268,7 @@ export const modules = {
         label: "settings",
         icon: "settings",
         showInNavbar: true,
+        tourId: "nav-settings",
       },
     ],
   },


### PR DESCRIPTION
## Changes:
- Add SEED Phrase guided tour: floating intro popover on `/store` (desktop 2-step, mobile 1-step with link to Settings), settings card highlight popover on `/store/settings`, and replay support from Settings > Tutorials                  
- Add Lightning Wallet guided tour: shown once after first login, replay-only from Settings > Tutorials (no longer auto-fires on every mount)
- Fix wallet tour re-appearing on every page navigation after cancelling step 1                                                                                                                                                              
- Fix wallet tour not firing from Tutorials replay button due to React Strict Mode double-invoke (timer ref not reset to null on cleanup)                                                                                                    
- Fix mobile SEED tour: settings card tour now triggers after navigating via the "Go to Settings" link (key set eagerly on timer fire instead of on `onDestroyStarted`)                                                                      
- Fix mobile popover covering the highlighted seed card — scroll element into view with 80px top margin before driver.js renders                                                                                                             
- Move nav item tour IDs out of hardcoded Sidebar ternaries into `tourId` field on navItem config in `modules.js`                                                                                                                            
- Fix driver.js overlay not destroyed on component unmount in `useTour`                                                                                                                                                                      
- Fix crash when user cancels WalletGuard during tour replay from Settings                                                                                                                                                                   
- Add maximum height for store logo in StoreLayout

## Related to
https://github.com/olympus-btc/ambrosia/issues/497