### PR TITLE
feat(hardware): add hardware/ tree for physical-device deployment

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,22 @@
+# Hardware
+
+Resources for running Ambrosia on physical devices. For software-only installs (laptop, server, any machine), see [`doc/installation.md`](../doc/installation.md).
+
+This tree organises content by how the device got into the user's hands:
+
+## DIY (per-board)
+
+You bought parts and want to build a unit yourself. Today's flow is a manual narrative — flash an OS, run install steps by hand. The long-term goal is a single command that produces a **reproducible image** (e.g., via Nix), which you flash to an SD card and boot. The per-board guides below double as the spec for what that build must produce.
+
+- [`rpi/`](rpi/) — Raspberry Pi Zero 2W
+- [`opi/`](opi/) — OrangePi Zero 2W
+
+New boards plug in here as siblings.
+
+## Preinstalled
+
+You received a device with Ambrosia already configured (built by an operator from one of the per-board flows above).
+
+- [`preinstalled/`](preinstalled/) — buyer take-home flow, captive portal, and operator provisioning tooling.
+
+A buyer can verify their preinstalled device matches the published reproducible build by hash-comparing — that's the link between the two paths, not a separate one.

--- a/hardware/opi/README.md
+++ b/hardware/opi/README.md
@@ -1,0 +1,15 @@
+# OrangePi Zero 2W
+
+Reference notes for running Ambrosia on an OrangePi Zero 2W.
+
+For the step-by-step setup walkthrough — flashing the OS, first boot, SSH, installing Ambrosia — see the tutorial site:
+
+- [Setup the board](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/opi)
+
+## Status
+
+Today's flow is manual: flash Armbian, configure Wi-Fi, install Ambrosia by hand. The long-term goal is a single command that produces a verifiable reproducible image you flash to an SD card. That work is the natural continuation of [`../preinstalled/operator/scripts/bootstrap-ambrosia.sh`](../preinstalled/operator/scripts/bootstrap-ambrosia.sh) — see the operator README for the trajectory.
+
+## Known caveat
+
+The `unisoc_wifi` driver on this board can wedge silently — the link associates and DHCP succeeds, but no L3 traffic flows. Bouncing the NetworkManager connection usually clears it. If you build automation against this board, make that recovery the first thing you try before chasing AP/firewall issues.

--- a/hardware/preinstalled/README.md
+++ b/hardware/preinstalled/README.md
@@ -1,0 +1,20 @@
+# Preinstalled
+
+For users who received an Ambrosia device already configured. Two audiences share this path:
+
+## Buyer / end-user
+
+You have a device. Plug it in, connect to its Wi-Fi hotspot from your phone, choose your home Wi-Fi in the captive portal, and you're done.
+
+- [Take-home walkthrough](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/preinstalled) (English + Spanish on the tutorial site)
+- [`portal/`](portal/) — the captive portal that makes first-boot Wi-Fi reconfig possible. README explains how it's wired into a unit.
+
+## Operator / vendor
+
+You want to make preinstalled devices for others (kermés, gifts, fleet deployment).
+
+- [`operator/`](operator/) — provisioning tooling: golden-image bake, per-unit wipe, fleet cloning, printable buyer-facing cards with credentials and QR codes.
+
+## Verification
+
+A preinstalled device's image should hash-match the reproducible build output from [`../rpi/`](../rpi/) or [`../opi/`](../opi/). That's the trust link between buyer and operator — not a separate verification path. The reproducible build itself doesn't exist yet (see those READMEs for status); until it does, this is an aspirational claim.

--- a/hardware/preinstalled/operator/README.md
+++ b/hardware/preinstalled/operator/README.md
@@ -1,0 +1,26 @@
+# Operator tooling
+
+For people producing preinstalled Ambrosia units to sell or give away (kermés deployments, gifts, fleet rollouts). The buyer-facing experience is on the tutorial site at [tutorial.ambrosiapay.com/docs/quick-start-hardware/preinstalled](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/preinstalled).
+
+## Flow
+
+1. Set up a single golden unit by hand (see [`../../opi/`](../../opi/) or [`../../rpi/`](../../rpi/) and the linked tutorial-site walkthrough).
+2. Run [`scripts/bootstrap-ambrosia.sh`](scripts/bootstrap-ambrosia.sh) to install Ambrosia + Phoenixd + the captive portal onto the golden unit.
+3. Run [`scripts/prep-opi-as-golden.sh`](scripts/prep-opi-as-golden.sh) to wipe per-unit state (machine-id, SSH keys, phoenixd wallet) and re-image the SD card to a compressed `.img.gz`.
+4. Optionally run [`scripts/stubify-golden.sh`](scripts/stubify-golden.sh) on the image to remove residual user credentials.
+5. For each new unit: `dd` the image onto a fresh SD card, then run [`scripts/wipe-and-provision.sh`](scripts/wipe-and-provision.sh) on your laptop against the mounted card to give it a unique hostname and fresh per-unit state.
+6. Generate printable buyer materials:
+   - [`scripts/generate-vendor-cards.sh`](scripts/generate-vendor-cards.sh) — per-unit vendor cards with random passwords, Wi-Fi QR, support QR (English + Spanish).
+   - [`scripts/generate-take-home-cards.sh`](scripts/generate-take-home-cards.sh) — compact per-unit take-home cards (companion to the vendor cards).
+   - [`scripts/generate-take-home.sh`](scripts/generate-take-home.sh) — the multi-page printable instruction sheet that goes home with each unit (English + Spanish).
+
+[`clone-fleet.md`](clone-fleet.md) is the technical reference for the cloning step.
+
+## Status
+
+This is the imperative ancestor of a future reproducible-build flow. Eventually the "golden image" will be the output of a single declarative build (e.g., a `flake.nix` consuming the current source) rather than the result of a script chain that downloads tagged releases at runtime.
+
+### Known TODOs
+
+- **`bootstrap-ambrosia.sh` pins `AMBROSIA_TAG`** and downloads a tagged release at runtime. The reproducible-build replacement should instead build from the current code in this repo so the resulting image's hash is deterministic and traceable. Treating this as the next concrete step toward real reproducibility.
+- **OPi-flavoured naming throughout** (`/mnt/opi-wipe-and-provision`, default `ambrosia-opi-N` hostnames). The scripts work for any aarch64 board today but the names imply OPi. RPi-side operators will want to either parameterise these or fork the scripts; out of scope for this introductory PR.

--- a/hardware/preinstalled/operator/clone-fleet.md
+++ b/hardware/preinstalled/operator/clone-fleet.md
@@ -1,0 +1,216 @@
+# Cloning an OrangePi fleet for a kermés
+
+Once you have one OrangePi fully set up (OS + Ambrosia installed), you can clone its SD card to build the rest of your fleet in a fraction of the time it would take to run the [OrangePi setup walkthrough](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/opi) and [Ambrosia install](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/rpi-install) on each unit.
+
+**What cloning skips:** OS flash, user creation, Wi-Fi config, avahi, swap, apt upgrade, Ambrosia install — everything from Steps 2-14 of the OrangePi setup plus the full Ambrosia install.
+
+**What still needs to be per-unit:** unique hostname, fresh SSH host keys, fresh `/etc/machine-id`, and (most importantly) a fresh phoenixd wallet — otherwise every board shares the same Lightning seed and the first channel open trashes state for all of them.
+
+This tutorial assumes your golden unit is reachable as `ambrosia-opi-1.local`. Substitute your actual hostname/user throughout.
+
+> **Network tip:** we ran into some odd SSH / TCP hangs over Wi-Fi on the OrangePi Zero 2W (pings fine, TCP data flows stalling with packets stuck in the send queue — root cause never fully nailed down). Running the backup over Ethernet worked reliably. If you have the USB-C Ethernet adapter from Step 4 of the [OrangePi setup walkthrough](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/opi), plug it in and use that. Shared-to-laptop Ethernet (IP like `10.42.0.x`) is fine.
+
+---
+
+## Step 1: Back up phoenixd and Ambrosia data
+
+Before wiping the golden image, pull both datadirs to your laptop. `~/.phoenix/seed.dat` is the Lightning wallet seed — losing it means losing any funds the wallet has ever held.
+
+Stop services on the OrangePi so the files aren't mid-write (`-t` is needed so sudo can prompt for your password):
+
+```bash
+ssh -t ambrosia-opi-1@<golden-ip> 'sudo systemctl stop ambrosia-client ambrosia phoenixd'
+```
+
+From your laptop, stream both datadirs as a compressed tarball (no `-t`, so stdout is a clean binary stream):
+
+```bash
+ssh ambrosia-opi-1@<golden-ip> 'tar czf - .phoenix .Ambrosia-POS' \
+  > ~/ambrosia-backup-$(date +%Y%m%d-%H%M%S).tar.gz
+```
+
+Verify the backup — you should see `seed.dat`, the phoenixd mainnet DB, and the Ambrosia DB/keystore in the listing:
+
+```bash
+ls -lh ~/ambrosia-backup-*.tar.gz
+tar tzf ~/ambrosia-backup-*.tar.gz | head -20
+```
+
+Don't proceed until `seed.dat` and `.Ambrosia-POS/ambrosia.db` both appear.
+
+---
+
+## Step 2: Wipe per-device state on the golden image
+
+SSH back into the golden unit and wipe everything that must not be shared across clones: the Lightning wallet, the Ambrosia DB, SSH host keys, `/etc/machine-id`, shell history, and the journal.
+
+```bash
+ssh ambrosia-opi-1@<golden-ip>
+```
+
+Then on the OrangePi, run each line individually (pasting a multi-line block with `\` continuations often gets mangled by terminal paste handling):
+
+```bash
+sudo -v
+rm -rf ~/.phoenix
+rm -rf ~/.Ambrosia-POS
+sudo rm -f /etc/ssh/ssh_host_*
+sudo truncate -s 0 /etc/machine-id
+sudo rm -f /var/lib/dbus/machine-id
+sudo ln -s /etc/machine-id /var/lib/dbus/machine-id
+rm -f ~/.bash_history
+sudo journalctl --rotate
+sudo journalctl --vacuum-time=1s
+sudo shutdown -h now
+```
+
+`sudo -v` primes the sudo password cache so you only type it once. Your SSH session drops when shutdown runs — that's expected.
+
+> **Note:** bash **rewrites** `~/.bash_history` when your shell exits, so the `rm` above gets undone a few seconds later. We'll clean the regenerated file up on the mounted SD card in the next step.
+
+Once the green LED stops blinking, unplug power and pull the microSD card.
+
+---
+
+## Step 3: Verify the wipe and image the golden SD card
+
+Insert the card into your laptop's reader and find its device:
+
+```bash
+lsblk -d -o NAME,SIZE,MODEL,TRAN
+```
+
+Identify the card by size (`29.7G` for a 32GB card) and by `TRAN=usb`. **Double-check** — writing the wrong device later will destroy your system disk.
+
+Mount the rootfs partition to verify the wipe (the OrangePi Debian image uses a single partition `sda1`, with u-boot in the raw sectors before it):
+
+```bash
+sudo mkdir -p /mnt/opi
+sudo mount /dev/sda1 /mnt/opi
+```
+
+Confirm each sensitive file is gone (each should print `GONE:` unless bash regenerated `.bash_history`):
+
+```bash
+sudo ls /mnt/opi/home/ambrosia-opi-1/.phoenix 2>&1
+sudo ls /mnt/opi/home/ambrosia-opi-1/.Ambrosia-POS 2>&1
+sudo ls /mnt/opi/home/ambrosia-opi-1/.bash_history 2>&1
+sudo ls /mnt/opi/etc/ssh/ | grep ssh_host
+sudo wc -c /mnt/opi/etc/machine-id
+sudo ls -la /mnt/opi/var/lib/dbus/machine-id
+```
+
+`.phoenix` and `.Ambrosia-POS` should be "No such file or directory". `/etc/ssh/` should have no `ssh_host_*` files. `machine-id` should be 0 bytes. The dbus `machine-id` should be a symlink to `/etc/machine-id`.
+
+**Bash almost always regenerates `~/.bash_history` on shell exit — delete it now on the mounted FS:**
+
+```bash
+sudo rm -f /mnt/opi/home/ambrosia-opi-1/.bash_history
+```
+
+Then unmount and image the whole device (not just the partition — we want u-boot and the partition table too):
+
+```bash
+sudo umount /mnt/opi
+sudo dd if=/dev/sda bs=4M status=progress | gzip -c > ~/ambrosia-golden-$(date +%Y%m%d).img.gz
+ls -lh ~/ambrosia-golden-*.img.gz
+```
+
+On USB 3.0 with a decent card, 32GB reads in ~7 minutes at ~70 MB/s. The compressed image is typically 2-4GB since most of the card is empty and compresses to near-zero.
+
+---
+
+## Step 4: Flash the clones
+
+For each new microSD card (you need 7 more to reach 8 total):
+
+```bash
+# Insert fresh card, then find its device name:
+lsblk -d -o NAME,SIZE,MODEL,TRAN
+
+# Unmount and flash:
+sudo umount /dev/sdX*
+gunzip -c ~/ambrosia-golden-YYYYMMDD.img.gz | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
+sync
+sudo eject /dev/sdX
+```
+
+Label each card physically (`opi-2`, `opi-3`, … `opi-8`) so you can keep track.
+
+---
+
+## Step 5: First boot of each clone — set a unique hostname
+
+**Boot clones one at a time.** All fresh clones will initially announce themselves as `ambrosia-opi-1.local` over avahi — if you boot two at once, `.local` resolution is a coin flip.
+
+For each clone:
+
+1. Insert the card, plug power, wait ~60s for first boot. Systemd regenerates SSH host keys and `/etc/machine-id` automatically.
+
+2. SSH in. Your laptop's known_hosts still has the fingerprint from the golden unit, so you'll get a mismatch warning — that's expected (the clone has fresh host keys). Clear the old entry first:
+
+   ```bash
+   ssh-keygen -R ambrosia-opi-1.local
+   ssh ambrosia-opi-1@ambrosia-opi-1.local
+   ```
+
+3. On the clone, set a new unique hostname (e.g. `ambrosia-opi-2` for the second unit):
+
+   ```bash
+   NEW=ambrosia-opi-2
+   sudo hostnamectl set-hostname "$NEW"
+   sudo sed -i "s/127.0.1.1.*/127.0.1.1\t$NEW/" /etc/hosts
+   sudo reboot
+   ```
+
+4. Wait ~30s, then reconnect at the new name:
+
+   ```bash
+   ssh ambrosia-opi-1@ambrosia-opi-2.local
+   ```
+
+   (The username stays `ambrosia-opi-1` — that's fine, it's baked into the cloned filesystem. If you want per-unit usernames, rename with `usermod -l` before the reboot above, but it's not required.)
+
+5. Only after the clone is on its new hostname, power up the next clone and repeat.
+
+---
+
+## Step 6: Restore backup to your kermés store unit
+
+Pick one unit to be your personal store register — probably the original golden OrangePi. Re-insert its SD card (still holding the wiped image), boot it, and from your laptop push the backup back:
+
+```bash
+rsync -avz --progress ~/ambrosia-backup-YYYYMMDD-HHMMSS/.phoenix/ ambrosia-opi-1@ambrosia-opi-1.local:.phoenix/
+rsync -avz --progress ~/ambrosia-backup-YYYYMMDD-HHMMSS/.Ambrosia-POS/ ambrosia-opi-1@ambrosia-opi-1.local:.Ambrosia-POS/
+```
+
+Then on that unit, restart services:
+
+```bash
+ssh ambrosia-opi-1@ambrosia-opi-1.local 'sudo systemctl start phoenixd ambrosia ambrosia-client'
+```
+
+Check everything came up:
+
+```bash
+ssh ambrosia-opi-1@ambrosia-opi-1.local 'sudo systemctl status phoenixd ambrosia ambrosia-client --no-pager'
+```
+
+Your wallet funds, channels, and Ambrosia menu are back on the original unit. The other 7 clones each have a fresh phoenixd wallet — each merchant will generate their own seed the first time they open the Ambrosia UI.
+
+---
+
+## Step 7: Verify fleet health
+
+From your laptop, ping each unit:
+
+```bash
+for i in 1 2 3 4 5 6 7 8; do
+  echo "--- ambrosia-opi-$i ---"
+  ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
+    ambrosia-opi-1@ambrosia-opi-$i.local \
+    'hostname; systemctl is-active phoenixd ambrosia ambrosia-client' || echo "UNREACHABLE"
+done
+```
+
+Each unit should report its own hostname and three `active` services. Any `UNREACHABLE` or `inactive` lines are units to investigate before the event.

--- a/hardware/preinstalled/operator/scripts/bootstrap-ambrosia.sh
+++ b/hardware/preinstalled/operator/scripts/bootstrap-ambrosia.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Bootstrap a vanilla OrangePi Zero 2W into a ready-to-golden Ambrosia unit.
+#
+# Assumes:
+#   - The Pi has been flashed with the vanilla Debian Bookworm server image
+#     and set up through orangepi-setup.md (your user exists, Wi-Fi is up,
+#     SSH works, avahi-daemon is installed).
+#   - You have SSH key access and the user has sudo (password or NOPASSWD).
+#   - The Pi has internet access (apt + github reachable).
+#
+# What this script does on the Pi:
+#   1. Installs Ambrosia server + client + phoenixd via the upstream install.sh
+#   2. Installs Caddy and writes a hostname-aware reverse-proxy Caddyfile
+#   3. Installs the Wi-Fi captive-portal service + binary, enables it
+#   4. Drops the EFF wordlist at ~/scripts/ so Ambrosia first-boot doesn't
+#      need internet
+#   5. Writes stub phoenix.conf + ambrosia.conf (auto-liquidity off, http
+#      bound to 0.0.0.0)
+#   6. Saves the kermés Wi-Fi as a NetworkManager auto-connect profile
+#   7. Disables the system dnsmasq (conflicts with the captive portal)
+#   8. Adds 127.0.1.1 <hostname>.local to /etc/hosts so local SSR fetches
+#      in the Next.js middleware resolve correctly
+#   9. (Optional) Applies the reverse-proxy-compat patch to the installed
+#      client's proxy.js and rebuilds — required until Ambrosia PR #507
+#      merges. Skipped by default to keep the script hermetic.
+#
+# After this finishes, shut down the Pi, move the SD card to your laptop,
+# and run prep-opi-as-golden.sh to wipe per-unit state and re-image as the
+# distributable golden.
+#
+# Usage: ./bootstrap-ambrosia.sh [options]
+#   --host <pi-host-or-ip>    SSH target (required)
+#   --user <ssh-user>         SSH username (required; also becomes the
+#                             Ambrosia user and expected to match the Pi's
+#                             hostname, e.g. ambrosia-opi-1)
+#   --kermes-ssid <name>      Wi-Fi SSID to pre-save as auto-connect
+#   --kermes-password <pw>    WPA password for the above
+#   --ambrosia-tag <vX.Y.Z>   Ambrosia release tag (default: v0.6.0-beta)
+#   --wordlist <path>         Path to eff_large_wordlist.txt on your laptop
+#                             (default: sibling ambrosia checkout at
+#                              ~/code/ambrosia/scripts/eff_large_wordlist.txt)
+#   --skip-caddy              Don't install/configure Caddy
+#   --skip-portal             Don't install the Wi-Fi captive-portal
+#   --skip-wifi               Don't save the kermés Wi-Fi profile
+#   --no-confirm              Don't pause before making changes
+#
+# Example:
+#   ./bootstrap-ambrosia.sh --host ambrosia-opi-1.local \
+#     --user ambrosia-opi-1 \
+#     --kermes-ssid "YOUR-VENUE-WIFI" --kermes-password "your-wifi-password"
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+HOST=""
+USER_NAME=""
+KERMES_SSID=""
+KERMES_PW=""
+AMBROSIA_TAG="v0.6.0-beta"
+WORDLIST="$HOME/code/ambrosia/scripts/eff_large_wordlist.txt"
+SKIP_CADDY=0
+SKIP_PORTAL=0
+SKIP_WIFI=0
+NO_CONFIRM=0
+
+usage() { sed -n '2,40p' "$0" | sed 's|^# *||'; exit "${1:-0}"; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)             HOST="$2"; shift 2 ;;
+        --user)             USER_NAME="$2"; shift 2 ;;
+        --kermes-ssid)      KERMES_SSID="$2"; shift 2 ;;
+        --kermes-password)  KERMES_PW="$2"; shift 2 ;;
+        --ambrosia-tag)     AMBROSIA_TAG="$2"; shift 2 ;;
+        --wordlist)         WORDLIST="$2"; shift 2 ;;
+        --skip-caddy)       SKIP_CADDY=1; shift ;;
+        --skip-portal)      SKIP_PORTAL=1; shift ;;
+        --skip-wifi)        SKIP_WIFI=1; shift ;;
+        --no-confirm)       NO_CONFIRM=1; shift ;;
+        -h|--help)          usage ;;
+        *) echo "Unknown option: $1" >&2; usage 1 ;;
+    esac
+done
+
+[[ -z "$HOST" || -z "$USER_NAME" ]] && { echo "--host and --user are required" >&2; usage 1; }
+if [[ $SKIP_WIFI -eq 0 && (-z "$KERMES_SSID" || -z "$KERMES_PW") ]]; then
+    echo "--kermes-ssid and --kermes-password are required unless --skip-wifi" >&2
+    exit 1
+fi
+
+# SSH helper. -S reads the sudo password from stdin; pass via echo for
+# commands that need root. `ssh -t` would allocate a tty but breaks piping
+# for complex blocks — we use BatchMode and explicit password-piping.
+SSH="ssh -o BatchMode=yes ${USER_NAME}@${HOST}"
+
+banner() { printf '\n\033[1;34m==> %s\033[0m\n' "$1"; }
+
+banner "Checking SSH to ${USER_NAME}@${HOST}"
+if ! $SSH true 2>/dev/null; then
+    echo "SSH key auth to ${USER_NAME}@${HOST} is not set up." >&2
+    echo "Run:  ssh-copy-id ${USER_NAME}@${HOST}" >&2
+    exit 1
+fi
+
+if [[ $NO_CONFIRM -eq 0 ]]; then
+    cat <<EOF
+
+About to bootstrap ${HOST} with:
+  SSH user:        ${USER_NAME}
+  Ambrosia tag:    ${AMBROSIA_TAG}
+  Caddy:           $([[ $SKIP_CADDY -eq 0 ]] && echo yes || echo SKIP)
+  Wi-Fi portal:    $([[ $SKIP_PORTAL -eq 0 ]] && echo yes || echo SKIP)
+  Kermés Wi-Fi:    $([[ $SKIP_WIFI -eq 0 ]] && echo "$KERMES_SSID" || echo SKIP)
+  Wordlist:        ${WORDLIST}
+
+This will install packages, enable services, and write config files on the Pi.
+Press Enter to continue, Ctrl+C to abort.
+EOF
+    read -r _
+fi
+
+banner "Installing Ambrosia ${AMBROSIA_TAG} (this can take 5-10 min)"
+$SSH "curl -fsSL https://raw.githubusercontent.com/olympus-btc/ambrosia/refs/tags/${AMBROSIA_TAG}/scripts/install.sh | bash -s -- --yes"
+
+# Stub phoenix.conf / ambrosia.conf always get reset to their minimal form
+# by wipe-and-provision.sh, but we put them here too so the first boot
+# before golden-prep behaves identically to a cloned unit.
+banner "Writing stub configs"
+$SSH "mkdir -p ~/.phoenix ~/.Ambrosia-POS && \
+     printf 'auto-liquidity=off\nmax-mining-fee=5000\n' > ~/.phoenix/phoenix.conf && \
+     printf 'http-bind-ip=0.0.0.0\nhttp-bind-port=9154\n' > ~/.Ambrosia-POS/ambrosia.conf"
+
+banner "Copying EFF wordlist"
+if [[ ! -f "$WORDLIST" ]]; then
+    echo "Wordlist not found at $WORDLIST" >&2
+    echo "Point --wordlist at eff_large_wordlist.txt from the ambrosia repo." >&2
+    exit 1
+fi
+scp -q -o BatchMode=yes "$WORDLIST" "${USER_NAME}@${HOST}:/tmp/eff_large_wordlist.txt"
+$SSH "mkdir -p ~/scripts && mv -f /tmp/eff_large_wordlist.txt ~/scripts/"
+
+if [[ $SKIP_CADDY -eq 0 ]]; then
+    banner "Installing Caddy + writing Caddyfile"
+    $SSH "sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl && \
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor --yes -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg && \
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list > /dev/null && \
+        sudo apt-get update && sudo apt-get install -y caddy"
+
+    # Use the Pi's hostname for the Caddy site block. wipe-and-provision.sh
+    # sed-replaces this later when renaming each clone.
+    $SSH "H=\$(hostname); printf '{\n    debug\n    local_certs\n}\n\n%s.local {\n    tls internal\n    reverse_proxy /ws/* localhost:9154\n    reverse_proxy localhost:3000\n}\n' \"\$H\" | sudo tee /etc/caddy/Caddyfile > /dev/null && sudo systemctl restart caddy"
+fi
+
+banner "Adding 127.0.1.1 <hostname>.local to /etc/hosts"
+# Ambrosia's Next.js middleware does SSR fetches against its own public URL;
+# the proxy.js fix in PR #507 makes them hit 127.0.0.1 instead, but even
+# without the patch we need <host>.local to resolve on-box for other tools.
+$SSH "H=\$(hostname); grep -q \"\$H.local\" /etc/hosts || echo \"127.0.1.1 \$H.local\" | sudo tee -a /etc/hosts > /dev/null"
+
+if [[ $SKIP_PORTAL -eq 0 ]]; then
+    banner "Installing Wi-Fi captive-portal service"
+    scp -q -o BatchMode=yes "$SCRIPT_DIR/ambrosia-wifi-portal" "${USER_NAME}@${HOST}:/tmp/"
+    scp -q -o BatchMode=yes "$SCRIPT_DIR/ambrosia-wifi-portal.service" "${USER_NAME}@${HOST}:/tmp/"
+    $SSH "sudo apt-get install -y hostapd python3-flask && \
+        sudo install -m 0755 /tmp/ambrosia-wifi-portal /usr/local/bin/ambrosia-wifi-portal && \
+        sudo install -m 0644 /tmp/ambrosia-wifi-portal.service /etc/systemd/system/ambrosia-wifi-portal.service && \
+        sudo systemctl disable --now dnsmasq hostapd 2>/dev/null || true && \
+        sudo systemctl daemon-reload && \
+        sudo systemctl enable ambrosia-wifi-portal"
+fi
+
+if [[ $SKIP_WIFI -eq 0 ]]; then
+    banner "Saving kermés Wi-Fi (${KERMES_SSID}) as auto-connect profile"
+    $SSH "sudo nmcli connection delete \"${KERMES_SSID}\" 2>/dev/null || true && \
+        sudo nmcli connection add type wifi con-name \"${KERMES_SSID}\" ifname wlan0 \
+            ssid \"${KERMES_SSID}\" \
+            wifi-sec.key-mgmt wpa-psk wifi-sec.psk \"${KERMES_PW}\" \
+            connection.autoconnect yes"
+fi
+
+banner "All done."
+cat <<EOF
+
+Next steps:
+  1. Shut the Pi down cleanly:    ssh ${USER_NAME}@${HOST} 'sudo shutdown -h now'
+  2. Pull the microSD card and insert it into your laptop's reader.
+  3. Run prep-opi-as-golden.sh to wipe per-unit state, then dd the card to
+     a compressed image file. See clone-fleet.md Step 3 for details.
+
+Important caveat (Ambrosia PR #507):
+  If you installed Caddy and want the HTTPS + captive-portal flow to work
+  with the Ambrosia client, you must also apply the reverse-proxy-compat
+  patch to the installed client until Ambrosia upstreams it. See:
+      https://github.com/olympus-btc/ambrosia/pull/507
+  The installer ships a pre-built Next.js client that doesn't have this
+  fix; patching requires rebuilding the client from source. This script
+  does NOT do that automatically.
+EOF

--- a/hardware/preinstalled/operator/scripts/generate-take-home-cards.sh
+++ b/hardware/preinstalled/operator/scripts/generate-take-home-cards.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# Generate compact per-unit take-home cards (one per unit) with the
+# captive-portal Wi-Fi setup flow only — meant to be cut out and slipped
+# into the box that goes home with each vendor. Mirrors the layout of
+# generate-vendor-cards.sh so the two cards feel like a set.
+#
+# Usage: ./generate-take-home-cards.sh [options]
+#   --support-url <url>  Telegram (or other) support invite URL — adds a small
+#                        QR + text block in the footer.
+#   --lang <code>        Card language: en (default) or es (Mexican Spanish).
+#   --log <path>         password log path (default: ~/ambrosia-fleet-passwords.txt)
+#   --out <path>         output HTML file (default: ~/ambrosia-take-home-cards.html)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+SUPPORT_URL=""
+CARD_LANG="en"
+LOG="$HOME/ambrosia-fleet-passwords.txt"
+OUT="$REPO_ROOT/out/ambrosia-take-home-cards.html"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --support-url) SUPPORT_URL="$2"; shift 2 ;;
+        --lang)        CARD_LANG="$2"; shift 2 ;;
+        --log)         LOG="$2"; shift 2 ;;
+        --out)         OUT="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,13p' "$0" | sed 's|^# *||'
+            exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+case "$CARD_LANG" in
+    es|es-mx|es-MX|es_MX|es_mx) CARD_LANG="es" ;;
+    en|en-us|en-US|en_US)       CARD_LANG="en" ;;
+    *) echo "Unknown language: $CARD_LANG (supported: en, es)" >&2; exit 1 ;;
+esac
+
+if [[ ! -r "$LOG" ]]; then
+    echo "Password log not found or unreadable: $LOG" >&2
+    exit 1
+fi
+if ! command -v qrencode >/dev/null 2>&1; then
+    echo "qrencode is required. Install with: sudo apt install -y qrencode" >&2
+    exit 1
+fi
+
+if [[ "$CARD_LANG" == "es" ]]; then
+    T_HTML_LANG="es-MX"
+    T_TITLE="Tarjetas para llevar a casa — Ambrosia"
+    T_PAGE_NOTE="Imprime en papel tamaño carta. Corta por las líneas punteadas y entrega una tarjeta a cada vendedor."
+    T_PRODUCT="Ambrosia POS — Llévate a casa"
+    T_INTRO="Cuando llegues a casa, tu unidad no encontrará el Wi-Fi de la kermés y abrirá su propia red de configuración. Sigue estos pasos para enseñarle tu Wi-Fi de casa:"
+    T_STEPS_TITLE="Pasos"
+    T_STEP_1="Conecta la corriente y espera unos <b>60 segundos</b>."
+    T_STEP_2_PRE="Conecta tu teléfono al Wi-Fi"
+    T_STEP_2_NOTE="(red abierta, sin contraseña)"
+    T_STEP_3="Debe abrirse sola la <b>página de configuración</b>. Si no, abre <code>http://10.42.1.1</code> en Chrome o Safari."
+    T_STEP_4="Toca tu Wi-Fi de casa de la lista (o escribe el nombre si está oculta), escribe la contraseña — toca <b>Mostrar</b> para verificar — y toca <b>Conectar</b>."
+    T_STEP_5="Toca <b>Copiar dirección y terminar</b>. La red de configuración se cierra y tu teléfono vuelve solo a tu Wi-Fi de casa."
+    T_STEP_6="Abre Chrome o Safari, <b>pega la dirección</b> en la barra. ¡Listo, ya estás en el POS!"
+    T_AP_LABEL="Wi-Fi de configuración"
+    T_POS_TITLE="Ambrosia POS"
+    T_POS_HINT="O escanea para abrir directo después."
+    T_TROUBLE_HEAD="¿Problemas?"
+    T_TROUBLE_BODY="Si no aparece <code>%s-setup</code> en la lista del teléfono, espera 60 seg y vuelve a buscar. Si no abre la página de configuración, escribe <code>http://10.42.1.1</code> a mano."
+    T_ETHERNET_HEAD="¿Tienes adaptador Ethernet USB-C?"
+    T_ETHERNET_BODY="Conéctalo al router con un cable Ethernet, espera 60 seg, y entra directo a <code>%s</code> desde cualquier dispositivo en tu Wi-Fi de casa. No necesitas hacer nada más."
+    T_SUPPORT_TITLE="Soporte"
+    T_SUPPORT_TEXT="Escanea para unirte al chat de soporte en <b>Telegram</b>."
+    T_SUPPORT_NOTE="Requiere cuenta de Telegram."
+    T_SSH_TITLE="Acceso SSH"
+    T_SSH_SUBTITLE="(solo para uso avanzado):"
+    T_PASSWORD_LABEL="Contraseña:"
+    T_CHANGE_PASSWORD="Cambia esta contraseña al iniciar sesión SSH por primera vez con el comando <code>passwd</code>."
+else
+    T_HTML_LANG="en"
+    T_TITLE="Take-home cards — Ambrosia"
+    T_PAGE_NOTE="Print on letter paper. Cut along the dashed lines and hand one card to each vendor."
+    T_PRODUCT="Ambrosia POS — Take home"
+    T_INTRO="When you get home, your unit won&rsquo;t find the kermés Wi-Fi and will broadcast its own setup network instead. Follow these steps to teach it your home Wi-Fi:"
+    T_STEPS_TITLE="Steps"
+    T_STEP_1="Plug in power and wait about <b>60 seconds</b>."
+    T_STEP_2_PRE="On your phone, join the Wi-Fi"
+    T_STEP_2_NOTE="(open network, no password)"
+    T_STEP_3="The <b>setup page</b> should open by itself. If it doesn&rsquo;t, open <code>http://10.42.1.1</code> in Chrome or Safari."
+    T_STEP_4="Tap your home Wi-Fi from the list (or type the name if it&rsquo;s hidden), enter the password — tap <b>Show</b> to verify — and tap <b>Connect</b>."
+    T_STEP_5="Tap <b>Copy address and finish</b>. The setup network closes and your phone reconnects to your home Wi-Fi."
+    T_STEP_6="Open Chrome or Safari, <b>paste the address</b> into the URL bar. You&rsquo;re at the POS!"
+    T_AP_LABEL="Setup Wi-Fi"
+    T_POS_TITLE="Ambrosia POS"
+    T_POS_HINT="Or scan to open directly afterward."
+    T_TROUBLE_HEAD="Trouble?"
+    T_TROUBLE_BODY="If <code>%s-setup</code> doesn&rsquo;t show up in your phone&rsquo;s Wi-Fi list, wait 60 sec and rescan. If the setup page doesn&rsquo;t open, type <code>http://10.42.1.1</code> manually."
+    T_ETHERNET_HEAD="Got a USB-C Ethernet adapter?"
+    T_ETHERNET_BODY="Plug it into your router with an Ethernet cable, wait 60 sec, and visit <code>%s</code> from any device on your home Wi-Fi. Nothing else to do."
+    T_SUPPORT_TITLE="Support"
+    T_SUPPORT_TEXT="Scan to join our <b>Telegram</b> support chat."
+    T_SUPPORT_NOTE="Requires a Telegram account."
+    T_SSH_TITLE="SSH access"
+    T_SSH_SUBTITLE="(advanced use only):"
+    T_PASSWORD_LABEL="Password:"
+    T_CHANGE_PASSWORD="Change this password on first SSH login by running <code>passwd</code>."
+fi
+
+html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    s="${s//\"/&quot;}"
+    printf '%s' "$s"
+}
+
+SUPPORT_BLOCK=""
+if [[ -n "$SUPPORT_URL" ]]; then
+    SUPPORT_QR=$(qrencode -t SVG -m 0 -s 3 -o - "$SUPPORT_URL" | sed -n '/<svg/,/<\/svg>/p')
+    SUPPORT_URL_HTML=$(html_escape "$SUPPORT_URL")
+    SUPPORT_BLOCK=$(cat <<SUPPORT
+    <div class="qr-box support-block">
+      <div class="qr-box-title">${T_SUPPORT_TITLE}</div>
+      <div class="support-inner">
+        <div class="support-qr">${SUPPORT_QR}</div>
+        <div class="support-text">
+          <div>${T_SUPPORT_TEXT}</div>
+          <div class="support-url">${SUPPORT_URL_HTML}</div>
+          <div class="support-note">${T_SUPPORT_NOTE}</div>
+        </div>
+      </div>
+    </div>
+SUPPORT
+)
+fi
+
+mkdir -p "$(dirname "$OUT")"
+{
+cat <<HTML_HEAD
+<!DOCTYPE html>
+<html lang="${T_HTML_LANG}">
+<head>
+<meta charset="UTF-8">
+<title>${T_TITLE}</title>
+<style>
+  @page { size: letter; margin: 0.4in; }
+  body { font-family: -apple-system, Arial, sans-serif; margin: 0; color: #111; }
+  .page-note { font-size: 9pt; color: #888; margin: 0 0 0.15in 0; }
+  .card {
+    width: 7.7in;
+    margin: 0 0 0.15in 0;
+    padding: 0.25in 0.3in;
+    border: 2px dashed #888;
+    border-radius: 0.1in;
+    box-sizing: border-box;
+    page-break-inside: avoid;
+    display: flex;
+    flex-direction: column;
+  }
+  .header {
+    display: flex;
+    align-items: baseline;
+    border-bottom: 2px solid #000;
+    padding-bottom: 0.06in;
+    margin-bottom: 0.12in;
+  }
+  .header .name { font-size: 22pt; font-weight: 700; }
+  .header .product { margin-left: auto; font-size: 11pt; color: #555; }
+  .intro { font-size: 10pt; color: #333; margin: 0 0 0.1in 0; }
+  .body { display: flex; flex: 1; gap: 0.35in; }
+  .left { flex: 1.4; display: flex; flex-direction: column; min-width: 0; }
+  .right { width: 2.6in; display: flex; flex-direction: column; align-items: center; }
+  .steps-title { font-size: 11pt; font-weight: 700; margin-bottom: 0.04in; }
+  ol.steps { margin: 0; padding-left: 0.25in; font-size: 10pt; line-height: 1.35; }
+  ol.steps li { margin-bottom: 0.04in; }
+  ol.steps b { font-weight: 700; }
+  ol.steps code { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 9pt; background: #f4f4f4; padding: 0 2px; border-radius: 2px; }
+  .ap-callout {
+    display: inline-block;
+    background: #1a73e8;
+    color: #fff;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-weight: 700;
+    font-size: 11pt;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin: 1px 2px;
+    white-space: nowrap;
+  }
+  .ap-note { font-size: 8.5pt; color: #555; }
+  .qr-box {
+    display: flex;
+    flex-direction: column;
+    padding: 0.06in 0.1in;
+    background: #f4f4f4;
+    border-radius: 0.05in;
+    box-sizing: border-box;
+  }
+  .qr-box-title {
+    font-size: 9pt; font-weight: 700; text-align: center; color: #333;
+    border-bottom: 1px solid #ccc; padding-bottom: 0.03in; margin-bottom: 0.05in;
+  }
+  /* Big "Setup Wi-Fi" callout — the most important per-card data point */
+  .ap-block { width: 2.5in; align-items: center; margin-bottom: 0.1in; }
+  .ap-block .big {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 13pt;
+    font-weight: 700;
+    text-align: center;
+    word-break: break-all;
+    margin: 0.04in 0;
+  }
+  .ap-block .sub { font-size: 8pt; color: #666; text-align: center; }
+  /* POS QR block */
+  .pos-block { width: 2.5in; align-items: center; margin-bottom: 0.08in; }
+  .pos-block .qr svg { width: 1.4in; height: 1.4in; display: block; }
+  .pos-block .url {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 9pt; text-align: center; white-space: nowrap; margin-top: 0.04in;
+  }
+  .pos-block .qr-hint { font-size: 7pt; color: #666; text-align: center; margin-top: 0.02in; }
+  .footer {
+    margin-top: auto;
+    display: grid;
+    grid-template-columns: 2.2in 1fr 2.5in;
+    gap: 0.15in;
+    font-size: 8pt; color: #555;
+    border-top: 1px solid #ccc;
+    padding-top: 0.1in;
+    line-height: 1.35;
+  }
+  .footer .admin,
+  .footer .help { padding-top: 0.04in; }
+  .footer .admin { min-width: 0; overflow: hidden; }
+  .footer .admin .lbl { color: #888; }
+  .footer .admin code,
+  .footer .admin .val {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    color: #111; font-size: 7pt; white-space: nowrap;
+  }
+  .footer .help b { color: #111; }
+  .footer .help p { margin: 0 0 0.05in 0; }
+  .support-block { align-self: flex-start; width: 2.5in; box-sizing: border-box; }
+  .support-inner { display: flex; align-items: center; gap: 0.1in; }
+  .support-qr svg { width: 0.85in; height: 0.85in; display: block; }
+  .support-text { font-size: 8pt; line-height: 1.3; color: #111; min-width: 0; }
+  .support-url { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 7pt; color: #333; word-break: break-all; margin-top: 0.03in; }
+  .support-note { font-size: 7pt; color: #666; margin-top: 0.03in; }
+  @media print { .page-note { display: none; } }
+</style>
+</head>
+<body>
+<p class="page-note">${T_PAGE_NOTE}</p>
+HTML_HEAD
+
+while read -r NAME PASSWORD; do
+    [[ -z "$NAME" || "$NAME" =~ ^# ]] && continue
+    URL="https://${NAME}.local/"
+    AP_NAME="${NAME}-setup"
+    NAME_H=$(html_escape "$NAME")
+    PW_H=$(html_escape "$PASSWORD")
+    URL_H=$(html_escape "$URL")
+    AP_NAME_H=$(html_escape "$AP_NAME")
+    QR_SVG=$(qrencode -t SVG -m 0 -s 4 -o - "$URL" | sed -n '/<svg/,/<\/svg>/p')
+    TROUBLE_TEXT=$(printf "$T_TROUBLE_BODY" "$NAME_H")
+    ETHERNET_TEXT=$(printf "$T_ETHERNET_BODY" "$URL_H")
+    cat <<HTML_CARD
+<div class="card">
+  <div class="header">
+    <div class="name">${NAME_H}</div>
+    <div class="product">${T_PRODUCT}</div>
+  </div>
+  <p class="intro">${T_INTRO}</p>
+  <div class="body">
+    <div class="left">
+      <div class="steps-title">${T_STEPS_TITLE}</div>
+      <ol class="steps">
+        <li>${T_STEP_1}</li>
+        <li>${T_STEP_2_PRE} <span class="ap-callout">${AP_NAME_H}</span> <span class="ap-note">${T_STEP_2_NOTE}</span></li>
+        <li>${T_STEP_3}</li>
+        <li>${T_STEP_4}</li>
+        <li>${T_STEP_5}</li>
+        <li>${T_STEP_6}</li>
+      </ol>
+    </div>
+    <div class="right">
+      <div class="qr-box ap-block">
+        <div class="qr-box-title">${T_AP_LABEL}</div>
+        <div class="big">${AP_NAME_H}</div>
+        <div class="sub">${T_STEP_2_NOTE}</div>
+      </div>
+      <div class="qr-box pos-block">
+        <div class="qr-box-title">${T_POS_TITLE}</div>
+        <div class="qr">${QR_SVG}</div>
+        <div class="url">${URL_H}</div>
+        <div class="qr-hint">${T_POS_HINT}</div>
+      </div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="admin">
+      <div><span class="lbl"><b>${T_SSH_TITLE}</b> ${T_SSH_SUBTITLE}</span></div>
+      <div><code>ssh ${NAME_H}@${NAME_H}.local</code></div>
+      <div><span class="lbl">${T_PASSWORD_LABEL}</span> <span class="val">${PW_H}</span></div>
+      <div class="lbl">${T_CHANGE_PASSWORD}</div>
+    </div>
+    <div class="help">
+      <p><b>${T_TROUBLE_HEAD}</b> ${TROUBLE_TEXT}</p>
+      <p><b>${T_ETHERNET_HEAD}</b> ${ETHERNET_TEXT}</p>
+    </div>
+${SUPPORT_BLOCK}
+  </div>
+</div>
+HTML_CARD
+done < <(sort -V -k1,1 "$LOG")
+
+cat <<'HTML_TAIL'
+</body>
+</html>
+HTML_TAIL
+} > "$OUT"
+
+echo "Wrote $(grep -c '<div class="card"' "$OUT") card(s) to $OUT"
+echo "Open in a browser and Ctrl+P to print."

--- a/hardware/preinstalled/operator/scripts/generate-take-home.sh
+++ b/hardware/preinstalled/operator/scripts/generate-take-home.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+# Generate a printable take-home instruction sheet (letter paper, 3-4 pages)
+# for vendors who want to use their Ambrosia unit at home after the kermés.
+# Covers three Wi-Fi reconfiguration methods: phone+captive-portal (default),
+# HDMI+keyboard, and USB-Ethernet.
+#
+# Usage: ./generate-take-home.sh [options]
+#   --lang <code>  en (default) or es (Mexican Spanish)
+#   --out <path>   output HTML file (default: ~/ambrosia-take-home-<lang>.html)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+CARD_LANG="en"
+OUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --lang) CARD_LANG="$2"; shift 2 ;;
+        --out)  OUT="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,10p' "$0" | sed 's|^# *||'
+            exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+case "$CARD_LANG" in
+    es|es-mx|es-MX|es_MX|es_mx) CARD_LANG="es" ;;
+    en|en-us|en-US|en_US)       CARD_LANG="en" ;;
+    *) echo "Unknown language: $CARD_LANG (supported: en, es)" >&2; exit 1 ;;
+esac
+
+if [[ -z "$OUT" ]]; then
+    OUT="$REPO_ROOT/out/ambrosia-take-home-${CARD_LANG}.html"
+fi
+
+if [[ "$CARD_LANG" == "es" ]]; then
+    HTML_LANG="es-MX"
+    T_TITLE="Llévate tu unidad Ambrosia a casa"
+    T_INTRO='Tu OrangePi se configuró en la kermés, así que está conectada al Wi-Fi de la kermés. Para usarla en casa (u otro lugar) necesitas decirle el nombre y contraseña de tu Wi-Fi. Elige <b>uno</b> de los tres métodos según el equipo que tengas a la mano. <b>El Método 1 es el más fácil</b> &mdash; solo necesitas tu teléfono.'
+    T_REPLACE='El nombre de tu unidad está en la tarjeta impresa que recibiste (por ejemplo <code>ambrosia-opi-3</code>). Sustituye <code>TU-UNIDAD</code> en los ejemplos por el nombre que aparezca en tu tarjeta. Tu contraseña SSH también está en la tarjeta.'
+    T_M1="Método 1: Teléfono + Wi-Fi de configuración"
+    T_M1_SUB="más fácil, sin equipo extra"
+    T_M1_NEEDS="<b>Necesitas:</b> solo tu teléfono."
+    T_M1_STEPS='<p>Cuando la OrangePi enciende y no encuentra una red Wi-Fi conocida, levanta su propia red de configuración. Te conectas a esa red desde el teléfono, eliges tu Wi-Fi de la lista, escribes la contraseña y listo.</p>
+    <ol>
+      <li>Conecta la corriente a la OrangePi y espera unos 60 segundos.</li>
+      <li>En tu teléfono, abre los ajustes de Wi-Fi y conéctate a <b><code>TU-UNIDAD-setup</code></b> (red abierta, sin contraseña).</li>
+      <li>El teléfono debería abrir la página de configuración automáticamente. Si no aparece, abre Chrome o Safari y entra a <code>http://10.42.1.1</code>.</li>
+      <li>La página muestra las redes Wi-Fi que la OrangePi puede ver. Toca tu Wi-Fi de casa (o escribe el nombre si está oculta), luego escribe la contraseña &mdash; toca <b>Mostrar</b> para verificar lo que escribiste. Toca <b>Conectar</b>.</li>
+      <li>En la siguiente pantalla, lee los pasos y luego toca <b>Copiar dirección y terminar</b>. Esto copia la dirección del POS al portapapeles, apaga la red de configuración, y tu teléfono se reconecta solo a tu Wi-Fi de casa.</li>
+      <li>Abre Chrome o Safari, pega la dirección en la barra y entrarás al POS.</li>
+    </ol>
+    <div class="note">Si la página de configuración no aparece sola al unirte a <code>TU-UNIDAD-setup</code>, espera 5-10 segundos y abre <code>http://10.42.1.1</code> manualmente en el navegador.</div>'
+    T_M2="Método 2: HDMI + teclado USB"
+    T_M2_SUB="no requiere otra computadora"
+    T_M2_NEEDS="<b>Necesitas:</b> una TV o monitor con HDMI, un cable mini-HDMI a HDMI y un teclado USB."
+    T_M2_STEPS='<ol>
+      <li>Apaga la OrangePi (desconecta el cable USB-C).</li>
+      <li>Conéctala a tu TV/monitor con el cable mini-HDMI y conecta un teclado USB.</li>
+      <li>Vuelve a conectar la corriente y espera unos 60 segundos hasta que aparezca la pantalla de inicio.</li>
+      <li>Cuando aparezca <code>TU-UNIDAD login:</code> en la pantalla, escribe el nombre de tu unidad (de la tarjeta) y presiona Enter, luego tu contraseña y Enter.</li>
+      <li>Conéctate a tu Wi-Fi de casa con:
+        <pre>sudo nmcli --ask device wifi connect "NOMBRE-DE-TU-WIFI"</pre>
+        Te pedirá tu contraseña de sudo (la misma de la tarjeta) y luego la contraseña de tu Wi-Fi de casa.
+      </li>
+      <li>Verifica que funcionó:
+        <pre>nmcli device status</pre>
+        La línea de <code>wlan0</code> debe decir <b>connected</b> con el nombre de tu Wi-Fi a la derecha.
+      </li>
+      <li>Apaga con <code>sudo poweroff</code>, desconecta el HDMI y el teclado, mueve la OrangePi al lugar donde la vayas a usar. Al conectar la corriente se conectará sola a tu Wi-Fi de casa.</li>
+    </ol>'
+    T_M3="Método 3: Cable Ethernet USB"
+    T_M3_SUB="sin Wi-Fi"
+    T_M3_NEEDS="<b>Necesitas:</b> un adaptador USB-C a Ethernet, un cable Ethernet y tu router con un puerto LAN libre."
+    T_M3_STEPS='<p>Si prefieres simplemente conectar la OrangePi al router y olvidarte del Wi-Fi, este es el camino más rápido. Una vez en la red cableada, cualquier dispositivo en tu Wi-Fi de casa puede acceder a ella.</p>
+    <ol>
+      <li>Conecta el adaptador USB-C a Ethernet a la OrangePi, y un cable Ethernet del adaptador al router.</li>
+      <li>Conecta la corriente y espera unos 60 segundos.</li>
+      <li>Desde cualquier dispositivo en tu red de casa (teléfono, laptop), abre <code>https://TU-UNIDAD.local/</code> en el navegador. Acepta la advertencia del certificado (es el certificado autofirmado de la unidad &mdash; igual que en la kermés). Listo, ya estás en el POS.</li>
+    </ol>
+    <div class="note">Si <code>TU-UNIDAD.local</code> no resuelve, busca la IP de la OrangePi en la página de "dispositivos conectados" de tu router y usa <code>https://192.168.x.y/</code>.</div>
+    <p style="margin-top:0.1in;">Puedes dejar la unidad en Ethernet de forma permanente. Si después prefieres Wi-Fi, desconecta el cable Ethernet y la unidad arrancará con el AP de configuración del Método 1 al volver a encenderla.</p>'
+    T_FIND_TITLE="Cómo encontrar el nombre y contraseña de tu Wi-Fi"
+    T_FIND_INTRO="Si no sabes el nombre (SSID) o contraseña de tu Wi-Fi de casa, estos son los lugares más comunes donde encontrarlos:"
+    T_FIND_LIST='<ol>
+      <li><b>Calcomanía del router.</b> La mayoría de los routers traen el nombre de la red y la contraseña de fábrica impresos en una calcomanía en la parte de abajo o atrás. Busca etiquetas como "WiFi Name", "SSID" o "Nombre de red", y "Password", "WPA Key" o "Contraseña".</li>
+      <li><b>Un teléfono que ya está conectado a esa red.</b>
+        <ul>
+          <li><b>Android (10+):</b> Ajustes &rarr; Red e internet &rarr; Internet &rarr; toca tu Wi-Fi &rarr; Compartir &rarr; muestra el código QR o revela la contraseña.</li>
+          <li><b>iOS (16+):</b> Ajustes &rarr; Wi-Fi &rarr; toca la (i) junto a tu red &rarr; toca Contraseña para verla.</li>
+        </ul>
+      </li>
+      <li><b>App o portal de tu proveedor de internet.</b> Totalplay, Telmex, Izzi y Megacable te permiten ver (y cambiar) las credenciales del Wi-Fi desde su app o portal en línea.</li>
+      <li><b>Página de administración del router.</b> Desde un dispositivo ya conectado a tu Wi-Fi, abre <code>http://192.168.1.1</code> o <code>http://192.168.100.1</code> en un navegador. Inicia sesión con las credenciales de admin (a veces también están en la calcomanía) y busca la sección de Wireless o Wi-Fi.</li>
+    </ol>
+    <p>¿Sigues atorado? Pregunta en el chat de soporte de Telegram &mdash; te ayudamos a encontrarlos.</p>'
+    T_TROUBLE_TITLE="Solución de problemas"
+    T_TROUBLE='<ul>
+      <li><b><code>TU-UNIDAD-setup</code> no aparece en el listado de Wi-Fi.</b> Espera 60 segundos completos después de encender, y vuelve a buscar. Si aún no aparece, puede que se haya conectado a una red conocida — apaga y enciende en un lugar fuera del alcance de cualquier Wi-Fi que conozca.</li>
+      <li><b>La página de configuración no aparece al unirte a <code>TU-UNIDAD-setup</code>.</b> Abre Chrome o Safari y entra a <code>http://10.42.1.1</code> manualmente.</li>
+      <li><b>Escribiste mal la contraseña del Wi-Fi.</b> El AP de configuración vuelve a aparecer si falla el intento — solo vuelve a unirte a <code>TU-UNIDAD-setup</code> y prueba otra vez. (Si usaste el Método 2 o 3: <code>sudo nmcli connection delete "NOMBRE-DE-TU-WIFI"</code> y luego repite el comando connect.)</li>
+      <li><b>Sigue conectado al Wi-Fi de la kermés cuando no quieres.</b> En casa el Wi-Fi de la kermés no está al alcance, así que no se conectará solo — basta con agregar tu Wi-Fi de casa y la unidad usará la que esté disponible.</li>
+      <li><b>Olvidaste la contraseña o te bloqueaste.</b> Escríbenos al chat de soporte de Telegram (QR en tu tarjeta).</li>
+      <li><b>Nada resuelve ni funciona.</b> Apaga la unidad, tráela al organizador de la kermés o pide ayuda en Telegram — podemos reimaginar la tarjeta por ti.</li>
+    </ul>'
+    T_OUTRO='Cuando estés conectado, abre la app del POS en <code>https://TU-UNIDAD.local/</code> desde cualquier dispositivo en tu Wi-Fi de casa — igual que en la kermés, con la misma advertencia del navegador que hay que aceptar.'
+else
+    HTML_LANG="en"
+    T_TITLE="Taking your Ambrosia unit home"
+    T_INTRO='Your OrangePi was set up at the kermés, so it is configured to connect to the kermés Wi-Fi. To use it at home (or at another location), you need to tell it about your home Wi-Fi network. Pick <b>one</b> of the three methods below &mdash; whichever matches the hardware you have handy. <b>Method 1 is the easiest</b> &mdash; it only needs your phone.'
+    T_REPLACE='Your unit name is on the printed card that came with the OrangePi (e.g. <code>ambrosia-opi-3</code>). Replace <code>YOUR-UNIT</code> in the examples below with the actual name on your card. Your SSH password is also on the card.'
+    T_M1="Method 1: Phone + setup Wi-Fi"
+    T_M1_SUB="easiest, no extra hardware"
+    T_M1_NEEDS="<b>You'll need:</b> just your phone."
+    T_M1_STEPS='<p>When the OrangePi boots and cannot find a Wi-Fi it knows, it broadcasts its own setup network. You join that network from your phone, pick your home Wi-Fi from a list, type the password, and you are done.</p>
+    <ol>
+      <li>Plug power into the OrangePi and wait about 60 seconds.</li>
+      <li>On your phone, open Wi-Fi settings and connect to <b><code>YOUR-UNIT-setup</code></b> (open network, no password).</li>
+      <li>Your phone should automatically open the setup page. If nothing pops up, open Chrome or Safari and go to <code>http://10.42.1.1</code>.</li>
+      <li>The page lists Wi-Fi networks the OrangePi can see. Tap your home Wi-Fi (or type the name if it is hidden), then enter the password &mdash; tap <b>Show</b> to verify what you typed. Tap <b>Connect</b>.</li>
+      <li>On the next page, read the steps and then tap <b>Copy address and finish</b>. This copies the POS address to your clipboard, shuts down the setup network, and your phone reconnects to your home Wi-Fi.</li>
+      <li>Open Chrome or Safari, paste the address into the URL bar, and you are at the POS.</li>
+    </ol>
+    <div class="note">If the captive page does not pop up after you join <code>YOUR-UNIT-setup</code>, give it 5-10 seconds and then open <code>http://10.42.1.1</code> in a browser manually.</div>'
+    T_M2="Method 2: HDMI + USB keyboard"
+    T_M2_SUB="no other computer required"
+    T_M2_NEEDS="<b>You'll need:</b> a TV or monitor with HDMI, a mini-HDMI to HDMI cable, and a USB keyboard."
+    T_M2_STEPS='<ol>
+      <li>Power off the OrangePi (unplug the USB-C cable).</li>
+      <li>Connect the OrangePi to your TV/monitor with the mini-HDMI cable, and plug in a USB keyboard.</li>
+      <li>Plug the power back in and wait about 60 seconds for the boot screen.</li>
+      <li>When you see <code>YOUR-UNIT login:</code> on the screen, type your unit name (from the card) and press Enter, then your password and Enter.</li>
+      <li>Connect to your home Wi-Fi by typing:
+        <pre>sudo nmcli --ask device wifi connect "YOUR-HOME-WIFI-NAME"</pre>
+        It will ask for your sudo password (the one on the card) and then your home Wi-Fi password.
+      </li>
+      <li>Confirm it worked:
+        <pre>nmcli device status</pre>
+        The <code>wlan0</code> line should say <b>connected</b> with your home Wi-Fi name on the right.
+      </li>
+      <li>Power off (<code>sudo poweroff</code>), unplug the HDMI cable and keyboard, and move the OrangePi to wherever you want to use it. Plug power back in &mdash; it will auto-connect to your home Wi-Fi from now on.</li>
+    </ol>'
+    T_M3="Method 3: USB Ethernet cable"
+    T_M3_SUB="skip Wi-Fi entirely"
+    T_M3_NEEDS="<b>You'll need:</b> a USB-C to Ethernet adapter, an Ethernet cable, and your home router with a free LAN port."
+    T_M3_STEPS='<p>If you would rather just plug the OrangePi into your router and skip Wi-Fi setup altogether, this is the fastest option. Once it is on the wired network, every device on your home Wi-Fi can reach it.</p>
+    <ol>
+      <li>Plug the USB-C Ethernet adapter into the OrangePi, then an Ethernet cable from the adapter to your router.</li>
+      <li>Plug in power and wait about 60 seconds.</li>
+      <li>From any device on your home network (phone, laptop), open <code>https://YOUR-UNIT.local/</code> in a browser. Click through the certificate warning (it is the unit&apos;s self-signed cert &mdash; same as at the kermés). You are at the POS.</li>
+    </ol>
+    <div class="note">If <code>YOUR-UNIT.local</code> does not resolve, find the OrangePi&apos;s IP in your router&apos;s "connected devices" admin page and use <code>https://192.168.x.y/</code> instead.</div>
+    <p style="margin-top:0.1in;">You can leave the unit on Ethernet permanently. If you would later prefer Wi-Fi, unplug the Ethernet cable and the unit will boot into Method 1&apos;s setup AP next time you power-cycle it.</p>'
+    T_FIND_TITLE="Finding your Wi-Fi name and password"
+    T_FIND_INTRO="If you do not know your home Wi-Fi name (SSID) or password, here are the common places to look:"
+    T_FIND_LIST='<ol>
+      <li><b>Sticker on the router.</b> Most home routers have the default network name and password printed on a sticker on the bottom or back. Look for labels like "WiFi Name", "SSID", or "Network Name", and "Password", "WPA Key", or "Wi-Fi Password".</li>
+      <li><b>A phone that is already connected.</b>
+        <ul>
+          <li><b>Android (10+):</b> Settings &rarr; Network &amp; Internet &rarr; Internet &rarr; tap your Wi-Fi &rarr; Share &rarr; scan the QR or reveal the password.</li>
+          <li><b>iOS (16+):</b> Settings &rarr; Wi-Fi &rarr; tap the (i) next to your network &rarr; tap Password to reveal.</li>
+        </ul>
+      </li>
+      <li><b>Your ISP app or account portal.</b> Providers like Totalplay, Telmex, Izzi, and Megacable let you view (and change) your Wi-Fi credentials in their mobile app or online account.</li>
+      <li><b>Router admin page.</b> From a device already on your Wi-Fi, open <code>http://192.168.1.1</code> or <code>http://192.168.100.1</code> in a browser. Log in with admin credentials (often also on the router sticker) and look under Wireless / Wi-Fi settings.</li>
+    </ol>
+    <p>Still stuck? Ask in the Telegram support chat &mdash; we can walk you through it.</p>'
+    T_TROUBLE_TITLE="Troubleshooting"
+    T_TROUBLE='<ul>
+      <li><b><code>YOUR-UNIT-setup</code> does not appear in your phone&apos;s Wi-Fi list.</b> Wait a full 60 seconds after powering on, then re-scan. If still nothing, the unit may have auto-connected to a known network &mdash; power-cycle it somewhere out of range of any Wi-Fi it knows.</li>
+      <li><b>Setup page does not pop up after joining <code>YOUR-UNIT-setup</code>.</b> Open Chrome or Safari and go to <code>http://10.42.1.1</code> manually.</li>
+      <li><b>Wrong Wi-Fi password typed.</b> The setup AP comes back up after a failed attempt &mdash; just rejoin <code>YOUR-UNIT-setup</code> and try again. (If you used Method 2 or 3: <code>sudo nmcli connection delete "YOUR-HOME-WIFI-NAME"</code> then repeat the connect command.)</li>
+      <li><b>Still on the kermés Wi-Fi when you do not want to be.</b> At home the kermés Wi-Fi is not in range so it will not auto-connect &mdash; just add your home one and the unit will prefer whichever is available.</li>
+      <li><b>Forgot your password or locked yourself out.</b> Reach out in the Telegram support chat (QR on your card).</li>
+      <li><b>Nothing resolves and nothing works.</b> Power off, bring the unit to the kermés organizer or ping support on Telegram &mdash; we can reimage it for you.</li>
+    </ul>'
+    T_OUTRO='After you are connected, access the POS UI at <code>https://YOUR-UNIT.local/</code> from any device on your home Wi-Fi &mdash; same as at the kermés, same cert warning to click through.'
+fi
+
+mkdir -p "$(dirname "$OUT")"
+cat > "$OUT" <<HTML
+<!DOCTYPE html>
+<html lang="${HTML_LANG}">
+<head>
+<meta charset="UTF-8">
+<title>${T_TITLE}</title>
+<style>
+  @page { size: letter; margin: 0.7in; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, Arial, sans-serif;
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #111;
+    max-width: 7.1in;
+  }
+  h1 {
+    font-size: 22pt;
+    margin: 0 0 0.15in 0;
+    padding-bottom: 0.08in;
+    border-bottom: 3px solid #000;
+  }
+  h2 {
+    font-size: 15pt;
+    margin: 0.3in 0 0.08in 0;
+    padding: 0.06in 0.1in;
+    background: #f0f0f0;
+    border-left: 4px solid #444;
+    page-break-after: avoid;
+  }
+  h2 .sub { font-size: 10pt; font-weight: 400; color: #555; margin-left: 0.1in; }
+  h3 { font-size: 12pt; margin: 0.2in 0 0.05in 0; }
+  p { margin: 0 0 0.1in 0; }
+  ol, ul { margin: 0.05in 0; padding-left: 0.3in; }
+  ol li, ul li { margin-bottom: 0.08in; }
+  pre {
+    background: #f4f4f4;
+    border: 1px solid #ddd;
+    border-radius: 0.04in;
+    padding: 0.08in 0.1in;
+    margin: 0.06in 0;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 10pt;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  code {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 10.5pt;
+    background: #f4f4f4;
+    padding: 0 0.03in;
+    border-radius: 0.02in;
+  }
+  .note {
+    font-size: 10pt;
+    color: #555;
+    background: #fafafa;
+    border-left: 3px solid #bbb;
+    padding: 0.05in 0.1in;
+    margin: 0.06in 0;
+  }
+  .intro { margin-bottom: 0.15in; }
+  .divider {
+    border: none;
+    border-top: 1px dashed #aaa;
+    margin: 0.2in 0;
+  }
+  /* Keep each method on its own page if possible */
+  .section { page-break-inside: avoid; }
+  @media print { h2 { page-break-before: always; } h2:first-of-type { page-break-before: auto; } }
+</style>
+</head>
+<body>
+  <h1>${T_TITLE}</h1>
+  <p class="intro">${T_INTRO}</p>
+  <p class="intro">${T_REPLACE}</p>
+
+  <div class="section">
+    <h2>${T_M1} <span class="sub">(${T_M1_SUB})</span></h2>
+    <p>${T_M1_NEEDS}</p>
+    ${T_M1_STEPS}
+  </div>
+
+  <div class="section">
+    <h2>${T_M2} <span class="sub">(${T_M2_SUB})</span></h2>
+    <p>${T_M2_NEEDS}</p>
+    ${T_M2_STEPS}
+  </div>
+
+  <div class="section">
+    <h2>${T_M3} <span class="sub">(${T_M3_SUB})</span></h2>
+    <p>${T_M3_NEEDS}</p>
+    ${T_M3_STEPS}
+  </div>
+
+  <div class="section">
+    <h2>${T_FIND_TITLE}</h2>
+    <p>${T_FIND_INTRO}</p>
+    ${T_FIND_LIST}
+  </div>
+
+  <div class="section">
+    <h2>${T_TROUBLE_TITLE}</h2>
+    ${T_TROUBLE}
+    <p style="margin-top: 0.15in;">${T_OUTRO}</p>
+  </div>
+</body>
+</html>
+HTML
+
+echo "Wrote $OUT"
+echo "Open in a browser and Ctrl+P to print."

--- a/hardware/preinstalled/operator/scripts/generate-vendor-cards.sh
+++ b/hardware/preinstalled/operator/scripts/generate-vendor-cards.sh
@@ -1,0 +1,409 @@
+#!/bin/bash
+# Generate printable vendor cards (one per unit) from the fleet password log
+# written by wipe-and-provision.sh. Each card includes hardware setup steps,
+# a QR code for the unit's HTTPS URL, the URL in readable text, and the
+# per-unit login credentials (small print, for admin use only).
+#
+# Open the resulting HTML in a browser and print on letter paper.
+#
+# Usage: ./generate-vendor-cards.sh [options]
+#   --ssid "Name"       Wi-Fi SSID vendors should connect to (default: "the venue Wi-Fi")
+#   --wifi-password <p> Wi-Fi password. If given (along with --ssid), each card
+#                       gets a small Wi-Fi QR code that iOS 11+/Android 10+
+#                       cameras auto-recognize as a join-network prompt.
+#   --wifi-auth <type>  Wi-Fi auth type for the QR: WPA (default), WEP, or nopass.
+#   --support-url <url> Support group invite URL (e.g. Telegram t.me/+AbCd...).
+#                       Renders a small "need help?" QR on each card.
+#   --lang <code>       Card language: en (default) or es (Mexican Spanish).
+#   --log <path>        password log path (default: ~/ambrosia-fleet-passwords.txt)
+#   --out <path>        output HTML file (default: ~/ambrosia-vendor-cards.html)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+SSID="the venue Wi-Fi"
+WIFI_PASSWORD=""
+WIFI_AUTH="WPA"
+SUPPORT_URL=""
+CARD_LANG="en"
+LOG="$HOME/ambrosia-fleet-passwords.txt"
+OUT="$REPO_ROOT/out/ambrosia-vendor-cards.html"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ssid)          SSID="$2"; shift 2 ;;
+        --wifi-password) WIFI_PASSWORD="$2"; shift 2 ;;
+        --wifi-auth)     WIFI_AUTH="$2"; shift 2 ;;
+        --support-url)   SUPPORT_URL="$2"; shift 2 ;;
+        --lang)          CARD_LANG="$2"; shift 2 ;;
+        --log)           LOG="$2"; shift 2 ;;
+        --out)           OUT="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,17p' "$0" | sed 's|^# *||'
+            exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Normalize language code
+case "$CARD_LANG" in
+    es|es-mx|es-MX|es_MX|es_mx) CARD_LANG="es" ;;
+    en|en-us|en-US|en_US)       CARD_LANG="en" ;;
+    *) echo "Unknown language: $CARD_LANG (supported: en, es)" >&2; exit 1 ;;
+esac
+
+if [[ ! -r "$LOG" ]]; then
+    echo "Password log not found or unreadable: $LOG" >&2
+    exit 1
+fi
+if ! command -v qrencode >/dev/null 2>&1; then
+    echo "qrencode is required. Install with: sudo apt install -y qrencode" >&2
+    exit 1
+fi
+
+# Translations. All user-visible text is keyed here; HTML template below uses
+# the T_* variables only.
+if [[ "$CARD_LANG" == "es" ]]; then
+    T_HTML_LANG="es-MX"
+    T_TITLE="Tarjetas para vendedores — Ambrosia"
+    T_PAGE_NOTE="Imprime en papel tamaño carta. Corta por las líneas punteadas y entrega una tarjeta a cada vendedor."
+    T_PRODUCT="Ambrosia POS"
+    T_STEPS_TITLE="Pasos de configuración"
+    T_STEP_1_PRE="<b>Inserta la tarjeta microSD</b> en la ranura de la OrangePi."
+    T_STEP_2_PRE="Conecta el <b>cable de corriente USB-C</b> a la OrangePi."
+    T_STEP_3_PRE="Espera unos <b>60 segundos</b> a que encienda."
+    T_STEP_4_PRE="Conecta tu teléfono a"
+    T_STEP_4_WIFI_SUFFIX=" &mdash; <b>escanea el QR de Wi-Fi &nearr;</b>"
+    T_WIFI_TITLE="Wi-Fi"
+    T_WIFI_SCAN_HINT="Escanea para unirte al Wi-Fi (iOS 11+ / Android 10+)."
+    T_WIFI_NAME_LABEL="Red:"
+    T_WIFI_PASS_LABEL="Contraseña:"
+    T_POS_TITLE="Ambrosia POS App"
+    T_POS_HINT="Escanea para abrir la app."
+    T_SUPPORT_TITLE="Soporte"
+    T_SUPPORT_TEXT="Escanea para unirte al chat de soporte en <b>Telegram</b>."
+    T_SUPPORT_NOTE="Requiere cuenta de Telegram."
+    T_STEP_5_PRE="Abre la cámara del teléfono y <b>escanea el código QR &rarr;</b>"
+    # Step 6 (browser warning) — include the hostname inline
+    T_STEP_6_TEMPLATE='Tu navegador te advertirá que la conexión <b>"no es privada"</b>. Es esperado en una red local y <b>seguro aquí</b>. Toca <b>Avanzado</b> (o <b>Mostrar detalles</b> en Safari), luego <b>Continuar a %s.local</b> o <b>Aceptar el riesgo</b> (varía según el navegador).'
+    T_STEP_7_PRE="Crea tu <b>cuenta de administrador</b> en el asistente. <em>Anota tu contraseña.</em>"
+    T_SSH_TITLE="Acceso SSH"
+    T_SSH_SUBTITLE="(solo para uso avanzado o fuera de la kermés):"
+    T_PASSWORD_LABEL="Contraseña:"
+    T_CHANGE_PASSWORD="Cambia esta contraseña al iniciar sesión SSH por primera vez con el comando <code>passwd</code>."
+    T_TROUBLE_HEAD="¿Problemas?"
+    T_TROUBLE_BODY_TEMPLATE='Si el QR no abre, escribe la URL a mano. Si la página no carga, verifica que tu teléfono esté conectado a <b>%s</b>.'
+    T_SUPPORT_HEAD="¿Necesitas ayuda?"
+    T_SUPPORT_L1="Escanea para unirte"
+    T_SUPPORT_L2="al chat de soporte."
+else
+    T_HTML_LANG="en"
+    T_TITLE="Ambrosia vendor cards"
+    T_PAGE_NOTE="Print on letter paper. Cut along the dashed lines and hand one card to each vendor."
+    T_PRODUCT="Ambrosia POS"
+    T_STEPS_TITLE="Setup steps"
+    T_STEP_1_PRE="<b>Insert the microSD card</b> into the slot on the OrangePi."
+    T_STEP_2_PRE="Plug the <b>USB-C power cable</b> into the OrangePi."
+    T_STEP_3_PRE="Wait about <b>60 seconds</b> for it to start up."
+    T_STEP_4_PRE="Connect your phone to"
+    T_STEP_4_WIFI_SUFFIX=" &mdash; <b>scan the Wi-Fi QR &nearr;</b>"
+    T_WIFI_TITLE="Wi-Fi"
+    T_WIFI_SCAN_HINT="Scan to join the Wi-Fi (iOS 11+ / Android 10+)."
+    T_WIFI_NAME_LABEL="Network:"
+    T_WIFI_PASS_LABEL="Password:"
+    T_POS_TITLE="Ambrosia POS App"
+    T_POS_HINT="Scan to open the app."
+    T_SUPPORT_TITLE="Support"
+    T_SUPPORT_TEXT="Scan to join our <b>Telegram</b> support chat."
+    T_SUPPORT_NOTE="Requires a Telegram account."
+    T_STEP_5_PRE="Open the camera app and <b>scan the QR code &rarr;</b>"
+    T_STEP_6_TEMPLATE='Your browser will warn that the connection is <b>"Not private"</b>. This is expected on a local network and <b>safe here</b>. Tap <b>Advanced</b> (or <b>Show details</b> on Safari), then <b>Proceed to %s.local</b> / <b>Continue</b> / <b>Accept the Risk</b> (wording varies by browser).'
+    T_STEP_7_PRE="Create your <b>admin account</b> in the setup wizard. <em>Write down your password.</em>"
+    T_SSH_TITLE="SSH access"
+    T_SSH_SUBTITLE="(for advanced use or use outside of the kermés):"
+    T_PASSWORD_LABEL="Password:"
+    T_CHANGE_PASSWORD="Change this password on first SSH login by running <code>passwd</code>."
+    T_TROUBLE_HEAD="Trouble?"
+    T_TROUBLE_BODY_TEMPLATE='If the QR doesn&rsquo;t open, type the URL by hand. If the page won&rsquo;t load, make sure your phone is on <b>%s</b>.'
+    T_SUPPORT_HEAD="Need help?"
+    T_SUPPORT_L1="Scan to join our"
+    T_SUPPORT_L2="support chat."
+fi
+
+# HTML-escape a string so it can be safely interpolated into element bodies
+html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    s="${s//\"/&quot;}"
+    printf '%s' "$s"
+}
+
+SSID_HTML=$(html_escape "$SSID")
+
+# Escape a string for embedding inside the WIFI: URI. The spec requires
+# backslash-escaping the five special chars : ; , " \.
+wifi_uri_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//:/\\:}"
+    s="${s//;/\\;}"
+    s="${s//,/\\,}"
+    printf '%s' "$s"
+}
+
+# Pre-render the Wi-Fi QR (one-shot, identical on every card).
+# Shape: WIFI:T:<auth>;S:<ssid>;P:<pass>;;
+WIFI_BLOCK=""
+if [[ -z "$WIFI_PASSWORD" ]]; then
+    # No Wi-Fi QR -> no arrow suffix pointing at a non-existent block
+    T_STEP_4_WIFI_SUFFIX=""
+fi
+if [[ -n "$WIFI_PASSWORD" ]]; then
+    WIFI_AUTH_UP=$(echo "$WIFI_AUTH" | tr '[:lower:]' '[:upper:]')
+    case "$WIFI_AUTH_UP" in WPA|WPA2|WPA3) WIFI_AUTH_UP="WPA" ;; WEP) ;; NOPASS|NONE) WIFI_AUTH_UP="nopass" ;; esac
+    WIFI_URI="WIFI:T:${WIFI_AUTH_UP};S:$(wifi_uri_escape "$SSID");P:$(wifi_uri_escape "$WIFI_PASSWORD");;"
+    WIFI_QR=$(qrencode -t SVG -m 0 -s 3 -o - "$WIFI_URI" | sed -n '/<svg/,/<\/svg>/p')
+    WIFI_PASS_HTML=$(html_escape "$WIFI_PASSWORD")
+    # Inline block rendered inside step 4
+    WIFI_INLINE=$(cat <<WIFI
+          <div class="qr-box wifi-block">
+            <div class="qr-box-title">${T_WIFI_TITLE}</div>
+            <div class="wifi-inner">
+              <div class="wifi-qr">${WIFI_QR}</div>
+              <div class="wifi-text">
+                <div>${T_WIFI_NAME_LABEL} <b>${SSID_HTML}</b></div>
+                <div>${T_WIFI_PASS_LABEL} <code>${WIFI_PASS_HTML}</code></div>
+                <div class="wifi-hint">${T_WIFI_SCAN_HINT}</div>
+              </div>
+            </div>
+          </div>
+WIFI
+)
+fi
+
+# Pre-render the support QR once (same on every card)
+SUPPORT_BLOCK=""
+if [[ -n "$SUPPORT_URL" ]]; then
+    SUPPORT_QR=$(qrencode -t SVG -m 0 -s 3 -o - "$SUPPORT_URL" | sed -n '/<svg/,/<\/svg>/p')
+    SUPPORT_URL_HTML=$(html_escape "$SUPPORT_URL")
+    SUPPORT_BLOCK=$(cat <<SUPPORT
+    <div class="qr-box support-block">
+      <div class="qr-box-title">${T_SUPPORT_TITLE}</div>
+      <div class="support-inner">
+        <div class="support-qr">${SUPPORT_QR}</div>
+        <div class="support-text">
+          <div>${T_SUPPORT_TEXT}</div>
+          <div class="support-url">${SUPPORT_URL_HTML}</div>
+          <div class="support-note">${T_SUPPORT_NOTE}</div>
+        </div>
+      </div>
+    </div>
+SUPPORT
+)
+fi
+
+mkdir -p "$(dirname "$OUT")"
+{
+cat <<HTML_HEAD
+<!DOCTYPE html>
+<html lang="${T_HTML_LANG}">
+<head>
+<meta charset="UTF-8">
+<title>${T_TITLE}</title>
+<style>
+  @page { size: letter; margin: 0.4in; }
+  body { font-family: -apple-system, Arial, sans-serif; margin: 0; color: #111; }
+  .page-note { font-size: 9pt; color: #888; margin: 0 0 0.15in 0; }
+  .card {
+    width: 7.7in;
+    margin: 0 0 0.15in 0;
+    padding: 0.25in 0.3in;
+    border: 2px dashed #888;
+    border-radius: 0.1in;
+    box-sizing: border-box;
+    page-break-inside: avoid;
+    display: flex;
+    flex-direction: column;
+  }
+  .header {
+    display: flex;
+    align-items: baseline;
+    border-bottom: 2px solid #000;
+    padding-bottom: 0.06in;
+    margin-bottom: 0.15in;
+  }
+  .header .name { font-size: 22pt; font-weight: 700; }
+  .header .product { margin-left: auto; font-size: 11pt; color: #555; }
+  .body {
+    display: flex;
+    flex: 1;
+    gap: 0.35in;
+  }
+  .left { flex: 1.3; display: flex; flex-direction: column; min-width: 0; }
+  .right {
+    width: 2.6in;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .steps-title { font-size: 11pt; font-weight: 700; margin-bottom: 0.04in; }
+  ol.steps {
+    margin: 0;
+    padding-left: 0.25in;
+    font-size: 11pt;
+    line-height: 1.4;
+  }
+  ol.steps li { margin-bottom: 0.03in; }
+  ol.steps b { font-weight: 700; }
+  /* Shared look for every QR-containing box */
+  .qr-box {
+    display: flex;
+    flex-direction: column;
+    padding: 0.06in 0.1in;
+    background: #f4f4f4;
+    border-radius: 0.05in;
+    box-sizing: border-box;
+  }
+  .qr-box-title {
+    font-size: 9pt;
+    font-weight: 700;
+    text-align: center;
+    color: #333;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 0.03in;
+    margin-bottom: 0.05in;
+  }
+  /* Wi-Fi block (row layout: QR + SSID/password) */
+  .wifi-block { width: 2.5in; margin-bottom: 0.08in; }
+  .wifi-inner { display: flex; align-items: center; gap: 0.1in; }
+  .wifi-qr svg { width: 0.7in; height: 0.7in; display: block; }
+  .wifi-text { font-size: 8.5pt; line-height: 1.3; }
+  .wifi-text code { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 8pt; }
+  .wifi-text .wifi-hint { font-size: 7pt; color: #666; margin-top: 0.02in; }
+  /* Main POS block (column layout: big QR + URL) */
+  .pos-block { width: 2.5in; align-items: center; margin-bottom: 0.1in; }
+  .pos-block .qr { margin-top: 0.02in; }
+  .pos-block .qr svg { width: 1.8in; height: 1.8in; display: block; }
+  .pos-block .url {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 9.5pt;
+    text-align: center;
+    white-space: nowrap;
+    margin-top: 0.06in;
+  }
+  .pos-block .qr-hint { font-size: 7pt; color: #666; text-align: center; margin-top: 0.02in; }
+  .footer {
+    margin-top: auto;
+    display: grid;
+    grid-template-columns: 2.5in 1fr 2.5in;
+    gap: 0.15in;
+    font-size: 8pt;
+    color: #555;
+    border-top: 1px solid #ccc;
+    padding-top: 0.12in;
+    line-height: 1.3;
+  }
+  /* Plain-text columns get a matching top pad so their first line sits on
+     the same baseline as the boxed support column's first line (title). */
+  .footer .admin,
+  .footer .help { padding-top: 0.06in; }
+  .footer .admin { min-width: 0; overflow: hidden; }
+  .footer .admin .lbl { color: #888; }
+  .footer .admin code,
+  .footer .admin .val {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    color: #111;
+    font-size: 7pt;
+    white-space: nowrap;
+  }
+  .footer .help { min-width: 0; }
+  /* Support block (row layout: small QR + text). Fixed width so it aligns
+     with the main POS QR box above it. */
+  .support-block { align-self: flex-start; width: 2.5in; box-sizing: border-box; }
+  .support-inner { display: flex; align-items: center; gap: 0.1in; }
+  .support-qr svg { width: 0.85in; height: 0.85in; display: block; }
+  .support-text { font-size: 8pt; line-height: 1.3; color: #111; min-width: 0; }
+  .support-url {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 7pt;
+    color: #333;
+    word-break: break-all;
+    margin-top: 0.03in;
+  }
+  .support-note { font-size: 7pt; color: #666; margin-top: 0.03in; }
+  @media print { .page-note { display: none; } }
+</style>
+</head>
+<body>
+<p class="page-note">${T_PAGE_NOTE}</p>
+HTML_HEAD
+
+while read -r NAME PASSWORD; do
+    [[ -z "$NAME" || "$NAME" =~ ^# ]] && continue
+    URL="https://${NAME}.local/"
+    NAME_H=$(html_escape "$NAME")
+    PW_H=$(html_escape "$PASSWORD")
+    URL_H=$(html_escape "$URL")
+    QR_SVG=$(qrencode -t SVG -m 0 -s 4 -o - "$URL" | sed -n '/<svg/,/<\/svg>/p')
+    # Interpolate per-card hostname into the browser-warning step and the
+    # trouble paragraph (keeps translations centralized above).
+    STEP_6_TEXT=$(printf "$T_STEP_6_TEMPLATE" "$NAME_H")
+    TROUBLE_TEXT=$(printf "$T_TROUBLE_BODY_TEMPLATE" "$SSID_HTML")
+    cat <<HTML_CARD
+<div class="card">
+  <div class="header">
+    <div class="name">${NAME_H}</div>
+    <div class="product">${T_PRODUCT}</div>
+  </div>
+  <div class="body">
+    <div class="left">
+      <div class="steps-title">${T_STEPS_TITLE}</div>
+      <ol class="steps">
+        <li>${T_STEP_1_PRE}</li>
+        <li>${T_STEP_2_PRE}</li>
+        <li>${T_STEP_3_PRE}</li>
+        <li>${T_STEP_4_PRE} <b>${SSID_HTML}</b>${T_STEP_4_WIFI_SUFFIX}</li>
+        <li>${T_STEP_5_PRE}</li>
+        <li>${STEP_6_TEXT}</li>
+        <li>${T_STEP_7_PRE}</li>
+      </ol>
+    </div>
+    <div class="right">
+${WIFI_INLINE}
+      <div class="qr-box pos-block">
+        <div class="qr-box-title">${T_POS_TITLE}</div>
+        <div class="qr">${QR_SVG}</div>
+        <div class="url">${URL_H}</div>
+      </div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="admin">
+      <div><span class="lbl"><b>${T_SSH_TITLE}</b> ${T_SSH_SUBTITLE}</span></div>
+      <div><code>ssh ${NAME_H}@${NAME_H}.local</code></div>
+      <div><span class="lbl">${T_PASSWORD_LABEL}</span> <span class="val">${PW_H}</span></div>
+      <div class="lbl">${T_CHANGE_PASSWORD}</div>
+    </div>
+    <div class="help">
+      <b>${T_TROUBLE_HEAD}</b> ${TROUBLE_TEXT}
+    </div>
+${SUPPORT_BLOCK}
+  </div>
+</div>
+HTML_CARD
+done < <(sort -V -k1,1 "$LOG")
+
+cat <<'HTML_TAIL'
+</body>
+</html>
+HTML_TAIL
+} > "$OUT"
+
+echo "Wrote $(grep -c '<div class="card"' "$OUT") card(s) to $OUT"
+echo "Wi-Fi SSID baked into cards: $SSID"
+echo "Open in a browser and Ctrl+P to print."

--- a/hardware/preinstalled/operator/scripts/prep-opi-as-golden.sh
+++ b/hardware/preinstalled/operator/scripts/prep-opi-as-golden.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Prep an already-configured OrangePi clone (e.g. opi-2 with Caddy installed)
+# as a new golden image source. Run on your laptop against the mounted SD card.
+# After this finishes, `dd` the card to a new .img.gz.
+#
+# What it does:
+#   - Renames user/home/hostname/service files/Caddyfile from OLD -> NEW
+#   - Wipes runtime state (seed.dat, DBs, keystore, uploads, Caddy CA+certs)
+#   - Leaves stub configs (phoenix.conf, ambrosia.conf) in place
+#   - Wipes SSH host keys, machine-id, bash history, journal
+#   - Resets password to match NEW name
+#
+# Usage: sudo ./prep-opi-as-golden.sh [old-name] [new-name] [device]
+# Defaults: old=ambrosia-opi-2, new=ambrosia-opi-1, device=/dev/sda
+
+set -euo pipefail
+
+OLD="${1:-ambrosia-opi-2}"
+NEW="${2:-ambrosia-opi-1}"
+DEV="${3:-/dev/sda}"
+PART="${DEV}1"
+MNT=/mnt/opi-golden-prep
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Must run as root (try: sudo $0 $OLD $NEW $DEV)" >&2
+    exit 1
+fi
+
+if [[ ! -b "$PART" ]]; then
+    echo "Partition $PART not found. Is the card inserted and is $DEV correct?" >&2
+    exit 1
+fi
+
+echo "==> Unmounting any auto-mounted partitions on $DEV"
+umount "${DEV}"* 2>/dev/null || true
+
+echo "==> Mounting $PART at $MNT"
+mkdir -p "$MNT"
+mount "$PART" "$MNT"
+
+cleanup() {
+    echo "==> Unmounting $MNT"
+    umount "$MNT" || true
+}
+trap cleanup EXIT
+
+if ! grep -q "^${OLD}:" "$MNT/etc/passwd"; then
+    echo "ERROR: user '${OLD}' not found in $MNT/etc/passwd" >&2
+    echo "Check that you passed the right OLD name. Found these users:" >&2
+    awk -F: '$3 >= 1000 {print "  " $1}' "$MNT/etc/passwd" >&2
+    exit 1
+fi
+
+if grep -q "^${NEW}:" "$MNT/etc/passwd"; then
+    echo "ERROR: user '${NEW}' already exists. Was this already un-renamed?" >&2
+    exit 1
+fi
+
+HOME_OLD="$MNT/home/${OLD}"
+HOME_NEW="$MNT/home/${NEW}"
+
+echo "==> Renaming $OLD -> $NEW"
+
+echo "    [1/9] Hostname and /etc/hosts"
+echo "$NEW" > "$MNT/etc/hostname"
+sed -i "s/\b${OLD}\b/${NEW}/g" "$MNT/etc/hosts"
+
+echo "    [2/9] User identity (passwd, shadow, group, gshadow)"
+sed -i "s/\b${OLD}\b/${NEW}/g" \
+    "$MNT/etc/passwd" \
+    "$MNT/etc/shadow" \
+    "$MNT/etc/group" \
+    "$MNT/etc/gshadow"
+
+echo "    [3/9] Home directory"
+mv "$HOME_OLD" "$HOME_NEW"
+# Wipe per-user SSH state so the golden doesn't ship authorized_keys to every
+# clone (would let the golden's setter SSH into every vendor's unit).
+rm -rf "$HOME_NEW/.ssh"
+# Defensive: prune any orphan /home/ambrosia-opi-* dirs left from earlier
+# rename rounds. Should be a no-op on a clean source.
+for d in "$MNT"/home/ambrosia-opi-*; do
+    [[ -d "$d" ]] || continue
+    base=$(basename "$d")
+    if [[ "$base" != "$NEW" ]]; then
+        echo "        pruning orphan home: $base"
+        rm -rf "$d"
+    fi
+done
+
+echo "    [4/9] Systemd service files"
+for svc in phoenixd ambrosia ambrosia-client; do
+    f="$MNT/etc/systemd/system/${svc}.service"
+    if [[ -f "$f" ]]; then
+        sed -i "s/\b${OLD}\b/${NEW}/g" "$f"
+    fi
+done
+
+echo "    [5/9] Caddyfile"
+if [[ -f "$MNT/etc/caddy/Caddyfile" ]]; then
+    sed -i "s/\b${OLD}\b/${NEW}/g" "$MNT/etc/caddy/Caddyfile"
+else
+    echo "    WARNING: no /etc/caddy/Caddyfile found — is Caddy installed on this card?"
+fi
+
+echo "    [6/9] Wipe datadirs and reset stub configs"
+# Full wipe of phoenixd + Ambrosia dirs. This also clears any per-unit secrets
+# that the services appended to the conf files during first boot
+# (e.g. http-password, webhook-secret, Ambrosia 'secret' seed phrase).
+rm -rf "$HOME_NEW/.phoenix" "$HOME_NEW/.Ambrosia-POS"
+mkdir -p "$HOME_NEW/.phoenix" "$HOME_NEW/.Ambrosia-POS"
+cat > "$HOME_NEW/.phoenix/phoenix.conf" <<'PHX_EOF'
+auto-liquidity=off
+max-mining-fee=5000
+PHX_EOF
+cat > "$HOME_NEW/.Ambrosia-POS/ambrosia.conf" <<'AMB_EOF'
+http-bind-ip=0.0.0.0
+http-bind-port=9154
+AMB_EOF
+chown -R 1001:1001 "$HOME_NEW/.phoenix" "$HOME_NEW/.Ambrosia-POS"
+# Caddy state (CA + certs — each clone will regen its own)
+rm -rf "$MNT"/var/lib/caddy/.local/share/caddy/* 2>/dev/null || true
+rm -f "$MNT"/var/lib/caddy/.config/caddy/autosave.json 2>/dev/null || true
+
+echo "    [7/9] SSH host keys, machine-id"
+rm -f "$MNT"/etc/ssh/ssh_host_*
+: > "$MNT/etc/machine-id"
+rm -f "$MNT/var/lib/dbus/machine-id"
+ln -s /etc/machine-id "$MNT/var/lib/dbus/machine-id"
+
+echo "    [8/9] Bash history and journal"
+rm -f "$HOME_NEW/.bash_history"
+rm -rf "$MNT/var/log/journal"/* 2>/dev/null || true
+
+echo "    [9/9] Password (set to username: ${NEW})"
+NEW_HASH=$(openssl passwd -6 "$NEW")
+sed -i "s|^${NEW}:[^:]*:|${NEW}:${NEW_HASH}:|" "$MNT/etc/shadow"
+
+echo "==> Verifying"
+grep "^${NEW}:" "$MNT/etc/passwd" | sed 's/:[^:]*:/:x:/' | sed 's/^/    /'
+echo "    --- stub configs preserved? ---"
+[[ -f "$HOME_NEW/.phoenix/phoenix.conf" ]] && echo "    .phoenix/phoenix.conf:" && sed 's/^/      /' "$HOME_NEW/.phoenix/phoenix.conf"
+[[ -f "$HOME_NEW/.Ambrosia-POS/ambrosia.conf" ]] && echo "    .Ambrosia-POS/ambrosia.conf:" && sed 's/^/      /' "$HOME_NEW/.Ambrosia-POS/ambrosia.conf"
+echo "    --- Caddyfile ---"
+[[ -f "$MNT/etc/caddy/Caddyfile" ]] && sed 's/^/      /' "$MNT/etc/caddy/Caddyfile"
+echo "    --- runtime files that should be GONE ---"
+for p in "$HOME_NEW/.phoenix/seed.dat" "$HOME_NEW/.Ambrosia-POS/ambrosia.db" "$HOME_NEW/.Ambrosia-POS/keystore.jks"; do
+    [[ -e "$p" ]] && echo "      STILL THERE: $p" || echo "      gone: $p"
+done
+echo "    --- Caddy state (should be empty) ---"
+ls -A "$MNT/var/lib/caddy/.local/share/caddy/" 2>/dev/null | sed 's/^/      /' || echo "      (empty)"
+
+echo
+echo "==> Done. Card is ready to be imaged as the new golden."
+echo "    Next: sudo dd if=$DEV bs=4M status=progress | gzip -c > ~/ambrosia-golden-vN-\$(date +%Y%m%d).img.gz"
+echo "          (bump vN each time you re-bake; see clone-fleet.md)"

--- a/hardware/preinstalled/operator/scripts/stubify-golden.sh
+++ b/hardware/preinstalled/operator/scripts/stubify-golden.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Bake phoenixd + Ambrosia stub configs into an existing golden image, so fresh
+# clones boot with LAN-reachable HTTP + disabled auto-liquidity out of the box.
+#
+# Produces a new *-stubbed.img.gz next to the input, leaving the original untouched.
+#
+# Usage: sudo ./stubify-golden.sh <path-to-golden.img.gz>
+# Example: sudo ./stubify-golden.sh ~/ambrosia-golden-20260421.img.gz
+
+set -euo pipefail
+
+SRC="${1:-}"
+if [[ -z "$SRC" ]]; then
+    echo "Usage: sudo $0 <path-to-golden.img.gz>" >&2
+    exit 1
+fi
+if [[ $EUID -ne 0 ]]; then
+    echo "Must run as root (try: sudo $0 $SRC)" >&2
+    exit 1
+fi
+if [[ ! -f "$SRC" ]]; then
+    echo "Not a file: $SRC" >&2
+    exit 1
+fi
+
+# Derive output path: foo.img.gz -> foo-stubbed.img.gz
+DIR=$(dirname "$SRC")
+BASE=$(basename "$SRC" .img.gz)
+WORK_IMG="$DIR/${BASE}-stubbed.img"
+OUT_GZ="$DIR/${BASE}-stubbed.img.gz"
+
+if [[ -e "$WORK_IMG" || -e "$OUT_GZ" ]]; then
+    echo "Output file already exists: $WORK_IMG or $OUT_GZ" >&2
+    echo "Remove it first if you want to regenerate." >&2
+    exit 1
+fi
+
+MNT=/mnt/golden-stubify
+LOOPDEV=""
+
+cleanup() {
+    set +e
+    if mountpoint -q "$MNT"; then umount "$MNT"; fi
+    if [[ -n "$LOOPDEV" ]] && losetup "$LOOPDEV" >/dev/null 2>&1; then
+        losetup -d "$LOOPDEV"
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Decompressing $SRC -> $WORK_IMG"
+gunzip -c "$SRC" > "$WORK_IMG"
+
+echo "==> Attaching loop device"
+LOOPDEV=$(losetup -f -P --show "$WORK_IMG")
+echo "    $LOOPDEV (partition: ${LOOPDEV}p1)"
+
+echo "==> Mounting ${LOOPDEV}p1 at $MNT"
+mkdir -p "$MNT"
+mount "${LOOPDEV}p1" "$MNT"
+
+USERHOME="$MNT/home/ambrosia-opi-1"
+if [[ ! -d "$USERHOME" ]]; then
+    echo "ERROR: expected $USERHOME in the image. Is this a fresh OrangePi golden?" >&2
+    exit 1
+fi
+
+echo "==> Writing stub configs"
+rm -rf "$USERHOME/.phoenix" "$USERHOME/.Ambrosia-POS"
+mkdir -p "$USERHOME/.phoenix" "$USERHOME/.Ambrosia-POS"
+
+cat > "$USERHOME/.phoenix/phoenix.conf" <<'PHX_EOF'
+auto-liquidity=off
+max-mining-fee=5000
+PHX_EOF
+
+cat > "$USERHOME/.Ambrosia-POS/ambrosia.conf" <<'AMB_EOF'
+http-bind-ip=0.0.0.0
+http-bind-port=9154
+AMB_EOF
+
+chown -R 1001:1001 "$USERHOME/.phoenix" "$USERHOME/.Ambrosia-POS"
+
+echo "==> Verifying"
+ls -la "$USERHOME/.phoenix" "$USERHOME/.Ambrosia-POS" | sed 's/^/    /'
+echo "    --- phoenix.conf ---"
+cat "$USERHOME/.phoenix/phoenix.conf" | sed 's/^/    /'
+echo "    --- ambrosia.conf ---"
+cat "$USERHOME/.Ambrosia-POS/ambrosia.conf" | sed 's/^/    /'
+
+echo "==> Unmounting and detaching"
+umount "$MNT"
+losetup -d "$LOOPDEV"
+LOOPDEV=""
+
+echo "==> Recompressing -> $OUT_GZ"
+gzip "$WORK_IMG"
+# gzip replaces $WORK_IMG with $WORK_IMG.gz, which matches $OUT_GZ
+
+ls -lh "$SRC" "$OUT_GZ" | sed 's/^/    /'
+
+echo
+echo "==> Done."
+echo "    Original (untouched): $SRC"
+echo "    Stubbed golden:       $OUT_GZ"
+echo "    Flash future clones from the stubbed image."

--- a/hardware/preinstalled/operator/scripts/wipe-and-provision.sh
+++ b/hardware/preinstalled/operator/scripts/wipe-and-provision.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Wipe all per-unit state on an Ambrosia OrangePi clone and provision it
+# with a new identity. Destructive — erases .phoenix (wallet seed, channel
+# DB), .Ambrosia-POS (admin DB, keystore, uploads), Caddy PKI, SSH host
+# keys, machine-id, and bash history; then renames user/hostname/service
+# files/Caddyfile to the new name, regenerates SSH host keys, writes stub
+# configs, and resets the password to the new name.
+#
+# Safe to run on a freshly-flashed golden card (first assignment) and also
+# on a card that was booted once for verification (re-assignment). If
+# <new-name> equals the current name, acts as a reset-in-place.
+#
+# Run on your laptop against the mounted SD card, NOT on the OrangePi.
+#
+# Usage: sudo ./wipe-and-provision.sh <new-name> [device] [old-name]
+#   <new-name>  e.g. ambrosia-opi-2
+#   [device]    block device holding the clone (default: /dev/sda)
+#   [old-name]  current user/hostname on the card. Default: auto-detect from
+#               UID 1001 in the mounted /etc/passwd. Pass this explicitly
+#               only if the card has multiple non-system users.
+#
+# Env vars:
+#   NEW_PASSWORD  If set, used as the unit password instead of generating a
+#                 random one. Useful for re-provisioning a card with its
+#                 previous password. sudo strips env by default — pass it
+#                 with `sudo -E` or inline: `sudo NEW_PASSWORD=... ./...`
+
+set -euo pipefail
+
+NEW="${1:-}"
+DEV="${2:-/dev/sda}"
+OLD_OVERRIDE="${3:-}"
+PART="${DEV}1"
+MNT=/mnt/opi-wipe-and-provision
+
+if [[ -z "$NEW" ]]; then
+    echo "Usage: sudo $0 <new-name> [device] [old-name]" >&2
+    echo "Example: sudo $0 ambrosia-opi-2 /dev/sda" >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Must run as root (try: sudo $0 $NEW $DEV)" >&2
+    exit 1
+fi
+
+if [[ ! -b "$PART" ]]; then
+    echo "Partition $PART not found. Is the card inserted and is $DEV correct?" >&2
+    exit 1
+fi
+
+echo "==> Unmounting any auto-mounted partitions on $DEV"
+umount "${DEV}"* 2>/dev/null || true
+
+echo "==> Mounting $PART at $MNT"
+mkdir -p "$MNT"
+mount "$PART" "$MNT"
+
+# Auto-detect the current non-system user (UID 1001) unless overridden
+if [[ -n "$OLD_OVERRIDE" ]]; then
+    OLD="$OLD_OVERRIDE"
+else
+    OLD=$(awk -F: '$3 == 1001 {print $1; exit}' "$MNT/etc/passwd" || true)
+fi
+
+if [[ -z "$OLD" ]]; then
+    echo "ERROR: could not find a UID-1001 user on $PART to rename." >&2
+    umount "$MNT" || true
+    exit 1
+fi
+echo "==> Detected current user: $OLD"
+
+if [[ "$NEW" == "$OLD" ]]; then
+    echo "==> Same name — running as reset-in-place (steps 1-4 are no-ops; steps 5-7 will wipe boot state)"
+fi
+
+cleanup() {
+    echo "==> Unmounting $MNT"
+    umount "$MNT" || true
+}
+trap cleanup EXIT
+
+# Sanity check: the old user must actually be on this card
+if ! grep -q "^${OLD}:" "$MNT/etc/passwd"; then
+    echo "ERROR: user '${OLD}' not found in $MNT/etc/passwd" >&2
+    echo "This card doesn't look like a fresh Ambrosia clone. Aborting." >&2
+    exit 1
+fi
+
+if [[ "$NEW" != "$OLD" ]] && grep -q "^${NEW}:" "$MNT/etc/passwd"; then
+    echo "ERROR: user '${NEW}' already exists in $MNT/etc/passwd" >&2
+    echo "Was this clone already renamed? Aborting." >&2
+    exit 1
+fi
+
+echo "==> Renaming: $OLD -> $NEW"
+
+echo "    [1/7] Hostname and /etc/hosts"
+echo "$NEW" > "$MNT/etc/hostname"
+sed -i "s/\b${OLD}\b/${NEW}/g" "$MNT/etc/hosts"
+
+echo "    [2/7] User identity (passwd, shadow, group, gshadow)"
+sed -i "s/\b${OLD}\b/${NEW}/g" \
+    "$MNT/etc/passwd" \
+    "$MNT/etc/shadow" \
+    "$MNT/etc/group" \
+    "$MNT/etc/gshadow"
+
+echo "    [3/7] Home directory"
+if [[ "$OLD" != "$NEW" ]]; then
+    mv "$MNT/home/${OLD}" "$MNT/home/${NEW}"
+fi
+# Wipe per-user SSH state — authorized_keys carried over from the golden
+# would let whoever set up the golden SSH into every vendor's unit. Same
+# for known_hosts.
+rm -rf "$MNT/home/${NEW}/.ssh"
+# Defensive: prune any orphan /home/ambrosia-opi-* dirs left from a sloppy
+# golden bake (e.g. SSH key still in some old user's home from before the
+# golden was prepped). Should be a no-op on a properly-prepped golden.
+for d in "$MNT"/home/ambrosia-opi-*; do
+    [[ -d "$d" ]] || continue
+    base=$(basename "$d")
+    if [[ "$base" != "$NEW" ]]; then
+        echo "        pruning orphan home: $base"
+        rm -rf "$d"
+    fi
+done
+
+echo "    [4/7] Systemd service files + Caddyfile"
+for svc in phoenixd ambrosia ambrosia-client; do
+    f="$MNT/etc/systemd/system/${svc}.service"
+    if [[ -f "$f" ]]; then
+        sed -i "s/\b${OLD}\b/${NEW}/g" "$f"
+    fi
+done
+if [[ -f "$MNT/etc/caddy/Caddyfile" ]]; then
+    sed -i "s/\b${OLD}\b/${NEW}/g" "$MNT/etc/caddy/Caddyfile"
+fi
+
+echo "    [5/7] Fresh SSH host keys (unique per clone)"
+rm -f "$MNT/etc/ssh/ssh_host_"*
+ssh-keygen -q -t rsa     -b 4096 -N '' -f "$MNT/etc/ssh/ssh_host_rsa_key"
+ssh-keygen -q -t ecdsa           -N '' -f "$MNT/etc/ssh/ssh_host_ecdsa_key"
+ssh-keygen -q -t ed25519         -N '' -f "$MNT/etc/ssh/ssh_host_ed25519_key"
+
+if [[ -n "${NEW_PASSWORD:-}" ]]; then
+    echo "    [6/7] Password (from \$NEW_PASSWORD env var)"
+else
+    echo "    [6/7] Password (random, 12 chars, no confusable glyphs)"
+    # Avoid visually-confusable characters: 0/O, 1/l/I, no mixed case to
+    # ease transcription to a paper card for the vendor.
+    # Read a finite chunk of urandom (~256 bytes >> 12 chars after filtering)
+    # so the pipeline doesn't SIGPIPE under set -o pipefail.
+    NEW_PASSWORD=$(head -c 256 /dev/urandom | LC_ALL=C tr -dc 'abcdefghjkmnpqrstuvwxyz23456789' | head -c 12)
+fi
+NEW_HASH=$(openssl passwd -6 "$NEW_PASSWORD")
+sed -i "s|^${NEW}:[^:]*:|${NEW}:${NEW_HASH}:|" "$MNT/etc/shadow"
+
+# Append to a per-laptop log so you keep a record across runs. When run via
+# sudo, write to the invoking user's home, not /root.
+if [[ -n "${SUDO_USER:-}" ]]; then
+    LOG_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+else
+    LOG_HOME="$HOME"
+fi
+PASSWORD_LOG="${LOG_HOME}/ambrosia-fleet-passwords.txt"
+# Replace any existing entry for this unit so re-provisioning overwrites
+# rather than accumulates duplicates.
+if [[ -f "$PASSWORD_LOG" ]]; then
+    sed -i "/^${NEW}[[:space:]]/d" "$PASSWORD_LOG"
+fi
+printf '%-24s  %s\n' "$NEW" "$NEW_PASSWORD" >> "$PASSWORD_LOG"
+if [[ -n "${SUDO_USER:-}" ]]; then
+    chown "$SUDO_USER:$SUDO_USER" "$PASSWORD_LOG" 2>/dev/null || true
+fi
+chmod 600 "$PASSWORD_LOG" 2>/dev/null || true
+
+echo "    [7/7] Stub configs + Caddy state reset"
+# Clear any residue (e.g. from an aborted first boot that started services)
+# and write the minimal configs the services need on first startup.
+rm -rf "$MNT/home/${NEW}/.phoenix" "$MNT/home/${NEW}/.Ambrosia-POS"
+mkdir -p "$MNT/home/${NEW}/.phoenix" "$MNT/home/${NEW}/.Ambrosia-POS"
+cat > "$MNT/home/${NEW}/.phoenix/phoenix.conf" <<'PHX_EOF'
+auto-liquidity=off
+max-mining-fee=5000
+PHX_EOF
+cat > "$MNT/home/${NEW}/.Ambrosia-POS/ambrosia.conf" <<'AMB_EOF'
+http-bind-ip=0.0.0.0
+http-bind-port=9154
+AMB_EOF
+chown -R 1001:1001 "$MNT/home/${NEW}/.phoenix" "$MNT/home/${NEW}/.Ambrosia-POS"
+# Wipe any Caddy CA + cert storage carried over from the golden so this clone
+# generates its own on first boot (independent per-unit PKI).
+rm -rf "$MNT"/var/lib/caddy/.local/share/caddy/* 2>/dev/null || true
+rm -f "$MNT"/var/lib/caddy/.config/caddy/autosave.json 2>/dev/null || true
+
+echo "==> Verifying"
+grep "^${NEW}:" "$MNT/etc/passwd" | sed 's/:[^:]*:/:x:/'
+ls "$MNT/etc/ssh/" | grep ssh_host_ | sed 's/^/    /'
+ls -d "$MNT/home/${NEW}" | sed 's/^/    /'
+ls "$MNT/home/${NEW}/.phoenix/" "$MNT/home/${NEW}/.Ambrosia-POS/" | sed 's/^/    /'
+if [[ -f "$MNT/etc/caddy/Caddyfile" ]]; then
+    echo "    Caddyfile host line: $(grep -E "^${NEW}\.local" "$MNT/etc/caddy/Caddyfile" || echo 'MISSING!')"
+fi
+
+echo
+echo "==> Done. Clone provisioned as: $NEW"
+echo
+echo "    ┌────────────────────────────────────────────────────────┐"
+printf  "    │  Login:     ssh %-37s  │\n" "${NEW}@${NEW}.local"
+printf  "    │  Password:  %-41s  │\n" "$NEW_PASSWORD"
+echo    "    └────────────────────────────────────────────────────────┘"
+echo
+echo "    Password also logged to: $PASSWORD_LOG"
+echo "    ** Tell the vendor to run 'passwd' on first login to change it. **"
+echo "    Safe to eject $DEV and boot the OrangePi."

--- a/hardware/preinstalled/portal/README.md
+++ b/hardware/preinstalled/portal/README.md
@@ -1,0 +1,23 @@
+# Wi-Fi captive portal
+
+A first-boot Wi-Fi setup flow for preinstalled Ambrosia units. When a unit boots and can't reach a known Wi-Fi network, the portal brings up its own hotspot, serves a captive page that lists nearby SSIDs, and lets the buyer pick one and enter the password from their phone. Once the unit successfully joins the chosen network, the portal exits and Caddy is started so the POS becomes reachable.
+
+## Files
+
+- `ambrosia-wifi-portal` — the Python application. Flask + NetworkManager (via `nmcli`) on port 80. SSID scanning happens before AP mode is raised so the list is current.
+- `ambrosia-wifi-portal.service` — the systemd unit. `ExecStopPost=systemctl start caddy` ensures the POS comes up after the portal exits.
+
+## Install on a unit
+
+```sh
+sudo install -m 0755 ambrosia-wifi-portal /usr/local/bin/ambrosia-wifi-portal
+sudo install -m 0644 ambrosia-wifi-portal.service /etc/systemd/system/ambrosia-wifi-portal.service
+sudo systemctl daemon-reload
+sudo systemctl enable ambrosia-wifi-portal.service
+```
+
+The provisioning scripts in [`../operator/scripts/`](../operator/scripts/) install this automatically as part of the golden-image bake.
+
+## Show-password toggle
+
+The captive portal page includes a show/hide toggle on the password field — keyboards on small phones plus complex Wi-Fi passwords benefit from being able to see what was typed.

--- a/hardware/preinstalled/portal/ambrosia-wifi-portal
+++ b/hardware/preinstalled/portal/ambrosia-wifi-portal
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""
+Ambrosia Wi-Fi setup portal.
+
+Runs at boot. Waits briefly for NetworkManager to auto-connect to a known
+Wi-Fi. If none is found, takes wlan0 out of NM management, brings up hostapd
+(AP) and dnsmasq (DHCP) directly, and serves a Flask captive portal on port 80
+where the user types an SSID + password. On successful connection we tear down
+hostapd/dnsmasq, hand wlan0 back to NM, and exit; systemd treats clean exit
+as success and won't restart us.
+
+Uses hostapd directly because NetworkManager's built-in AP mode relies on
+wpa_supplicant, which doesn't work reliably on the Orange Pi Zero 2W's Wi-Fi
+driver (wpa_supplicant times out after 30s trying to start AP mode).
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from flask import Flask, redirect, render_template_string, request
+
+WLAN = "wlan0"
+AP_IP = "10.42.1.1"
+AP_SUBNET = "10.42.1.0/24"
+DHCP_START = "10.42.1.100"
+DHCP_END = "10.42.1.150"
+HOSTAPD_CONF = Path("/run/ambrosia-wifi-portal/hostapd.conf")
+DNSMASQ_CONF = Path("/run/ambrosia-wifi-portal/dnsmasq.conf")
+DNSMASQ_LEASES = Path("/run/ambrosia-wifi-portal/dnsmasq.leases")
+BOOT_WAIT_SECONDS = 30
+
+app = Flask(__name__)
+hostapd_proc = None
+dnsmasq_proc = None
+# Populated by main() before start_ap(). AP mode disables scanning, so we have
+# to capture the airwaves while wlan0 is still managed by NM.
+scanned_ssids = []
+
+
+def sh(cmd, timeout=None):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def get_hostname():
+    return sh(["hostname"]).stdout.strip() or "ambrosia"
+
+
+def wifi_is_real():
+    """True if wlan0 is currently on a non-AP Wi-Fi managed by NM."""
+    r = sh(["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device"])
+    for line in r.stdout.splitlines():
+        parts = line.split(":")
+        if len(parts) >= 3 and parts[0] == WLAN and parts[1] == "wifi" and parts[2] == "connected":
+            return True
+    return False
+
+
+def scan_ssids():
+    """Return a list of nearby SSIDs sorted by signal strength (strongest first).
+
+    Must run while wlan0 is still managed by NM — once we flip to AP mode the
+    radio can't scan. Hidden SSIDs (empty name) and duplicates are dropped."""
+    sh(["nmcli", "device", "wifi", "rescan", "ifname", WLAN], timeout=15)
+    time.sleep(3)
+    r = sh(["nmcli", "-t", "-f", "SSID,SIGNAL", "device", "wifi", "list", "ifname", WLAN])
+    seen = {}
+    for line in r.stdout.splitlines():
+        # nmcli -t escapes ":" inside SSIDs as "\:" — rsplit on the last
+        # unescaped colon to split SSID from SIGNAL.
+        if not line:
+            continue
+        idx = line.rfind(":")
+        if idx < 0:
+            continue
+        ssid = line[:idx].replace("\\:", ":").strip()
+        try:
+            signal = int(line[idx + 1 :])
+        except ValueError:
+            signal = 0
+        if not ssid:
+            continue
+        if ssid not in seen or signal > seen[ssid]:
+            seen[ssid] = signal
+    return [s for s, _ in sorted(seen.items(), key=lambda kv: -kv[1])]
+
+
+def write_confs():
+    HOSTAPD_CONF.parent.mkdir(parents=True, exist_ok=True)
+    ap_ssid = f"{get_hostname()}-setup"
+    HOSTAPD_CONF.write_text(
+        f"interface={WLAN}\n"
+        f"driver=nl80211\n"
+        f"ssid={ap_ssid}\n"
+        "hw_mode=g\n"
+        "channel=6\n"
+        "auth_algs=1\n"
+        "wmm_enabled=0\n"
+        "ignore_broadcast_ssid=0\n"
+    )
+    DNSMASQ_CONF.write_text(
+        f"interface={WLAN}\n"
+        f"bind-interfaces\n"
+        f"dhcp-range={DHCP_START},{DHCP_END},255.255.255.0,12h\n"
+        f"dhcp-option=3,{AP_IP}\n"     # gateway
+        f"dhcp-option=6,{AP_IP}\n"     # DNS
+        # Redirect all DNS lookups to the portal IP for captive-portal detection
+        f"address=/#/{AP_IP}\n"
+        f"dhcp-authoritative\n"
+        f"dhcp-leasefile={DNSMASQ_LEASES}\n"
+        f"log-queries\n"
+        f"log-dhcp\n"
+    )
+
+
+def start_ap():
+    """Take wlan0 out of NM, kill wpa_supplicant, reset iftype, start hostapd + dnsmasq.
+
+    Order matters: NM's supplicant keeps a handle on wlan0 that prevents hostapd
+    from setting beacon parameters. We unmanage first, then stop the supplicant,
+    then explicitly set the interface to AP type on a down interface. Without
+    this exact sequence the driver returns -EIO and hostapd fails."""
+    global hostapd_proc, dnsmasq_proc
+
+    # Caddy (and anything else binding port 80) has to step aside for the
+    # captive portal. We'll start Caddy back up in stop_ap().
+    sh(["systemctl", "stop", "caddy"])
+    sh(["nmcli", "device", "set", WLAN, "managed", "no"])
+    sh(["systemctl", "stop", "wpa_supplicant"])
+    sh(["ip", "link", "set", WLAN, "down"])
+    sh(["iw", WLAN, "set", "type", "__ap"])
+    sh(["ip", "link", "set", WLAN, "up"])
+    sh(["ip", "addr", "flush", "dev", WLAN])
+    sh(["ip", "addr", "add", f"{AP_IP}/24", "dev", WLAN])
+
+    write_confs()
+
+    hostapd_proc = subprocess.Popen(
+        ["hostapd", str(HOSTAPD_CONF)],
+        stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+    )
+    # Give hostapd ~2s to establish; then start dnsmasq
+    time.sleep(2)
+    if hostapd_proc.poll() is not None:
+        print("hostapd exited immediately — giving up.", flush=True)
+        return False
+
+    dnsmasq_proc = subprocess.Popen(
+        ["dnsmasq", "--conf-file=" + str(DNSMASQ_CONF), "--no-daemon"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+    )
+    time.sleep(1)
+    return True
+
+
+def stop_ap():
+    """Shut down hostapd + dnsmasq and hand wlan0 back to NM.
+
+    Does NOT restart Caddy — callers must do that only when we're fully done
+    with port 80, i.e. after Flask shuts down. If we restart Caddy here while
+    Flask is still bound to :80, Caddy fails with EADDRINUSE."""
+    global hostapd_proc, dnsmasq_proc
+    for proc in (dnsmasq_proc, hostapd_proc):
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+    dnsmasq_proc = None
+    hostapd_proc = None
+    sh(["ip", "addr", "flush", "dev", WLAN])
+    sh(["ip", "link", "set", WLAN, "down"])
+    sh(["iw", WLAN, "set", "type", "managed"])
+    sh(["ip", "link", "set", WLAN, "up"])
+    sh(["systemctl", "start", "wpa_supplicant"])
+    sh(["nmcli", "device", "set", WLAN, "managed", "yes"])
+    time.sleep(2)
+
+
+def restart_caddy():
+    """Restore Caddy after Flask has fully released port 80."""
+    sh(["systemctl", "start", "caddy"])
+
+
+TEMPLATE = """<!doctype html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Configurar Wi-Fi — {{ hostname }}</title>
+<style>
+body { font-family: system-ui, -apple-system, Arial, sans-serif; max-width: 480px; margin: 30px auto; padding: 0 20px; color: #111; }
+h1 { font-size: 22pt; border-bottom: 2px solid #000; padding-bottom: 8px; margin-bottom: 12px; }
+label { display: block; margin: 16px 0 4px; font-weight: 600; }
+input { width: 100%; padding: 12px; font-size: 14pt; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+button { margin-top: 24px; width: 100%; padding: 14px; font-size: 14pt; background: #1a73e8; color: #fff; border: 0; border-radius: 4px; font-weight: 600; }
+.msg { padding: 12px; border-radius: 4px; margin: 16px 0; }
+.err { background: #fde7e7; color: #a00; }
+small { color: #666; }
+code { font-family: ui-monospace, Menlo, monospace; background: #f4f4f4; padding: 1px 4px; border-radius: 3px; }
+.ssid-list { list-style: none; padding: 0; margin: 6px 0 0; border: 1px solid #ddd; border-radius: 4px; max-height: 220px; overflow-y: auto; }
+.ssid-list li { padding: 12px 14px; font-size: 13pt; cursor: pointer; border-bottom: 1px solid #eee; }
+.ssid-list li:last-child { border-bottom: 0; }
+.ssid-list li:hover, .ssid-list li:active { background: #eef3fb; }
+.ssid-list li.selected { background: #1a73e8; color: #fff; }
+.pw-wrap { position: relative; }
+.pw-wrap input { padding-right: 52px; }
+.pw-toggle { position: absolute; right: 6px; top: 50%; transform: translateY(-50%); margin: 0; width: auto; padding: 6px 10px; font-size: 12pt; background: transparent; color: #555; border: 0; cursor: pointer; }
+</style>
+</head>
+<body>
+<h1>Configurar Wi-Fi</h1>
+<p>Elige una red Wi-Fi para <b>{{ hostname }}</b> y escribe su contraseña.</p>
+{% if msg %}<div class="msg err">{{ msg|safe }}</div>{% endif %}
+<form method="post" action="/">
+  <label for="ssid">Nombre del Wi-Fi (SSID)</label>
+  <input id="ssid" name="ssid" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{ last_ssid or '' }}" required>
+  {% if ssids %}
+  <ul class="ssid-list" id="ssid-list">
+    {% for s in ssids %}<li data-ssid="{{ s }}">{{ s }}</li>{% endfor %}
+  </ul>
+  <small>Toca una red para usarla, o escribe el nombre arriba si la red está oculta.</small>
+  {% else %}
+  <small>No se detectaron redes cercanas. Escribe el nombre manualmente.</small>
+  {% endif %}
+  <label for="password">Contraseña</label>
+  <div class="pw-wrap">
+    <input id="password" name="password" type="password" required>
+    <button type="button" class="pw-toggle" id="pw-toggle" aria-label="Mostrar contraseña">Mostrar</button>
+  </div>
+  <button type="submit">Conectar</button>
+</form>
+<p style="margin-top: 24px;"><small>Si sale bien, esta red (<code>{{ ap_ssid }}</code>) desaparecerá en unos segundos. Podrás acceder al POS en <code>https://{{ hostname }}.local/</code> desde tu Wi-Fi.</small></p>
+<script>
+(function(){
+  var ssidInput = document.getElementById('ssid');
+  var list = document.getElementById('ssid-list');
+  if (list) {
+    function highlight(){
+      var v = ssidInput.value;
+      Array.prototype.forEach.call(list.children, function(li){
+        li.classList.toggle('selected', li.getAttribute('data-ssid') === v);
+      });
+    }
+    list.addEventListener('click', function(e){
+      var li = e.target.closest('li');
+      if (!li) return;
+      ssidInput.value = li.getAttribute('data-ssid');
+      highlight();
+      document.getElementById('password').focus();
+    });
+    ssidInput.addEventListener('input', highlight);
+    highlight();
+  }
+  var pw = document.getElementById('password');
+  var tog = document.getElementById('pw-toggle');
+  tog.addEventListener('click', function(){
+    var showing = pw.type === 'text';
+    pw.type = showing ? 'password' : 'text';
+    tog.textContent = showing ? 'Mostrar' : 'Ocultar';
+  });
+})();
+</script>
+</body>
+</html>"""
+
+
+SUCCESS = """<!doctype html>
+<html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Casi listo</title>
+<style>
+body{font-family:system-ui,-apple-system,Arial,sans-serif;max-width:480px;margin:30px auto;padding:0 20px;color:#111;}
+h1{font-size:22pt;color:#0a7d2a;margin-bottom:8px;}
+.step{background:#f4f7fb;border-left:4px solid #1a73e8;padding:14px 14px;border-radius:4px;margin:18px 0;}
+.step h3{margin:0 0 8px;font-size:12pt;color:#1a73e8;}
+.url-box{background:#111;color:#fff;font-family:ui-monospace,Menlo,monospace;font-size:15pt;padding:14px 16px;border-radius:6px;text-align:center;word-break:break-all;margin:10px 0;user-select:all;}
+.btn{display:block;width:100%;padding:18px;border:0;border-radius:8px;font-size:15pt;font-weight:700;text-align:center;cursor:pointer;}
+.btn-primary{background:#1a73e8;color:#fff;}
+.btn-primary.done{background:#0a7d2a;}
+.btn-primary[disabled]{opacity:.7;cursor:not-allowed;}
+code{font-family:ui-monospace,monospace;background:#f4f4f4;padding:1px 4px;border-radius:3px;}
+small{color:#666;}
+.pending{display:none;margin-top:14px;padding:12px;background:#fff4d6;border-left:4px solid #e0a100;border-radius:4px;}
+.pending.show{display:block;}
+</style>
+</head><body>
+<h1>Casi listo</h1>
+<p>Ya guardamos el nombre y contraseña de <b>{{ ssid }}</b>. Lee esto antes de tocar el botón:</p>
+
+<div class="step">
+  <h3>Qué va a pasar</h3>
+  <ol style="margin:0 0 10px;padding-left:1.4em;">
+    <li>Se <b>copia</b> la dirección del POS a tu portapapeles.</li>
+    <li>Esta red de configuración (<code>{{ ap_ssid }}</code>) se <b>cierra</b> y esta ventana se cerrará sola.</li>
+    <li>Tu teléfono se conectará solo a <b>{{ ssid }}</b> (espera unos segundos).</li>
+    <li>Entonces abre <b>Chrome</b> o <b>Safari</b> y <b>pega</b> la dirección en la barra para entrar al POS.</li>
+  </ol>
+  <div class="url-box" id="posurl">https://{{ hostname }}.local/</div>
+  <button class="btn btn-primary" id="btn-go" type="button">Copiar dirección y terminar</button>
+  <div class="pending" id="pending">
+    <b>¡Listo!</b> Dirección copiada. Tu teléfono se está conectando a <b>{{ ssid }}</b> — pégala en Chrome o Safari cuando esté listo.
+  </div>
+</div>
+
+<p><small>No pasa nada hasta que toques el botón. Si te equivocaste de contraseña, cierra esta ventana, vuelve a conectarte a <code>{{ ap_ssid }}</code> y comienza de nuevo.</small></p>
+
+<form id="commit-form" method="post" action="/commit" style="display:none;">
+  <input type="hidden" name="ssid" value="{{ ssid }}">
+  <input type="hidden" name="password" value="{{ password }}">
+</form>
+
+<script>
+(function(){
+  var btn = document.getElementById('btn-go');
+  var pending = document.getElementById('pending');
+  var url = "https://{{ hostname }}.local/";
+
+  function commit(){
+    btn.disabled = true;
+    btn.textContent = '✓ Dirección copiada — cambiando red…';
+    btn.classList.add('done');
+    pending.classList.add('show');
+    // Fire-and-forget POST; phone may lose the AP mid-request, that's fine.
+    try {
+      fetch('/commit', {method:'POST', body:new FormData(document.getElementById('commit-form'))}).catch(function(){});
+    } catch(e) {}
+  }
+
+  // navigator.clipboard.writeText requires a secure context (HTTPS or
+  // localhost); we're on plain HTTP at 10.42.1.1 so it'll reject. The
+  // document.execCommand('copy') path works on HTTP in any browser engine
+  // old enough to care, including Android's captive-portal WebView.
+  function legacyCopy(text){
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '0'; ta.style.left = '0';
+    ta.style.width = '1px'; ta.style.height = '1px';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.focus(); ta.select();
+    ta.setSelectionRange(0, text.length);
+    var ok = false;
+    try { ok = document.execCommand('copy'); } catch(e){}
+    document.body.removeChild(ta);
+    return ok;
+  }
+
+  function selectUrl(){
+    // Nothing copied — at least highlight the URL so the user can long-press.
+    var sel = window.getSelection(); var r = document.createRange();
+    r.selectNodeContents(document.getElementById('posurl'));
+    sel.removeAllRanges(); sel.addRange(r);
+  }
+
+  btn.addEventListener('click', function(){
+    var copied = false;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      // Try modern API first; if it rejects (insecure context) fall through.
+      navigator.clipboard.writeText(url).then(function(){ copied = true; commit(); },
+        function(){ copied = legacyCopy(url); if (!copied) selectUrl(); commit(); });
+    } else {
+      copied = legacyCopy(url);
+      if (!copied) selectUrl();
+      commit();
+    }
+  });
+})();
+</script>
+</body></html>"""
+
+
+def _do_connect(ssid, pw):
+    """Background task: tear down AP, try to join the user's Wi-Fi.
+
+    Runs from /commit. By that point the user has already seen the
+    confirmation page and copied the POS URL to their clipboard, so there's
+    no race with Android's captive-portal sheet closing — the AP can drop
+    immediately. On successful association systemd's ExecStopPost restarts
+    Caddy as soon as Flask releases port 80. On failure we bring the AP back
+    up and stay running so the user can re-associate with the setup AP and
+    try again.
+    """
+    # Small delay so the /commit HTTP response reaches the phone before the
+    # radio flips mode.
+    time.sleep(1)
+    stop_ap()
+    r = sh(["nmcli", "device", "wifi", "connect", ssid,
+            "password", pw, "ifname", WLAN], timeout=60)
+    if r.returncode == 0:
+        os._exit(0)
+    start_ap()
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    last_ssid = ""
+    msg = None
+    if request.method == "POST":
+        ssid = request.form.get("ssid", "").strip()
+        pw = request.form.get("password", "")
+        last_ssid = ssid
+        if not ssid:
+            msg = "Escribe el nombre de la red."
+        else:
+            # Don't touch the radio yet — just render the confirmation page.
+            # The AP stays up and Caddy stays down until the user clicks the
+            # copy button on the next page, which posts to /commit.
+            return render_template_string(
+                SUCCESS,
+                ssid=ssid,
+                password=pw,
+                hostname=get_hostname(),
+                ap_ssid=f"{get_hostname()}-setup",
+            )
+    return render_template_string(
+        TEMPLATE,
+        hostname=get_hostname(),
+        ap_ssid=f"{get_hostname()}-setup",
+        msg=msg, last_ssid=last_ssid,
+        ssids=scanned_ssids,
+    )
+
+
+@app.route("/commit", methods=["POST"])
+def commit():
+    """Actually trigger the Wi-Fi switch. Called by the copy button on the
+    success page once the user has the POS URL on their clipboard."""
+    ssid = request.form.get("ssid", "").strip()
+    pw = request.form.get("password", "")
+    if not ssid:
+        return "missing ssid", 400
+    threading.Thread(target=_do_connect, args=(ssid, pw), daemon=True).start()
+    # Response body is rarely seen — the phone is about to lose the AP.
+    return "ok", 200
+
+
+# Captive-portal detection endpoints — phones probe these to detect a portal.
+@app.route("/generate_204")              # Android
+@app.route("/gen_204")                   # Android variant
+@app.route("/hotspot-detect.html")       # iOS/macOS
+@app.route("/library/test/success.html")  # iOS/macOS
+@app.route("/ncsi.txt")                  # Windows
+@app.route("/connecttest.txt")           # Windows
+def captive_probe():
+    return redirect("/", code=302)
+
+
+def shutdown_on_signal(signum, frame):
+    stop_ap()
+    os._exit(0)
+
+
+def main():
+    signal.signal(signal.SIGTERM, shutdown_on_signal)
+    signal.signal(signal.SIGINT, shutdown_on_signal)
+
+    for _ in range(BOOT_WAIT_SECONDS):
+        if wifi_is_real():
+            print("Known Wi-Fi already connected, exiting.", flush=True)
+            return
+        time.sleep(1)
+
+    print("No known Wi-Fi — scanning for nearby SSIDs before AP mode.", flush=True)
+    global scanned_ssids
+    try:
+        scanned_ssids = scan_ssids()
+        print(f"Found {len(scanned_ssids)} SSIDs: {scanned_ssids}", flush=True)
+    except Exception as e:
+        print(f"Scan failed (continuing without list): {e}", flush=True)
+        scanned_ssids = []
+
+    print("Bringing up setup AP (hostapd + dnsmasq).", flush=True)
+    if not start_ap():
+        sys.exit(1)
+    try:
+        app.run(host="0.0.0.0", port=80, debug=False, use_reloader=False)
+    finally:
+        stop_ap()
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/preinstalled/portal/ambrosia-wifi-portal.service
+++ b/hardware/preinstalled/portal/ambrosia-wifi-portal.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ambrosia Wi-Fi setup portal (hotspot + captive portal when no known Wi-Fi)
+After=NetworkManager.service
+Wants=NetworkManager.service
+ConditionPathExists=/usr/local/bin/ambrosia-wifi-portal
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ambrosia-wifi-portal
+Restart=on-failure
+RestartSec=10
+# After the portal exits (Wi-Fi set, Flask gone, port 80 free), bring Caddy
+# back up so the POS is reachable. "-" prefix ignores failure — harmless if
+# Caddy is already running (clean-boot "known Wi-Fi" path never stopped it).
+ExecStopPost=-/usr/bin/systemctl start caddy
+
+[Install]
+WantedBy=multi-user.target

--- a/hardware/rpi/README.md
+++ b/hardware/rpi/README.md
@@ -1,0 +1,12 @@
+# Raspberry Pi Zero 2W
+
+Reference notes for running Ambrosia on a Raspberry Pi Zero 2W.
+
+For the step-by-step setup walkthrough — flashing the OS, first boot, SSH, installing Ambrosia — see the tutorial site:
+
+- [Setup the board](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/rpi)
+- [Install Ambrosia](https://tutorial.ambrosiapay.com/docs/quick-start-hardware/rpi-install)
+
+## Status
+
+Today's flow is manual: flash the OS, configure Wi-Fi, install Ambrosia by hand. The long-term goal is a single command that produces a verifiable reproducible image you flash to an SD card. That work is the natural continuation of [`../preinstalled/operator/scripts/bootstrap-ambrosia.sh`](../preinstalled/operator/scripts/bootstrap-ambrosia.sh) — see the operator README for the trajectory.


### PR DESCRIPTION
## Summary
- New `hardware/` tree at the repo root for physical-device deployment, sibling to
  `doc/installation.md` (which already handles software-only installs).
- **DIY (per-board)** — `hardware/rpi/` and `hardware/opi/` reference notes,
  pointing at step-by-step walkthroughs on the tutorial site (companion PR).
- **Preinstalled** — for users who received a configured device:
  - `hardware/preinstalled/portal/` — Wi-Fi captive portal (Flask + `nmcli`) that
    runs on first boot so a buyer can join their home network from a phone, then
    hands off to Caddy.
  - `hardware/preinstalled/operator/` — golden-image bake, per-unit wipe, fleet
    cloning, printable buyer-card generators (English + Spanish).

## Companion PR
A coordinated PR is landing in `olympus-btc/ambrosia-tutorial` to add step-by-step
walkthroughs at `tutorial.ambrosiapay.com/docs/quick-start-hardware/`. Cross-links
use absolute URLs and will resolve once both are merged.

## Path forward
The operator scripts and captive portal here are imperative ancestors of a future
reproducible-image build (e.g., a `flake.nix` consuming the current source). The
operator README documents the trajectory and the concrete TODOs:
- `bootstrap-ambrosia.sh` pins `AMBROSIA_TAG` and downloads a tagged release at
  runtime — the reproducible build will replace this by building from the current
  code.
- OPi-flavoured naming (`/mnt/opi-wipe-and-provision`, default `ambrosia-opi-N`
  hostnames) — works for any aarch64 board today but should be parameterised.

## Test plan
- [ ] Render `hardware/README.md` and section READMEs on GitHub — relative links
      resolve, absolute tutorial-site URLs render
- [ ] `bash -n hardware/preinstalled/operator/scripts/*.sh` passes (verified locally)
- [ ] Executable bits preserved on `.sh` and `ambrosia-wifi-portal` (verified
      locally, mode 100755)
- [ ] Once companion tutorial-site PR merges, click through every absolute URL
      from `hardware/**/README.md` to `tutorial.ambrosiapay.com`