### PR TITLE
Fix/accessibility

### DIFF
--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -41,6 +41,13 @@ const componentsEn = {
     downloadFromGitHub: "Download from GitHub",
     dismiss: "Dismiss",
   },
+  actions: {
+    edit: "Edit",
+    delete: "Delete",
+  },
+  imageUploader: {
+    removeImage: "Remove image",
+  },
   shifts: {
     requiredOpenShiftTitle: "Open Shift Required",
     requiredOpenShiftMessage: "To continue, please open a shift by entering the starting amount of cash.",

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -41,6 +41,13 @@ const componentsEs = {
     downloadFromGitHub: "Descargar desde GitHub",
     dismiss: "Cerrar",
   },
+  actions: {
+    edit: "Editar",
+    delete: "Eliminar",
+  },
+  imageUploader: {
+    removeImage: "Eliminar imagen",
+  },
   shifts: {
     requiredOpenShiftTitle: "Abrir Turno Requerido",
     requiredOpenShiftMessage: "Para continuar, abre un turno registrando el efectivo inicial en caja.",

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -16,6 +16,7 @@ const cartEn = {
     },
     summary: {
       clearCart: "Remove All Items",
+      removeItem: "Remove item",
       title: "Summary",
       total: "Total",
       subtotal: "Subtotal",

--- a/client/src/components/pages/Store/Cart/locales/es.js
+++ b/client/src/components/pages/Store/Cart/locales/es.js
@@ -16,6 +16,7 @@ const cartEs = {
     },
     summary: {
       clearCart: "Remover Todo",
+      removeItem: "Eliminar artículo",
       title: "Resumen",
       total: "Total",
       subtotal: "Subtotal",

--- a/client/src/components/pages/Store/Orders/StoreOrders.jsx
+++ b/client/src/components/pages/Store/Orders/StoreOrders.jsx
@@ -141,6 +141,7 @@ export default function StoreOrders() {
                     color="primary"
                     showControls
                     showShadow
+                    aria-label={t("filter.paginationAria")}
                   />
                 </div>
               )}

--- a/client/src/components/pages/Store/Orders/locales/en.js
+++ b/client/src/components/pages/Store/Orders/locales/en.js
@@ -9,6 +9,8 @@ const ordersEn = {
       searchLabel: "Search",
       searchPlaceholder: "Search by ID or user...",
       rowsPerPage: "Rows per page",
+      paginationAria: "Orders pagination",
+      tableAriaLabel: "Orders table",
       rowsOption: "{count} rows",
       tabPaid: "Paid",
       statusLabel: "Status",

--- a/client/src/components/pages/Store/Orders/locales/es.js
+++ b/client/src/components/pages/Store/Orders/locales/es.js
@@ -9,6 +9,8 @@ const ordersEs = {
       searchLabel: "Buscar",
       searchPlaceholder: "Buscar por ID o usuario...",
       rowsPerPage: "Filas por página",
+      paginationAria: "Paginación de órdenes",
+      tableAriaLabel: "Tabla de órdenes",
       rowsOption: "{count} filas",
       tabPaid: "Pagadas",
       statusLabel: "Estado",

--- a/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
@@ -54,10 +54,10 @@ export function ProductsCard({ product, status, normalizeNumber, formatAmount, c
         {canManageProducts && (
           <div className="flex flex-col gap-2 shrink-0">
             <RequirePermission allOf={["products_update"]}>
-              <EditButton onPress={() => onEditProduct(product)} />
+              <EditButton onPress={() => onEditProduct(product)} aria-label={t("edit")} />
             </RequirePermission>
             <RequirePermission allOf={["products_delete"]}>
-              <DeleteButton onPress={() => onDeleteProduct(product)} />
+              <DeleteButton onPress={() => onDeleteProduct(product)} aria-label={t("delete")} />
             </RequirePermission>
           </div>
         )}

--- a/client/src/components/pages/Store/Settings/Lightning/LightningCard.jsx
+++ b/client/src/components/pages/Store/Settings/Lightning/LightningCard.jsx
@@ -49,6 +49,7 @@ export function LightningCard() {
               isSelected={enabled}
               isDisabled={loading || restarting}
               onValueChange={handleToggle}
+              aria-label={t("autoLiquidityLabel")}
             />
           </div>
 

--- a/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
+++ b/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
@@ -46,6 +46,7 @@ export function SidebarContent({
             width={160}
             height={160}
             className="object-contain max-h-40 w-auto"
+            priority
           />
         </Link>
         <p className="text-slate-100 text-center mt-4">

--- a/client/src/components/pages/Store/Users/UsersList/UsersTable.jsx
+++ b/client/src/components/pages/Store/Users/UsersList/UsersTable.jsx
@@ -21,7 +21,7 @@ export function UsersTable({ users, canManageUsers, onEditUser, onDeleteUser }) 
 
   return (
     <div className="overflow-x-auto">
-      <Table className="min-w-[400px]" removeWrapper>
+      <Table className="min-w-[400px]" removeWrapper aria-label={t("users.tableAriaLabel")}>
         <TableHeader>
           <TableColumn className="py-2 px-3 w-[120px]">{t("users.name")}</TableColumn>
           <TableColumn className="py-2 px-3 w-20">{t("users.role")}</TableColumn>

--- a/client/src/components/pages/Store/Users/locales/en.js
+++ b/client/src/components/pages/Store/Users/locales/en.js
@@ -5,6 +5,7 @@ const usersEn = {
     title: "Users",
     subtitle: "Manage your store staff",
     addUser: "Add User",
+    tableAriaLabel: "Users table",
     noRole: "No role assigned",
     name: "Name",
     role: "Role",

--- a/client/src/components/pages/Store/Users/locales/es.js
+++ b/client/src/components/pages/Store/Users/locales/es.js
@@ -5,6 +5,7 @@ const usersEs = {
     title: "Usuarios",
     subtitle: "Gestiona el personal de tu tienda",
     addUser: "Agregar Usuario",
+    tableAriaLabel: "Tabla de usuarios",
     noRole: "Sin rol asignado",
     name: "Nombre",
     role: "Rol",

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -83,6 +83,7 @@ export function Transactions({
         <Tabs
           selectedKey={activeTab}
           onSelectionChange={setActiveTab}
+          aria-label={t("payments.title")}
           variant="underlined"
           classNames={{
             tabList: "gap-2 sm:gap-6 relative rounded-none px-4 sm:px-6 py-0 overflow-x-auto flex-nowrap w-full",

--- a/client/src/components/shared/DataTable.jsx
+++ b/client/src/components/shared/DataTable.jsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from "@heroui/react";
+import { useTranslations } from "next-intl";
 
 export function DataTable({ columns, items, getKey, emptyState }) {
+  const t = useTranslations("orders");
   return (
     <div className="overflow-x-auto">
-      <Table className="min-w-[600px]" removeWrapper>
+      <Table className="min-w-[600px]" removeWrapper aria-label={t("filter.tableAriaLabel")}>
         <TableHeader>
           {columns.map((col) => (
             <TableColumn

--- a/client/src/components/shared/DeleteButton.jsx
+++ b/client/src/components/shared/DeleteButton.jsx
@@ -2,13 +2,16 @@
 
 import { Button } from "@heroui/react";
 import { Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function DeleteButton({
   onPress,
   children,
   size = "sm",
   showLabelOnMobile = false,
+  "aria-label": ariaLabel,
 }) {
+  const t = useTranslations("actions");
   const hasLabel = Boolean(children);
   const buttonClassName = hasLabel
     ? showLabelOnMobile
@@ -22,6 +25,7 @@ export function DeleteButton({
       onPress={onPress}
       size={size}
       variant="outline"
+      aria-label={ariaLabel ?? t("delete")}
     >
       <Trash className="w-4 h-4" />
       {hasLabel && (

--- a/client/src/components/shared/EditButton.jsx
+++ b/client/src/components/shared/EditButton.jsx
@@ -2,14 +2,17 @@
 
 import { Button } from "@heroui/react";
 import { Pencil } from "lucide-react";
+import { useTranslations } from "next-intl";
 
-export function EditButton({ onPress, children, size = "sm" }) {
+export function EditButton({ onPress, children, size = "sm", "aria-label": ariaLabel }) {
+  const t = useTranslations("actions");
   return (
     <Button
       className={`border border-green-800 text-green-800 w-8 min-w-0 px-0 ${children ? "sm:w-auto sm:min-w-16 sm:px-3" : ""}`}
       onPress={onPress}
       size={size}
       variant="outline"
+      aria-label={ariaLabel ?? t("edit")}
     >
       <Pencil className="w-4 h-4" />
       {children && <span className="hidden sm:inline">{children}</span>}

--- a/client/src/components/shared/ImageUploader.jsx
+++ b/client/src/components/shared/ImageUploader.jsx
@@ -2,8 +2,10 @@ import { useState, useRef, useEffect } from "react";
 
 import { Button, Image } from "@heroui/react";
 import { Upload, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function ImageUploader({ title, uploadText, uploadDescription, onChange, value }) {
+  const t = useTranslations("imageUploader");
   const [filePreview, setFilePreview] = useState(null);
   const fileInputRef = useRef(null);
 
@@ -60,6 +62,7 @@ export function ImageUploader({ title, uploadText, uploadDescription, onChange, 
               isIconOnly
               size="sm"
               color="danger"
+              aria-label={t("removeImage")}
               data-testid="remove-image-button"
               className="absolute top-1 right-1 z-10 min-w-0 w-6 h-6"
               onPress={handleRemoveImage}


### PR DESCRIPTION
## Changes:
- Add default `aria-label` to `EditButton` and `DeleteButton` shared components using `useTranslations("actions")`, so all usages get accessible labels without caller changes
- Add `aria-label` to `<Table>` in `UsersTable` and `OrdersTable`; add `aria-label` to `<Tabs>` in `Transactions`, `<Switch>` in `LightningCard`, and `<Pagination>` in `StoreOrders`
- Add `priority` prop to sidebar logo `<Image>` to resolve LCP warning
- Add `imageUploader.removeImage` and `actions.edit/delete` translation keys to shared component locales (en/es)
- Add `paginationAria` and `tableAriaLabel` translation keys to orders locales (en/es); add `tableAriaLabel` to users locales (en/es)