### PR TITLE
fix(client): ensure consistent server/client locale

### DIFF
--- a/client/src/i18n/I18nProvider.jsx
+++ b/client/src/i18n/I18nProvider.jsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useMemo, createContext, useContext } from "react";
+import {
+  useState, useMemo, createContext, useContext, useEffect,
+} from "react";
 
 import { Button } from "@heroui/react";
 import { Languages } from "lucide-react";
@@ -50,11 +52,15 @@ function mergeLocales(locale) {
 }
 
 export function I18nProvider({ children }) {
-  const [locale, setLocale] = useState(() => {
-    if (typeof window === "undefined") return "en";
+  const [locale, setLocale] = useState("en");
+
+  useEffect(() => {
     const stored = localStorage.getItem("locale");
-    return (stored && translations[stored]) ? stored : "en";
-  });
+    if (stored && translations[stored]) {
+      setLocale(stored);
+    }
+  }, []);
+
   const messages = useMemo(() => mergeLocales(locale), [locale]);
 
   const changeLocale = (newLocale) => {


### PR DESCRIPTION
Overview                                                                                     
This PR fixes a hydration failure that occurred when the application's locale (stored in localStorage) differed from the default server-side rendering. This was causing a "Hydration failed" crash, which became visible when integrating more complex components (like Autocomplete).                                                                               
                                                                                               
The Problem                                                                                  
Previously, I18nProvider tried to read the user's language from localStorage immediately during initialization. Since localStorage does not exist on the server (Node.js), the server always rendered in English. If a user had previously selected Spanish, the browser would immediately try to render Spanish, resulting in a mismatch between the server's HTML and the client's initial state.                                                                      
                                                                                               
The Fix                                                                                      
   - Synchronous Initialization: The locale state now always defaults to "en" for the first render on both the server and the client.                                                 
   - Client-Side Sync: Added a useEffect hook to safely read the user's language preference from localStorage only after the component has mounted in the browser.                    
   - This ensures the initial "Hydration" pass matches perfectly while still persisting the user's language choice.                                                                 