### PR TITLE
Fix(wallet): Wallet phoenix errors

### DIFF
--- a/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
@@ -5,73 +5,52 @@ import { useState } from "react";
 import { addToast, Button, Input } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { getPaymentErrorDescription } from "@/components/pages/Store/Wallet/utils/paymentErrors";
 import { payInvoiceFromService } from "@/services/walletService";
 
 import { PaymentSentModal } from "./PaymentSentModal";
-
-const PAYMENT_ERROR_TRANSLATIONS = {
-  invoice_already_paid: "payments.send.errors.invoiceAlreadyPaid",
-  invalid_invoice: "payments.send.errors.invalidInvoice",
-  insufficient_funds: "payments.send.errors.insufficientFunds",
-  node_unavailable: "payments.send.errors.nodeUnavailable",
-  invalid_payment_response: "payments.send.errors.unknown",
-};
 
 export function SendTab({ fetchInfo, fetchTransactions }) {
   const t = useTranslations("wallet");
   const [payInvoice, setPayInvoice] = useState("");
   const [paymentResult, setPaymentResult] = useState(null);
-  const [invalidInvoice, setInvalidInvoice] = useState(false);
+  const [invoiceValidationError, setInvoiceValidationError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
-  const validateBolt11 = (invoice) => {
-    if (!invoice || !invoice.trim()) {
-      return { valid: false, error: t("payments.send.noInvoiceToPay") };
+  const getBolt11ValidationError = (invoiceValue) => {
+    if (!invoiceValue || !invoiceValue.trim()) {
+      return t("payments.send.noInvoiceToPay");
     }
 
-    const trimmed = invoice.trim().toLowerCase();
+    const trimmedInvoice = invoiceValue.trim().toLowerCase();
     const validPrefixes = ["lnbc", "lntb", "lnbcrt"];
-    const hasValidPrefix = validPrefixes.some((prefix) => trimmed.startsWith(prefix));
+    const hasValidPrefix = validPrefixes.some((prefix) => trimmedInvoice.startsWith(prefix));
 
     if (!hasValidPrefix) {
-      return { valid: false, error: t("payments.send.invalidInvoiceFormat") };
+      return t("payments.send.invalidInvoiceFormat");
     }
 
-    if (trimmed.length < 20) {
-      return { valid: false, error: t("payments.send.invalidInvoiceFormat") };
+    if (trimmedInvoice.length < 20) {
+      return t("payments.send.invalidInvoiceFormat");
     }
 
-    return { valid: true };
-  };
-
-  const getPaymentErrorDescription = (error) => {
-    const translationKey = PAYMENT_ERROR_TRANSLATIONS[error?.code];
-
-    if (translationKey) {
-      return t(translationKey);
-    }
-
-    if (error?.message) {
-      return error.message;
-    }
-
-    return t("payments.send.errors.unknown");
+    return "";
   };
 
   const handlePayInvoice = async () => {
-    const validation = validateBolt11(payInvoice);
+    const validationError = getBolt11ValidationError(payInvoice);
 
-    if (!validation.valid) {
-      setInvalidInvoice(true);
+    if (validationError) {
+      setInvoiceValidationError(validationError);
       return;
     }
 
     try {
       setIsLoading(true);
-      const res = await payInvoiceFromService(payInvoice);
-      setPaymentResult(res);
+      const paymentResponse = await payInvoiceFromService(payInvoice);
+      setPaymentResult(paymentResponse);
       setPayInvoice("");
-      setInvalidInvoice(false);
+      setInvoiceValidationError("");
       fetchInfo?.();
       fetchTransactions?.();
       addToast({
@@ -84,7 +63,7 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
       console.error(err);
       addToast({
         title: t("payments.send.paymentError"),
-        description: getPaymentErrorDescription(err),
+        description: getPaymentErrorDescription(t, err),
         variant: "solid",
         color: "danger",
       });
@@ -101,11 +80,11 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
         value={payInvoice}
         onChange={(e) => {
           setPayInvoice(e.target.value);
-          setInvalidInvoice(false);
+          setInvoiceValidationError("");
         }}
         isDisabled={isLoading}
-        isInvalid={invalidInvoice}
-        errorMessage={invalidInvoice ? t("payments.send.invalidInvoiceFormat") : ""}
+        isInvalid={Boolean(invoiceValidationError)}
+        errorMessage={invoiceValidationError}
       />
       <Button
         onPress={handlePayInvoice}
@@ -121,7 +100,6 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
         result={paymentResult}
         onClose={() => setPaymentResult(null)}
       />
-
     </div>
   );
 }

--- a/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
@@ -60,7 +60,11 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
         color: "success",
       });
     } catch (err) {
-      console.error(err);
+      if (err?.code) {
+        console.warn(err);
+      } else {
+        console.error(err);
+      }
       addToast({
         title: t("payments.send.paymentError"),
         description: getPaymentErrorDescription(t, err),

--- a/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/SendTab.jsx
@@ -9,6 +9,14 @@ import { payInvoiceFromService } from "@/services/walletService";
 
 import { PaymentSentModal } from "./PaymentSentModal";
 
+const PAYMENT_ERROR_TRANSLATIONS = {
+  invoice_already_paid: "payments.send.errors.invoiceAlreadyPaid",
+  invalid_invoice: "payments.send.errors.invalidInvoice",
+  insufficient_funds: "payments.send.errors.insufficientFunds",
+  node_unavailable: "payments.send.errors.nodeUnavailable",
+  invalid_payment_response: "payments.send.errors.unknown",
+};
+
 export function SendTab({ fetchInfo, fetchTransactions }) {
   const t = useTranslations("wallet");
   const [payInvoice, setPayInvoice] = useState("");
@@ -36,6 +44,20 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
     return { valid: true };
   };
 
+  const getPaymentErrorDescription = (error) => {
+    const translationKey = PAYMENT_ERROR_TRANSLATIONS[error?.code];
+
+    if (translationKey) {
+      return t(translationKey);
+    }
+
+    if (error?.message) {
+      return error.message;
+    }
+
+    return t("payments.send.errors.unknown");
+  };
+
   const handlePayInvoice = async () => {
     const validation = validateBolt11(payInvoice);
 
@@ -61,8 +83,8 @@ export function SendTab({ fetchInfo, fetchTransactions }) {
     } catch (err) {
       console.error(err);
       addToast({
-        title: "Error",
-        description: t("payments.send.paymentErrorDescription"),
+        title: t("payments.send.paymentError"),
+        description: getPaymentErrorDescription(err),
         variant: "solid",
         color: "danger",
       });

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
@@ -30,12 +30,12 @@ const originalWarn = console.warn;
 const originalError = console.error;
 
 beforeEach(() => {
-  console.warn = (...args) => {
+  console.warn = jest.fn((...args) => {
     if (typeof args[0] === "string" && args[0].includes("aria-label")) return;
     originalWarn.call(console, ...args);
-  };
+  });
 
-  console.error = (...args) => {
+  console.error = jest.fn((...args) => {
     if (
       typeof args[0] === "string" &&
       (args[0].includes("onAnimationComplete") ||
@@ -44,7 +44,7 @@ beforeEach(() => {
     ) return;
     if (args[0] instanceof Error && args[0].message === "API Error") return;
     originalError.call(console, ...args);
-  };
+  });
 
   jest.clearAllMocks();
   jest.spyOn(walletService, "payInvoiceFromService").mockResolvedValue({
@@ -278,6 +278,10 @@ describe("SendTab Component", () => {
 
       expect(screen.queryByText("payments.send.paymentDone")).not.toBeInTheDocument();
       expect(invoiceInput).toHaveValue("lnbc1000n1pj9h8uqpp5test");
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalledWith(expect.objectContaining({
+        code: "invoice_already_paid",
+      }));
     });
 
     it("shows translated error when invoice has expired", async () => {
@@ -335,6 +339,18 @@ describe("SendTab Component", () => {
         expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
           description: "phoenixd custom failure",
         }));
+      });
+    });
+
+    it("uses console error for unexpected errors without code", async () => {
+      jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(new Error("unexpected failure"));
+
+      renderSendTab();
+      typeInvoice(screen.getByLabelText("payments.send.payInvoiceLabel"), "lnbc1000n1pj9h8uqpp5test");
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(console.error).toHaveBeenCalled();
       });
     });
   });

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
@@ -1,9 +1,18 @@
+import { addToast } from "@heroui/react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import * as walletService from "@/services/walletService";
 import { I18nProvider } from "@i18n/I18nProvider";
 
 import { SendTab } from "../SendTab";
+
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return {
+    ...actual,
+    addToast: jest.fn(),
+  };
+});
 
 function renderSendTab(props = {}) {
   return render(
@@ -244,6 +253,48 @@ describe("SendTab Component", () => {
 
       await waitFor(() => {
         expect(screen.getByText("payments.send.payLightningButton")).toBeInTheDocument();
+      });
+    });
+
+    it("shows translated error when invoice was already paid", async () => {
+      jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(
+        Object.assign(new Error("This invoice has already been paid"), {
+          code: "invoice_already_paid",
+        }),
+      );
+
+      renderSendTab();
+      const invoiceInput = screen.getByLabelText("payments.send.payInvoiceLabel");
+      typeInvoice(invoiceInput, "lnbc1000n1pj9h8uqpp5test");
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
+          title: "payments.send.paymentError",
+          description: "payments.send.errors.invoiceAlreadyPaid",
+          color: "danger",
+        }));
+      });
+
+      expect(screen.queryByText("payments.send.paymentDone")).not.toBeInTheDocument();
+      expect(invoiceInput).toHaveValue("lnbc1000n1pj9h8uqpp5test");
+    });
+
+    it("uses backend message as fallback for unknown errors", async () => {
+      jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(
+        Object.assign(new Error("phoenixd custom failure"), {
+          code: "unknown",
+        }),
+      );
+
+      renderSendTab();
+      typeInvoice(screen.getByLabelText("payments.send.payInvoiceLabel"), "lnbc1000n1pj9h8uqpp5test");
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
+          description: "phoenixd custom failure",
+        }));
       });
     });
   });

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/SendTab.test.jsx
@@ -280,6 +280,46 @@ describe("SendTab Component", () => {
       expect(invoiceInput).toHaveValue("lnbc1000n1pj9h8uqpp5test");
     });
 
+    it("shows translated error when invoice has expired", async () => {
+      jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(
+        Object.assign(new Error("This invoice has expired"), {
+          code: "invoice_expired",
+        }),
+      );
+
+      renderSendTab();
+      typeInvoice(screen.getByLabelText("payments.send.payInvoiceLabel"), "lnbc1000n1pj9h8uqpp5test");
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
+          title: "payments.send.paymentError",
+          description: "payments.send.errors.invoiceExpired",
+          color: "danger",
+        }));
+      });
+    });
+
+    it("shows translated error when recipient node rejects the payment", async () => {
+      jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(
+        Object.assign(new Error("The recipient node rejected the payment"), {
+          code: "recipient_rejected_payment",
+        }),
+      );
+
+      renderSendTab();
+      typeInvoice(screen.getByLabelText("payments.send.payInvoiceLabel"), "lnbc1000n1pj9h8uqpp5test");
+      fireEvent.click(screen.getByText("payments.send.payLightningButton"));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
+          title: "payments.send.paymentError",
+          description: "payments.send.errors.recipientRejectedPayment",
+          color: "danger",
+        }));
+      });
+    });
+
     it("uses backend message as fallback for unknown errors", async () => {
       jest.spyOn(walletService, "payInvoiceFromService").mockRejectedValue(
         Object.assign(new Error("phoenixd custom failure"), {

--- a/client/src/components/pages/Store/Wallet/utils/paymentErrors.js
+++ b/client/src/components/pages/Store/Wallet/utils/paymentErrors.js
@@ -1,0 +1,21 @@
+const PAYMENT_ERROR_TRANSLATION_KEYS = {
+  invoice_already_paid: "payments.send.errors.invoiceAlreadyPaid",
+  invalid_invoice: "payments.send.errors.invalidInvoice",
+  insufficient_funds: "payments.send.errors.insufficientFunds",
+  node_unavailable: "payments.send.errors.nodeUnavailable",
+  invalid_payment_response: "payments.send.errors.unknown",
+};
+
+export function getPaymentErrorDescription(translate, paymentError) {
+  const translationKey = PAYMENT_ERROR_TRANSLATION_KEYS[paymentError?.code];
+
+  if (translationKey) {
+    return translate(translationKey);
+  }
+
+  if (paymentError?.message) {
+    return paymentError.message;
+  }
+
+  return translate("payments.send.errors.unknown");
+}

--- a/client/src/components/pages/Store/Wallet/utils/paymentErrors.js
+++ b/client/src/components/pages/Store/Wallet/utils/paymentErrors.js
@@ -1,5 +1,7 @@
 const PAYMENT_ERROR_TRANSLATION_KEYS = {
   invoice_already_paid: "payments.send.errors.invoiceAlreadyPaid",
+  invoice_expired: "payments.send.errors.invoiceExpired",
+  recipient_rejected_payment: "payments.send.errors.recipientRejectedPayment",
   invalid_invoice: "payments.send.errors.invalidInvoice",
   insufficient_funds: "payments.send.errors.insufficientFunds",
   node_unavailable: "payments.send.errors.nodeUnavailable",

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -881,6 +881,8 @@ const storeEn = {
         paymentErrorDescription: "Could not process the payment",
         errors: {
           invoiceAlreadyPaid: "This invoice has already been paid",
+          invoiceExpired: "This invoice has expired",
+          recipientRejectedPayment: "The recipient node rejected the payment",
           invalidInvoice: "This Lightning invoice is invalid",
           insufficientFunds: "There are not enough funds to complete this payment",
           nodeUnavailable: "The Lightning node is not available right now",

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -879,6 +879,13 @@ const storeEn = {
         paySuccessDescription: "Lightning payment sent successfully",
         paymentError: "Error paying the invoice",
         paymentErrorDescription: "Could not process the payment",
+        errors: {
+          invoiceAlreadyPaid: "This invoice has already been paid",
+          invalidInvoice: "This Lightning invoice is invalid",
+          insufficientFunds: "There are not enough funds to complete this payment",
+          nodeUnavailable: "The Lightning node is not available right now",
+          unknown: "Could not process the payment",
+        },
         closeButton: "Close",
       },
       history: {

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -879,6 +879,13 @@ const storeEs = {
         paySuccessDescription: "El pago Lightning se ha enviado correctamente",
         paymentError: "Error al pagar el invoice",
         paymentErrorDescription: "No se pudo procesar el pago",
+        errors: {
+          invoiceAlreadyPaid: "Esta factura ya fue pagada",
+          invalidInvoice: "La factura Lightning no es válida",
+          insufficientFunds: "No hay fondos suficientes para realizar este pago",
+          nodeUnavailable: "El nodo Lightning no está disponible en este momento",
+          unknown: "No se pudo procesar el pago",
+        },
         closeButton: "Cerrar",
       },
       history: {

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -881,6 +881,8 @@ const storeEs = {
         paymentErrorDescription: "No se pudo procesar el pago",
         errors: {
           invoiceAlreadyPaid: "Esta factura ya fue pagada",
+          invoiceExpired: "Esta factura ha caducado",
+          recipientRejectedPayment: "El nodo del destinatario rechazó el pago",
           invalidInvoice: "La factura Lightning no es válida",
           insufficientFunds: "No hay fondos suficientes para realizar este pago",
           nodeUnavailable: "El nodo Lightning no está disponible en este momento",

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -151,7 +151,11 @@ describe("walletService", () => {
   describe("payInvoiceFromService", () => {
     it("calls /wallet/payinvoice with trimmed invoice", async () => {
       httpClient.mockResolvedValue(makeResponse(200));
-      parseJsonResponse.mockResolvedValue({});
+      parseJsonResponse.mockResolvedValue({
+        recipientAmountSat: 1000,
+        routingFeeSat: 5,
+        paymentHash: "hash-123",
+      });
 
       await payInvoiceFromService("  lnbc...  ");
 
@@ -161,11 +165,41 @@ describe("walletService", () => {
 
     it("uses POST method", async () => {
       httpClient.mockResolvedValue(makeResponse(200));
-      parseJsonResponse.mockResolvedValue({});
+      parseJsonResponse.mockResolvedValue({
+        recipientAmountSat: 1000,
+        routingFeeSat: 5,
+        paymentHash: "hash-123",
+      });
 
       await payInvoiceFromService("lnbc...");
 
       expect(httpClient.mock.calls[0][1].method).toBe("POST");
+    });
+
+    it("throws structured error when response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(409, false));
+      parseJsonResponse.mockResolvedValue({
+        message: "This invoice has already been paid",
+        code: "invoice_already_paid",
+        source: "phoenixd",
+      });
+
+      await expect(payInvoiceFromService("lnbc...")).rejects.toMatchObject({
+        message: "This invoice has already been paid",
+        status: 409,
+        code: "invoice_already_paid",
+        source: "phoenixd",
+      });
+    });
+
+    it("throws when successful response body is invalid", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ paymentHash: "" });
+
+      await expect(payInvoiceFromService("lnbc...")).rejects.toMatchObject({
+        message: "Invalid payment response",
+        code: "invalid_payment_response",
+      });
     });
   });
 

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -1,21 +1,21 @@
 import { httpClient } from "@/lib/http/httpClient";
 import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
 
-function createWalletServiceError(message, details = {}) {
+function createWalletServiceError(message, errorDetails = {}) {
   const error = new Error(message);
-  error.status = details.status;
-  error.code = details.code ?? "unknown";
-  error.source = details.source ?? "ambrosia";
+  error.status = errorDetails.status;
+  error.code = errorDetails.code ?? "unknown";
+  error.source = errorDetails.source ?? "ambrosia";
   return error;
 }
 
-function isValidPaymentResponse(body) {
+function isValidPaymentResponse(responseBody) {
   return (
-    body &&
-    typeof body.recipientAmountSat === "number" &&
-    typeof body.routingFeeSat === "number" &&
-    typeof body.paymentHash === "string" &&
-    body.paymentHash.trim() !== ""
+    responseBody &&
+    typeof responseBody.recipientAmountSat === "number" &&
+    typeof responseBody.routingFeeSat === "number" &&
+    typeof responseBody.paymentHash === "string" &&
+    responseBody.paymentHash.trim() !== ""
   );
 }
 
@@ -76,20 +76,20 @@ export async function payInvoiceFromService(invoice) {
     },
     body: JSON.stringify({ invoice: invoice.trim() }),
   });
-  const body = await parseJsonResponse(response, null);
+  const responseBody = await parseJsonResponse(response, null);
 
   if (!response.ok) {
     throw createWalletServiceError(
-      body?.message ?? "Could not process the payment",
+      responseBody?.message ?? "Could not process the payment",
       {
         status: response.status,
-        code: body?.code,
-        source: body?.source,
+        code: responseBody?.code,
+        source: responseBody?.source,
       },
     );
   }
 
-  if (!isValidPaymentResponse(body)) {
+  if (!isValidPaymentResponse(responseBody)) {
     throw createWalletServiceError(
       "Invalid payment response",
       {
@@ -100,7 +100,7 @@ export async function payInvoiceFromService(invoice) {
     );
   }
 
-  return body;
+  return responseBody;
 }
 
 export async function getIncomingTransactions() {

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -1,6 +1,24 @@
 import { httpClient } from "@/lib/http/httpClient";
 import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
 
+function createWalletServiceError(message, details = {}) {
+  const error = new Error(message);
+  error.status = details.status;
+  error.code = details.code ?? "unknown";
+  error.source = details.source ?? "ambrosia";
+  return error;
+}
+
+function isValidPaymentResponse(body) {
+  return (
+    body &&
+    typeof body.recipientAmountSat === "number" &&
+    typeof body.routingFeeSat === "number" &&
+    typeof body.paymentHash === "string" &&
+    body.paymentHash.trim() !== ""
+  );
+}
+
 export const loginWallet = async (password) => {
   const response = await httpClient("/wallet/auth", {
     method: "POST",
@@ -58,7 +76,31 @@ export async function payInvoiceFromService(invoice) {
     },
     body: JSON.stringify({ invoice: invoice.trim() }),
   });
-  return await parseJsonResponse(response, null);
+  const body = await parseJsonResponse(response, null);
+
+  if (!response.ok) {
+    throw createWalletServiceError(
+      body?.message ?? "Could not process the payment",
+      {
+        status: response.status,
+        code: body?.code,
+        source: body?.source,
+      },
+    );
+  }
+
+  if (!isValidPaymentResponse(body)) {
+    throw createWalletServiceError(
+      "Invalid payment response",
+      {
+        status: response.status,
+        code: "invalid_payment_response",
+        source: "ambrosia",
+      },
+    );
+  }
+
+  return body;
 }
 
 export async function getIncomingTransactions() {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -9,6 +9,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import pos.ambrosia.logger
 import pos.ambrosia.models.Message
+import pos.ambrosia.models.WalletErrorResponse
 import pos.ambrosia.utils.AdminOnlyException
 import pos.ambrosia.utils.DatabaseException
 import pos.ambrosia.utils.DuplicateProductSkuException
@@ -104,7 +105,15 @@ fun Application.handler() {
         }
         exception<PhoenixServiceException> { call, cause ->
             logger.error("Phoenix service error: ${cause.message}")
-            call.respond(HttpStatusCode.ServiceUnavailable, Message("Lightning node service error"))
+            val statusCode = cause.statusCode?.let(HttpStatusCode::fromValue) ?: HttpStatusCode.ServiceUnavailable
+            call.respond(
+                statusCode,
+                WalletErrorResponse(
+                    message = cause.message ?: "Lightning node service error",
+                    code = cause.code,
+                    source = cause.source,
+                ),
+            )
         }
         exception<DatabaseException> { call, cause ->
             logger.error("Database operation failed: ${cause.message}")

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -52,6 +52,13 @@ data class LoginResponse(
 )
 
 @Serializable
+data class WalletErrorResponse(
+    val message: String,
+    val code: String,
+    val source: String,
+)
+
+@Serializable
 data class WalletAuthResponse(
     val message: String,
     val walletTokenExpiresAt: Long,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -46,14 +46,16 @@ class PhoenixService(
     app: ApplicationEnvironment,
     private val httpClient: HttpClient,
 ) {
+    companion object {
+        private val phoenixJson =
+            Json {
+                ignoreUnknownKeys = true
+                prettyPrint = true
+            }
+    }
+
     private val config = app.config
-    private val json =
-        Json {
-            ignoreUnknownKeys = true
-            prettyPrint = true
-        }
     private val phoenixdUrl = config.property("phoenixd-url").getString()
-    private val phoenixdPassword = config.property("phoenixd-password").getString()
     constructor(app: ApplicationEnvironment) : this(
         app,
         HttpClient(CIO) {
@@ -68,12 +70,7 @@ class PhoenixService(
                 }
             }
             install(ContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                        prettyPrint = true
-                    },
-                )
+                json(phoenixJson)
             }
         },
     )
@@ -437,7 +434,7 @@ class PhoenixService(
         if (rawBody.isBlank()) return null
 
         return try {
-            json
+            phoenixJson
                 .parseToJsonElement(rawBody)
                 .jsonObject["message"]
                 ?.jsonPrimitive
@@ -458,7 +455,7 @@ class PhoenixService(
         }
 
         return try {
-            json.decodeFromString<PaymentResponse>(rawBody)
+            phoenixJson.decodeFromString<PaymentResponse>(rawBody)
         } catch (_: Exception) {
             val message = extractPhoenixErrorMessage(rawBody)
             if (message != null) {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -46,6 +46,11 @@ class PhoenixService(
     app: ApplicationEnvironment,
     private val httpClient: HttpClient,
 ) {
+    private data class PhoenixPaymentErrorResolution(
+        val code: String,
+        val statusCode: Int,
+    )
+
     companion object {
         private val phoenixJson =
             Json {
@@ -420,12 +425,12 @@ class PhoenixService(
         val message =
             extractPhoenixErrorMessage(rawBody)
                 ?: "$fallbackMessage: Phoenix node returned ${response.status.value}"
-        val code = classifyPhoenixPaymentError(message)
+        val errorResolution = resolvePhoenixPaymentError(message)
 
         return PhoenixServiceException(
             message = message,
-            code = code,
-            statusCode = mapPhoenixPaymentStatus(response.status.value, code),
+            code = errorResolution.code,
+            statusCode = errorResolution.statusCode,
             upstreamMessage = rawBody.ifBlank { null },
         )
     }
@@ -459,11 +464,11 @@ class PhoenixService(
         } catch (_: Exception) {
             val message = extractPhoenixErrorMessage(rawBody)
             if (message != null) {
-                val code = classifyPhoenixPaymentError(message)
+                val errorResolution = resolvePhoenixPaymentError(message)
                 throw PhoenixServiceException(
                     message = message,
-                    code = code,
-                    statusCode = mapPhoenixPaymentStatus(200, code),
+                    code = errorResolution.code,
+                    statusCode = errorResolution.statusCode,
                     upstreamMessage = rawBody,
                 )
             }
@@ -477,40 +482,61 @@ class PhoenixService(
         }
     }
 
-    private fun classifyPhoenixPaymentError(message: String): String {
+    private fun resolvePhoenixPaymentError(message: String): PhoenixPaymentErrorResolution {
         val normalizedMessage = message.lowercase()
 
         return when {
-            "already paid" in normalizedMessage || "already been paid" in normalizedMessage -> "invoice_already_paid"
+            "already paid" in normalizedMessage || "already been paid" in normalizedMessage -> {
+                PhoenixPaymentErrorResolution(
+                    code = "invoice_already_paid",
+                    statusCode = 409,
+                )
+            }
 
-            "expired" in normalizedMessage && "invoice" in normalizedMessage -> "invoice_expired"
+            "expired" in normalizedMessage && "invoice" in normalizedMessage -> {
+                PhoenixPaymentErrorResolution(
+                    code = "invoice_expired",
+                    statusCode = 410,
+                )
+            }
 
-            "recipient node rejected the payment" in normalizedMessage -> "recipient_rejected_payment"
+            "recipient node rejected the payment" in normalizedMessage -> {
+                PhoenixPaymentErrorResolution(
+                    code = "recipient_rejected_payment",
+                    statusCode = 422,
+                )
+            }
 
-            "invalid" in normalizedMessage && ("invoice" in normalizedMessage || "bolt11" in normalizedMessage) -> "invalid_invoice"
+            "invalid" in normalizedMessage && ("invoice" in normalizedMessage || "bolt11" in normalizedMessage) -> {
+                PhoenixPaymentErrorResolution(
+                    code = "invalid_invoice",
+                    statusCode = 400,
+                )
+            }
 
             ("insufficient" in normalizedMessage || "not enough" in normalizedMessage) &&
-                ("fund" in normalizedMessage || "balance" in normalizedMessage || "liquidity" in normalizedMessage) -> "insufficient_funds"
+                ("fund" in normalizedMessage || "balance" in normalizedMessage || "liquidity" in normalizedMessage) -> {
+                PhoenixPaymentErrorResolution(
+                    code = "insufficient_funds",
+                    statusCode = 402,
+                )
+            }
 
-            "timeout" in normalizedMessage || "unavailable" in normalizedMessage || "connection" in normalizedMessage -> "node_unavailable"
+            "timeout" in normalizedMessage || "unavailable" in normalizedMessage || "connection" in normalizedMessage -> {
+                PhoenixPaymentErrorResolution(
+                    code = "node_unavailable",
+                    statusCode = 503,
+                )
+            }
 
-            else -> "unknown"
+            else -> {
+                PhoenixPaymentErrorResolution(
+                    code = "unknown",
+                    statusCode = 502,
+                )
+            }
         }
     }
-
-    private fun mapPhoenixPaymentStatus(
-        upstreamStatusCode: Int,
-        code: String,
-    ): Int =
-        when (code) {
-            "invoice_already_paid" -> 409
-            "invoice_expired" -> 410
-            "recipient_rejected_payment" -> 422
-            "invalid_invoice" -> 400
-            "insufficient_funds" -> 402
-            "node_unavailable" -> 503
-            else -> upstreamStatusCode
-        }
 
     /** Get seed from Phoenix */
     suspend fun getSeed(): String = AppConfig.loadPhoenixSeed()

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -483,6 +483,10 @@ class PhoenixService(
         return when {
             "already paid" in normalizedMessage || "already been paid" in normalizedMessage -> "invoice_already_paid"
 
+            "expired" in normalizedMessage && "invoice" in normalizedMessage -> "invoice_expired"
+
+            "recipient node rejected the payment" in normalizedMessage -> "recipient_rejected_payment"
+
             "invalid" in normalizedMessage && ("invoice" in normalizedMessage || "bolt11" in normalizedMessage) -> "invalid_invoice"
 
             ("insufficient" in normalizedMessage || "not enough" in normalizedMessage) &&
@@ -500,6 +504,8 @@ class PhoenixService(
     ): Int =
         when (code) {
             "invoice_already_paid" -> 409
+            "invoice_expired" -> 410
+            "recipient_rejected_payment" -> 422
             "invalid_invoice" -> 400
             "insufficient_funds" -> 402
             "node_unavailable" -> 503

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -17,6 +17,9 @@ import io.ktor.http.Parameters
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.ApplicationEnvironment
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import pos.ambrosia.config.AppConfig
 import pos.ambrosia.models.phoenix.CloseChannelRequest
 import pos.ambrosia.models.phoenix.CloseChannelResponse
@@ -44,6 +47,11 @@ class PhoenixService(
     private val httpClient: HttpClient,
 ) {
     private val config = app.config
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+        }
     private val phoenixdUrl = config.property("phoenixd-url").getString()
     private val phoenixdPassword = config.property("phoenixd-password").getString()
     constructor(app: ApplicationEnvironment) : this(
@@ -133,11 +141,22 @@ class PhoenixService(
                         },
                 )
             if (response.status.value != 200) {
-                throw PhoenixServiceException("Phoenix node returned ${response.status.value}")
+                throw buildPhoenixServiceException(
+                    response = response,
+                    fallbackMessage = "Failed to pay invoice on Phoenix",
+                )
             }
-            return response.body<PaymentResponse>()
+            val rawBody = response.bodyAsText().trim()
+            return parsePaymentResponse(rawBody)
+        } catch (e: PhoenixServiceException) {
+            throw e
         } catch (e: Exception) {
-            throw PhoenixServiceException("Failed to pay invoice on Phoenix: ${e.message}")
+            throw PhoenixServiceException(
+                message = "Failed to pay invoice on Phoenix: ${e.message}",
+                code = "node_unavailable",
+                statusCode = 503,
+                upstreamMessage = e.message,
+            )
         }
     }
 
@@ -395,6 +414,100 @@ class PhoenixService(
         }
     }
     //endregion
+
+    private suspend fun buildPhoenixServiceException(
+        response: HttpResponse,
+        fallbackMessage: String,
+    ): PhoenixServiceException {
+        val rawBody = response.bodyAsText().trim()
+        val message =
+            extractPhoenixErrorMessage(rawBody)
+                ?: "$fallbackMessage: Phoenix node returned ${response.status.value}"
+        val code = classifyPhoenixPaymentError(message)
+
+        return PhoenixServiceException(
+            message = message,
+            code = code,
+            statusCode = mapPhoenixPaymentStatus(response.status.value, code),
+            upstreamMessage = rawBody.ifBlank { null },
+        )
+    }
+
+    private fun extractPhoenixErrorMessage(rawBody: String): String? {
+        if (rawBody.isBlank()) return null
+
+        return try {
+            json
+                .parseToJsonElement(rawBody)
+                .jsonObject["message"]
+                ?.jsonPrimitive
+                ?.contentOrNull
+                ?: rawBody
+        } catch (_: Exception) {
+            rawBody
+        }
+    }
+
+    private fun parsePaymentResponse(rawBody: String): PaymentResponse {
+        if (rawBody.isBlank()) {
+            throw PhoenixServiceException(
+                message = "Failed to pay invoice on Phoenix: Empty response body",
+                code = "unknown",
+                statusCode = 502,
+            )
+        }
+
+        return try {
+            json.decodeFromString<PaymentResponse>(rawBody)
+        } catch (_: Exception) {
+            val message = extractPhoenixErrorMessage(rawBody)
+            if (message != null) {
+                val code = classifyPhoenixPaymentError(message)
+                throw PhoenixServiceException(
+                    message = message,
+                    code = code,
+                    statusCode = mapPhoenixPaymentStatus(200, code),
+                    upstreamMessage = rawBody,
+                )
+            }
+
+            throw PhoenixServiceException(
+                message = "Failed to pay invoice on Phoenix: Invalid payment response",
+                code = "unknown",
+                statusCode = 502,
+                upstreamMessage = rawBody,
+            )
+        }
+    }
+
+    private fun classifyPhoenixPaymentError(message: String): String {
+        val normalizedMessage = message.lowercase()
+
+        return when {
+            "already paid" in normalizedMessage || "already been paid" in normalizedMessage -> "invoice_already_paid"
+
+            "invalid" in normalizedMessage && ("invoice" in normalizedMessage || "bolt11" in normalizedMessage) -> "invalid_invoice"
+
+            ("insufficient" in normalizedMessage || "not enough" in normalizedMessage) &&
+                ("fund" in normalizedMessage || "balance" in normalizedMessage || "liquidity" in normalizedMessage) -> "insufficient_funds"
+
+            "timeout" in normalizedMessage || "unavailable" in normalizedMessage || "connection" in normalizedMessage -> "node_unavailable"
+
+            else -> "unknown"
+        }
+    }
+
+    private fun mapPhoenixPaymentStatus(
+        upstreamStatusCode: Int,
+        code: String,
+    ): Int =
+        when (code) {
+            "invoice_already_paid" -> 409
+            "invalid_invoice" -> 400
+            "insufficient_funds" -> 402
+            "node_unavailable" -> 503
+            else -> upstreamStatusCode
+        }
 
     /** Get seed from Phoenix */
     suspend fun getSeed(): String = AppConfig.loadPhoenixSeed()

--- a/server/app/src/main/kotlin/pos/ambrosia/util/Exceptions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/util/Exceptions.kt
@@ -28,6 +28,10 @@ class PhoenixBalanceException(
 
 class PhoenixServiceException(
     message: String = "Phoenix Lightning node service error",
+    val code: String = "unknown",
+    val statusCode: Int? = null,
+    val source: String = "phoenixd",
+    val upstreamMessage: String? = null,
 ) : RuntimeException(message)
 
 class InvalidTokenException(

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
@@ -459,6 +459,47 @@ class PhoenixServiceTest {
     }
 
     @Test
+    fun `payInvoice maps unknown phoenix error payload with 200 status to bad gateway`() {
+        // Arrange
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel("""{"message":"Unexpected phoenix payment failure"}"""),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val mockHttpClient =
+            HttpClient(mockEngine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            }
+        val mockUrlValue: ApplicationConfigValue = mock()
+        whenever(mockUrlValue.getString()).thenReturn("http://dummy-url")
+        whenever(mockConfig.property("phoenixd-url")).thenReturn(mockUrlValue)
+        val mockPasswordValue: ApplicationConfigValue = mock()
+        whenever(mockPasswordValue.getString()).thenReturn("dummy-password")
+        whenever(mockConfig.property("phoenixd-password")).thenReturn(mockPasswordValue)
+
+        val phoenixService = PhoenixService(mockEnv, mockHttpClient)
+
+        // Act
+        val request =
+            pos.ambrosia.models.phoenix
+                .PayInvoiceRequest(invoice = "lnbc10...")
+        val exception =
+            assertFailsWith<pos.ambrosia.utils.PhoenixServiceException> {
+                runBlocking { phoenixService.payInvoice(request) }
+            }
+
+        // Assert
+        assertEquals("unknown", exception.code)
+        assertEquals(502, exception.statusCode)
+        assertEquals("Unexpected phoenix payment failure", exception.message)
+    }
+
+    @Test
     fun `payInvoice throws PhoenixServiceException on network error`() {
         // Arrange
         val mockEngine =

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
@@ -377,6 +377,88 @@ class PhoenixServiceTest {
     }
 
     @Test
+    fun `payInvoice classifies expired invoice error`() {
+        // Arrange
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel("""{"message":"Invoice expired"}"""),
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val mockHttpClient =
+            HttpClient(mockEngine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            }
+        val mockUrlValue: ApplicationConfigValue = mock()
+        whenever(mockUrlValue.getString()).thenReturn("http://dummy-url")
+        whenever(mockConfig.property("phoenixd-url")).thenReturn(mockUrlValue)
+        val mockPasswordValue: ApplicationConfigValue = mock()
+        whenever(mockPasswordValue.getString()).thenReturn("dummy-password")
+        whenever(mockConfig.property("phoenixd-password")).thenReturn(mockPasswordValue)
+
+        val phoenixService = PhoenixService(mockEnv, mockHttpClient)
+
+        // Act
+        val request =
+            pos.ambrosia.models.phoenix
+                .PayInvoiceRequest(invoice = "lnbc10...")
+        val exception =
+            assertFailsWith<pos.ambrosia.utils.PhoenixServiceException> {
+                runBlocking { phoenixService.payInvoice(request) }
+            }
+
+        // Assert
+        assertEquals("invoice_expired", exception.code)
+        assertEquals(410, exception.statusCode)
+        assertEquals("Invoice expired", exception.message)
+    }
+
+    @Test
+    fun `payInvoice classifies recipient rejected payment error`() {
+        // Arrange
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel("""{"message":"Recipient node rejected the payment"}"""),
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val mockHttpClient =
+            HttpClient(mockEngine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            }
+        val mockUrlValue: ApplicationConfigValue = mock()
+        whenever(mockUrlValue.getString()).thenReturn("http://dummy-url")
+        whenever(mockConfig.property("phoenixd-url")).thenReturn(mockUrlValue)
+        val mockPasswordValue: ApplicationConfigValue = mock()
+        whenever(mockPasswordValue.getString()).thenReturn("dummy-password")
+        whenever(mockConfig.property("phoenixd-password")).thenReturn(mockPasswordValue)
+
+        val phoenixService = PhoenixService(mockEnv, mockHttpClient)
+
+        // Act
+        val request =
+            pos.ambrosia.models.phoenix
+                .PayInvoiceRequest(invoice = "lnbc10...")
+        val exception =
+            assertFailsWith<pos.ambrosia.utils.PhoenixServiceException> {
+                runBlocking { phoenixService.payInvoice(request) }
+            }
+
+        // Assert
+        assertEquals("recipient_rejected_payment", exception.code)
+        assertEquals(422, exception.statusCode)
+        assertEquals("Recipient node rejected the payment", exception.message)
+    }
+
+    @Test
     fun `payInvoice throws PhoenixServiceException on network error`() {
         // Arrange
         val mockEngine =

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixServiceTest.kt
@@ -300,6 +300,83 @@ class PhoenixServiceTest {
     }
 
     @Test
+    fun `payInvoice preserves phoenix error details for already paid invoice`() {
+        // Arrange
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel("""{"message":"Invoice already paid"}"""),
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val mockHttpClient = HttpClient(mockEngine)
+        val mockUrlValue: ApplicationConfigValue = mock()
+        whenever(mockUrlValue.getString()).thenReturn("http://dummy-url")
+        whenever(mockConfig.property("phoenixd-url")).thenReturn(mockUrlValue)
+        val mockPasswordValue: ApplicationConfigValue = mock()
+        whenever(mockPasswordValue.getString()).thenReturn("dummy-password")
+        whenever(mockConfig.property("phoenixd-password")).thenReturn(mockPasswordValue)
+
+        val phoenixService = PhoenixService(mockEnv, mockHttpClient)
+
+        // Act
+        val request =
+            pos.ambrosia.models.phoenix
+                .PayInvoiceRequest(invoice = "lnbc10...")
+        val exception =
+            assertFailsWith<pos.ambrosia.utils.PhoenixServiceException> {
+                runBlocking { phoenixService.payInvoice(request) }
+            }
+
+        // Assert
+        assertEquals("invoice_already_paid", exception.code)
+        assertEquals(409, exception.statusCode)
+        assertEquals("Invoice already paid", exception.message)
+    }
+
+    @Test
+    fun `payInvoice handles phoenix error payload returned with 200 status`() {
+        // Arrange
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel("""{"message":"Invoice already paid"}"""),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val mockHttpClient =
+            HttpClient(mockEngine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            }
+        val mockUrlValue: ApplicationConfigValue = mock()
+        whenever(mockUrlValue.getString()).thenReturn("http://dummy-url")
+        whenever(mockConfig.property("phoenixd-url")).thenReturn(mockUrlValue)
+        val mockPasswordValue: ApplicationConfigValue = mock()
+        whenever(mockPasswordValue.getString()).thenReturn("dummy-password")
+        whenever(mockConfig.property("phoenixd-password")).thenReturn(mockPasswordValue)
+
+        val phoenixService = PhoenixService(mockEnv, mockHttpClient)
+
+        // Act
+        val request =
+            pos.ambrosia.models.phoenix
+                .PayInvoiceRequest(invoice = "lnbc10...")
+        val exception =
+            assertFailsWith<pos.ambrosia.utils.PhoenixServiceException> {
+                runBlocking { phoenixService.payInvoice(request) }
+            }
+
+        // Assert
+        assertEquals("invoice_already_paid", exception.code)
+        assertEquals(409, exception.statusCode)
+        assertEquals("Invoice already paid", exception.message)
+    }
+
+    @Test
     fun `payInvoice throws PhoenixServiceException on network error`() {
         // Arrange
         val mockEngine =


### PR DESCRIPTION
This pull request introduces robust, structured error handling for Lightning payment failures in the wallet send flow, improving both user experience and developer clarity. The changes ensure that backend error codes are surfaced to the frontend, translated into user-friendly messages, and well-covered by tests. Additionally, the backend now returns structured error responses for wallet operations.

**Frontend error handling and UX improvements:**

* Enhanced invoice validation and error feedback in `SendTab.jsx`, replacing the previous boolean error state with a string for detailed error messages. Errors from payment attempts are now translated using a new utility, and the UI surfaces specific, localized error messages to users. [[1]](diffhunk://#diff-fbd614455b923473e31276d49c58d28a7926fed8bcc53768d7ae2f4a150102ebL16-R53) [[2]](diffhunk://#diff-fbd614455b923473e31276d49c58d28a7926fed8bcc53768d7ae2f4a150102ebR63-R70) [[3]](diffhunk://#diff-fbd614455b923473e31276d49c58d28a7926fed8bcc53768d7ae2f4a150102ebL82-R91)
* Added a utility function `getPaymentErrorDescription` in `paymentErrors.js` to map backend error codes to translation keys, with a fallback to the backend message or a generic error.
* Updated English and Spanish locale files to include specific error messages for common Lightning payment errors. [[1]](diffhunk://#diff-cd6cabb661b4c8b90544c74da065b262bdcc623769c53a5f7b5997be352ee0b9R882-R890) [[2]](diffhunk://#diff-0f917a2928a34900c8f92c10bf21b0ab2d161d381bf8d29e56e3209ab3e5647aR882-R890)

**Testing improvements:**

* Extended `SendTab` tests to cover all major error scenarios, including already paid invoices, expired invoices, recipient rejections, unknown errors, and validation failures. Also improved mocking of `addToast` and console methods for better test reliability. [[1]](diffhunk://#diff-431afb448aebac36359417b67bb6afe1e63d01ae3e7eb0e5176ff031844a3034R1-R16) [[2]](diffhunk://#diff-431afb448aebac36359417b67bb6afe1e63d01ae3e7eb0e5176ff031844a3034L24-R38) [[3]](diffhunk://#diff-431afb448aebac36359417b67bb6afe1e63d01ae3e7eb0e5176ff031844a3034L38-R47) [[4]](diffhunk://#diff-431afb448aebac36359417b67bb6afe1e63d01ae3e7eb0e5176ff031844a3034R258-R355)

**Backend error response and validation:**

* The backend (`PhoenixServiceException` handler in `Handler.kt`) now returns a structured `WalletErrorResponse` object with `message`, `code`, and `source` fields, and uses the appropriate HTTP status code. [[1]](diffhunk://#diff-25b487fb7de8062539cb5c37b76439b7aefeeeb89c531287dacd42b118652b8bR12) [[2]](diffhunk://#diff-25b487fb7de8062539cb5c37b76439b7aefeeeb89c531287dacd42b118652b8bL107-R116) [[3]](diffhunk://#diff-bcea94bd86d271d7c2d0eee3706cb79f1092a37643f91727fdc5d675df7c3ff7R54-R60)
* The wallet service (`walletService.js`) now throws structured errors with code, status, and source fields when payment fails or the response is invalid, and validates payment responses for required fields. [[1]](diffhunk://#diff-0422f79f256252c46202fd8d7d7d7f900aa310290641a4eb62352a20a6a94a03R4-R21) [[2]](diffhunk://#diff-0422f79f256252c46202fd8d7d7d7f900aa310290641a4eb62352a20a6a94a03L61-R103)
* Added comprehensive backend tests to ensure structured errors are thrown and handled correctly for various failure scenarios. [[1]](diffhunk://#diff-aa22f9e101f5ebbfab4ab6865fc3bcd828116119ca2c149acde10a865ac88799L154-R158) [[2]](diffhunk://#diff-aa22f9e101f5ebbfab4ab6865fc3bcd828116119ca2c149acde10a865ac88799L164-R203)

These changes collectively provide users with clearer, localized feedback for payment issues and make error handling more consistent and maintainable across the stack.



fix #456 #464 