### PR TITLE
Chore/props refactor

### DIFF
--- a/client/__tests__/__mocks__/next/image.js
+++ b/client/__tests__/__mocks__/next/image.js
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable jsx-a11y/alt-text */
-export default function MockedImage(props) {
+export default function MockedImage({ priority, fill, quality, loader, blurDataURL, placeholder, ...props }) {
   return <img {...props} />;
 }

--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -163,6 +163,25 @@ export function Cart() {
     setCart([]);
   };
 
+  const btcPayment = {
+    config: btcPaymentConfig,
+    onInvoiceReady: handleBtcInvoiceReady,
+    onComplete: handleBtcComplete,
+    onClose: clearBtcPaymentConfig,
+  };
+
+  const cashPayment = {
+    config: cashPaymentConfig,
+    onComplete: handleCashComplete,
+    onClose: clearCashPaymentConfig,
+  };
+
+  const cardPayment = {
+    config: cardPaymentConfig,
+    onComplete: handleCardComplete,
+    onClose: clearCardPaymentConfig,
+  };
+
   return (
     <div className={`transition-[padding] duration-200 md:pt-0 ${cart.length ? "pt-14" : "pt-0"}`}>
       <PageHeader title={t("title")} subtitle={t("subtitle")} />
@@ -182,16 +201,9 @@ export function Cart() {
             isPaying={isPaying}
             paymentError={paymentError}
             onClearPaymentError={clearPaymentError}
-            btcPaymentConfig={btcPaymentConfig}
-            onInvoiceReady={handleBtcInvoiceReady}
-            onBtcComplete={handleBtcComplete}
-            onCloseBtcPayment={clearBtcPaymentConfig}
-            cashPaymentConfig={cashPaymentConfig}
-            onCashComplete={handleCashComplete}
-            onCloseCashPayment={clearCashPaymentConfig}
-            cardPaymentConfig={cardPaymentConfig}
-            onCardComplete={handleCardComplete}
-            onCloseCardPayment={clearCardPaymentConfig}
+            btcPayment={btcPayment}
+            cashPayment={cashPayment}
+            cardPayment={cardPayment}
           />
         </div>
       </div>
@@ -214,16 +226,9 @@ export function Cart() {
         isPaying={isPaying}
         paymentError={paymentError}
         onClearPaymentError={clearPaymentError}
-        btcPaymentConfig={btcPaymentConfig}
-        onInvoiceReady={handleBtcInvoiceReady}
-        onBtcComplete={handleBtcComplete}
-        onCloseBtcPayment={clearBtcPaymentConfig}
-        cashPaymentConfig={cashPaymentConfig}
-        onCashComplete={handleCashComplete}
-        onCloseCashPayment={clearCashPaymentConfig}
-        cardPaymentConfig={cardPaymentConfig}
-        onCardComplete={handleCardComplete}
-        onCloseCardPayment={clearCardPaymentConfig}
+        btcPayment={btcPayment}
+        cashPayment={cashPayment}
+        cardPayment={cardPayment}
       />
     </div>
   );

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -19,17 +19,10 @@ export function SummaryContent({
   onPay,
   isPaying,
   paymentError,
-  btcPaymentConfig,
-  onInvoiceReady,
-  onBtcComplete,
-  onCloseBtcPayment,
-  cashPaymentConfig,
-  onCashComplete,
-  onCloseCashPayment,
-  cardPaymentConfig,
-  onCardComplete,
-  onCloseCardPayment,
   onClearPaymentError,
+  btcPayment,
+  cashPayment,
+  cardPayment,
 }) {
   const t = useTranslations("cart");
   const { formatAmount } = useCurrency();
@@ -162,32 +155,32 @@ export function SummaryContent({
       </div>
 
       <BitcoinPaymentModal
-        isOpen={!!btcPaymentConfig}
-        amountFiat={btcPaymentConfig?.amountFiat}
-        currencyAcronym={btcPaymentConfig?.currencyAcronym}
-        paymentId={btcPaymentConfig?.paymentId}
-        invoiceDescription={btcPaymentConfig?.invoiceDescription}
-        displayTotal={btcPaymentConfig?.displayTotal}
-        onClose={onCloseBtcPayment}
-        onInvoiceReady={onInvoiceReady}
-        onComplete={onBtcComplete}
+        isOpen={!!btcPayment?.config}
+        amountFiat={btcPayment?.config?.amountFiat}
+        currencyAcronym={btcPayment?.config?.currencyAcronym}
+        paymentId={btcPayment?.config?.paymentId}
+        invoiceDescription={btcPayment?.config?.invoiceDescription}
+        displayTotal={btcPayment?.config?.displayTotal}
+        onClose={btcPayment?.onClose}
+        onInvoiceReady={btcPayment?.onInvoiceReady}
+        onComplete={btcPayment?.onComplete}
       />
 
       <CashPaymentModal
-        isOpen={!!cashPaymentConfig}
-        amountDue={cashPaymentConfig?.amountDue}
-        displayTotal={cashPaymentConfig?.displayTotal}
-        onClose={onCloseCashPayment}
-        onComplete={onCashComplete}
+        isOpen={!!cashPayment?.config}
+        amountDue={cashPayment?.config?.amountDue}
+        displayTotal={cashPayment?.config?.displayTotal}
+        onClose={cashPayment?.onClose}
+        onComplete={cashPayment?.onComplete}
       />
 
       <CardPaymentModal
-        isOpen={!!cardPaymentConfig}
-        amountDue={cardPaymentConfig?.amountDue}
-        displayTotal={cardPaymentConfig?.displayTotal}
-        methodLabel={cardPaymentConfig?.methodLabel}
-        onClose={onCloseCardPayment}
-        onComplete={onCardComplete}
+        isOpen={!!cardPayment?.config}
+        amountDue={cardPayment?.config?.amountDue}
+        displayTotal={cardPayment?.config?.displayTotal}
+        methodLabel={cardPayment?.config?.methodLabel}
+        onClose={cardPayment?.onClose}
+        onComplete={cardPayment?.onComplete}
       />
     </>
   );

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -147,9 +147,9 @@ describe("SummaryContent", () => {
     render(
       <SummaryContent
         {...defaultProps}
-        btcPaymentConfig={{ paymentId: "btc-1" }}
-        cashPaymentConfig={{ paymentId: "cash-1" }}
-        cardPaymentConfig={{ paymentId: "card-1" }}
+        btcPayment={{ config: { paymentId: "btc-1" } }}
+        cashPayment={{ config: { paymentId: "cash-1" } }}
+        cardPayment={{ config: { paymentId: "card-1" } }}
       />,
     );
 

--- a/client/src/components/pages/Store/Orders/OrdersFilterBar/OrdersFilterBar.jsx
+++ b/client/src/components/pages/Store/Orders/OrdersFilterBar/OrdersFilterBar.jsx
@@ -9,12 +9,10 @@ import { useTranslations } from "next-intl";
 import { AdvancedFiltersPanel } from "./AdvancedFiltersPanel";
 
 export function OrdersFilterBar({
-  searchTerm,
-  rowsPerPage,
+  search,
+  pagination,
   filters,
   paymentMethods = [],
-  onSearchChange,
-  onRowsPerPageChange,
   onFiltersChange,
   onApplyFilters,
   onClearFilters,
@@ -41,16 +39,16 @@ export function OrdersFilterBar({
           className="w-full lg:flex-1"
           label={t("filter.searchLabel")}
           placeholder={t("filter.searchPlaceholder")}
-          value={searchTerm}
-          onChange={(e) => onSearchChange(e.target.value)}
-          onClear={() => onSearchChange("")}
+          value={search.term}
+          onChange={(e) => search.onChange(e.target.value)}
+          onClear={() => search.onChange("")}
         />
         <div className="flex flex-col sm:flex-row gap-3 lg:contents">
           <Select
             aria-label="Rows per page"
             label={t("filter.rowsPerPage")}
-            selectedKeys={[rowsPerPage.toString()]}
-            onSelectionChange={(keys) => onRowsPerPageChange(Array.from(keys)[0])}
+            selectedKeys={[pagination.rowsPerPage.toString()]}
+            onSelectionChange={(keys) => pagination.onChange(Array.from(keys)[0])}
             className="flex-1 lg:w-48 lg:flex-none"
           >
             {[5, 10, 20, 50].map((count) => (

--- a/client/src/components/pages/Store/Orders/OrdersFilterBar/__tests__/OrdersFilterBar.test.jsx
+++ b/client/src/components/pages/Store/Orders/OrdersFilterBar/__tests__/OrdersFilterBar.test.jsx
@@ -71,12 +71,10 @@ describe("OrdersFilterBar", () => {
 
     render(
       <OrdersFilterBar
-        searchTerm=""
-        rowsPerPage={10}
+        search={{ term: "", onChange: onSearchChange }}
+        pagination={{ rowsPerPage: 10, onChange: onRowsPerPageChange }}
         filters={defaultFilters}
         paymentMethods={[{ id: "cash", name: "Cash" }]}
-        onSearchChange={onSearchChange}
-        onRowsPerPageChange={onRowsPerPageChange}
         onFiltersChange={jest.fn()}
         onApplyFilters={jest.fn()}
         onClearFilters={jest.fn()}
@@ -97,12 +95,10 @@ describe("OrdersFilterBar", () => {
   it("renders the more filters toggle button", () => {
     render(
       <OrdersFilterBar
-        searchTerm=""
-        rowsPerPage={10}
+        search={{ term: "", onChange: jest.fn() }}
+        pagination={{ rowsPerPage: 10, onChange: jest.fn() }}
         filters={defaultFilters}
         paymentMethods={[]}
-        onSearchChange={jest.fn()}
-        onRowsPerPageChange={jest.fn()}
         onFiltersChange={jest.fn()}
         onApplyFilters={jest.fn()}
         onClearFilters={jest.fn()}
@@ -115,12 +111,10 @@ describe("OrdersFilterBar", () => {
   it("shows active filter count in trigger", () => {
     render(
       <OrdersFilterBar
-        searchTerm=""
-        rowsPerPage={10}
+        search={{ term: "", onChange: jest.fn() }}
+        pagination={{ rowsPerPage: 10, onChange: jest.fn() }}
         filters={{ ...defaultFilters, status: "paid", paymentMethod: "Cash" }}
         paymentMethods={[{ id: "cash", name: "Cash" }]}
-        onSearchChange={jest.fn()}
-        onRowsPerPageChange={jest.fn()}
         onFiltersChange={jest.fn()}
         onApplyFilters={jest.fn()}
         onClearFilters={jest.fn()}
@@ -136,12 +130,10 @@ describe("OrdersFilterBar", () => {
 
     render(
       <OrdersFilterBar
-        searchTerm=""
-        rowsPerPage={10}
+        search={{ term: "", onChange: jest.fn() }}
+        pagination={{ rowsPerPage: 10, onChange: jest.fn() }}
         filters={defaultFilters}
         paymentMethods={[]}
-        onSearchChange={jest.fn()}
-        onRowsPerPageChange={jest.fn()}
         onFiltersChange={jest.fn()}
         onApplyFilters={onApplyFilters}
         onClearFilters={onClearFilters}

--- a/client/src/components/pages/Store/Orders/StoreOrders.jsx
+++ b/client/src/components/pages/Store/Orders/StoreOrders.jsx
@@ -89,28 +89,33 @@ export default function StoreOrders() {
     setPage(1);
   };
 
+  const handleSearchChange = (value) => {
+    setSearchTerm(value);
+    setPage(1);
+  };
+
+  const handleRowsPerPageChange = (value) => {
+    setRowsPerPage(parseInt(value, 10));
+    setPage(1);
+  };
+
   const totalPages = Math.ceil(filteredOrders.length / rowsPerPage);
   const startIndex = (page - 1) * rowsPerPage;
   const endIndex = startIndex + rowsPerPage;
   const paginatedOrders = filteredOrders.slice(startIndex, endIndex);
+
+  const filterSearch = { term: searchTerm, onChange: handleSearchChange };
+  const filterPagination = { rowsPerPage, onChange: handleRowsPerPageChange };
 
   return (
     <div className="max-w-7xl mx-auto">
       <Card shadow="none" className="mb-6 shadow-lg bg-white rounded-lg p-4 lg:p-8">
         <CardBody>
           <OrdersFilterBar
-            searchTerm={searchTerm}
-            rowsPerPage={rowsPerPage}
+            search={filterSearch}
+            pagination={filterPagination}
             filters={filters}
             paymentMethods={paymentMethods}
-            onSearchChange={(value) => {
-              setSearchTerm(value);
-              setPage(1);
-            }}
-            onRowsPerPageChange={(value) => {
-              setRowsPerPage(parseInt(value, 10));
-              setPage(1);
-            }}
             onFiltersChange={handleFiltersChange}
             onApplyFilters={handleApplyFilters}
             onClearFilters={handleClearFilters}

--- a/client/src/components/pages/Store/Orders/__tests__/StoreOrders.test.jsx
+++ b/client/src/components/pages/Store/Orders/__tests__/StoreOrders.test.jsx
@@ -34,15 +34,15 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("../OrdersFilterBar", () => ({
-  OrdersFilterBar: ({ onSearchChange, onRowsPerPageChange, onFiltersChange, onApplyFilters, onClearFilters }) => (
+  OrdersFilterBar: ({ search, pagination, onFiltersChange, onApplyFilters, onClearFilters }) => (
     <div>
-      <button type="button" onClick={() => onSearchChange("order-1")}>
+      <button type="button" onClick={() => search.onChange("order-1")}>
         search-match
       </button>
-      <button type="button" onClick={() => onSearchChange("missing")}>
+      <button type="button" onClick={() => search.onChange("missing")}>
         search-empty
       </button>
-      <button type="button" onClick={() => onRowsPerPageChange("1")}>
+      <button type="button" onClick={() => pagination.onChange("1")}>
         rows-1
       </button>
       <button type="button" onClick={() => onFiltersChange({ status: "paid" })}>

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useReports.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useReports.test.js
@@ -36,8 +36,9 @@ describe("useReports — fetch", () => {
     parseJsonResponse.mockResolvedValue(successReport);
   });
 
-  it("exposes fetchReport as a function", () => {
+  it("exposes fetchReport as a function", async () => {
     const { result } = renderHook(() => useReports());
+    await act(async () => {});
     expect(typeof result.current.fetchReport).toBe("function");
   });
 
@@ -289,8 +290,9 @@ describe("useReports — filters", () => {
     parseJsonResponse.mockResolvedValue(successReport);
   });
 
-  it("initial filters match defaultFilters", () => {
+  it("initial filters match defaultFilters", async () => {
     const { result } = renderHook(() => useReports());
+    await act(async () => {});
     expect(result.current.filters).toEqual(defaultFilters);
   });
 
@@ -425,13 +427,15 @@ describe("useReports — derived values", () => {
     httpClient.mockResolvedValue({});
   });
 
-  it("totalRevenue is 0 when reportData is null", () => {
+  it("totalRevenue is 0 when reportData is null", async () => {
     const { result } = renderHook(() => useReports());
+    await act(async () => {});
     expect(result.current.totalRevenue).toBe(0);
   });
 
-  it("totalItems is 0 when reportData is null", () => {
+  it("totalItems is 0 when reportData is null", async () => {
     const { result } = renderHook(() => useReports());
+    await act(async () => {});
     expect(result.current.totalItems).toBe(0);
   });
 

--- a/client/src/components/pages/Store/Settings/Printers/PrinterAddForm.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/PrinterAddForm.jsx
@@ -1,28 +1,19 @@
 "use client";
 
 import { Button, Card, CardBody, Select, SelectItem, Switch } from "@heroui/react";
+import { useTranslations } from "next-intl";
 
 const PRINTER_TYPES = ["CUSTOMER"];
 
-export function PrinterAddForm({
-  printerType,
-  printerName,
-  templateName,
-  isDefault,
-  enabled,
-  availablePrinters,
-  templates,
-  loadingAvailable,
-  loadingTemplates,
-  saving,
-  onPrinterTypeChange,
-  onPrinterNameChange,
-  onTemplateNameChange,
-  onDefaultChange,
-  onEnabledChange,
-  onSubmit,
-  t,
-}) {
+export function PrinterAddForm({ formState, data, loading, saving }) {
+  const t = useTranslations("settings");
+  const {
+    printerType, printerName, templateName, isDefault, enabled,
+    onPrinterTypeChange, onPrinterNameChange, onTemplateNameChange,
+    onDefaultChange, onEnabledChange, onSubmit,
+  } = formState;
+  const { availablePrinters, templates } = data;
+  const { available: loadingAvailable, templates: loadingTemplates } = loading;
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-col gap-4 p-4">

--- a/client/src/components/pages/Store/Settings/Printers/PrinterConfigRow.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/PrinterConfigRow.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card, CardBody, Select, SelectItem, Switch } from "@heroui/react";
+import { useTranslations } from "next-intl";
 
 import { DeleteButton } from "@components/shared/DeleteButton";
 
@@ -13,8 +14,8 @@ export function PrinterConfigRow({
   onToggleDefault,
   onToggleEnabled,
   onRemove,
-  t,
 }) {
+  const t = useTranslations("settings");
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-col gap-3 p-4">

--- a/client/src/components/pages/Store/Settings/Printers/Printers.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/Printers.jsx
@@ -2,15 +2,12 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { useTranslations } from "next-intl";
-
 import { usePrinters } from "../../hooks/usePrinter";
 import { useTemplates } from "../../hooks/useTemplates";
 
 import { PrintersCard } from "./PrintersCard";
 
 export function Printers() {
-  const t = useTranslations("settings");
   const {
     availablePrinters,
     printerConfigs,
@@ -83,31 +80,30 @@ export function Printers() {
     }
   };
 
+  const printerFormState = {
+    printerType, printerName, templateName, isDefault, enabled,
+    onPrinterTypeChange: setPrinterType,
+    onPrinterNameChange: setPrinterName,
+    onTemplateNameChange: setTemplateName,
+    onDefaultChange: setIsDefault,
+    onEnabledChange: setEnabled,
+  };
+  const printerData = { availablePrinters, configRows, templates };
+  const printerLoading = { available: loadingAvailable, configs: loadingConfigs, templates: loadingTemplates };
+  const printerState = {
+    error, saving,
+    onAdd: handleAdd,
+    onUpdateConfig: updatePrinterConfig,
+    onDeleteConfig: deletePrinterConfig,
+    onSetDefaultConfig: setDefaultPrinterConfig,
+  };
+
   return (
     <PrintersCard
-      printerType={printerType}
-      printerName={printerName}
-      templateName={templateName}
-      isDefault={isDefault}
-      enabled={enabled}
-      availablePrinters={availablePrinters}
-      configRows={configRows}
-      loadingAvailable={loadingAvailable}
-      loadingConfigs={loadingConfigs}
-      loadingTemplates={loadingTemplates}
-      templates={templates}
-      error={error}
-      saving={saving}
-      onPrinterTypeChange={setPrinterType}
-      onPrinterNameChange={setPrinterName}
-      onTemplateNameChange={setTemplateName}
-      onDefaultChange={setIsDefault}
-      onEnabledChange={setEnabled}
-      onAdd={handleAdd}
-      onUpdateConfig={updatePrinterConfig}
-      onDeleteConfig={deletePrinterConfig}
-      onSetDefaultConfig={setDefaultPrinterConfig}
-      t={t}
+      formState={printerFormState}
+      data={printerData}
+      loading={printerLoading}
+      state={printerState}
     />
   );
 }

--- a/client/src/components/pages/Store/Settings/Printers/PrintersCard.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/PrintersCard.jsx
@@ -1,35 +1,19 @@
 "use client";
 
 import { Card, CardBody, CardHeader } from "@heroui/react";
+import { useTranslations } from "next-intl";
 
 import { PrinterAddForm } from "./PrinterAddForm";
 import { PrinterConfigRow } from "./PrinterConfigRow";
 
-export function PrintersCard({
-  printerType,
-  printerName,
-  templateName,
-  isDefault,
-  enabled,
-  availablePrinters,
-  configRows,
-  loadingAvailable,
-  loadingConfigs,
-  loadingTemplates,
-  templates,
-  error,
-  saving,
-  onPrinterTypeChange,
-  onPrinterNameChange,
-  onTemplateNameChange,
-  onDefaultChange,
-  onEnabledChange,
-  onAdd,
-  onUpdateConfig,
-  onDeleteConfig,
-  onSetDefaultConfig,
-  t,
-}) {
+export function PrintersCard({ formState, data, loading, state }) {
+  const t = useTranslations("settings");
+  const { configRows } = data;
+  const { configs: loadingConfigs } = loading;
+  const { error, saving, onAdd, onUpdateConfig, onDeleteConfig, onSetDefaultConfig } = state;
+
+  const addFormState = { ...formState, onSubmit: onAdd };
+
   return (
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
@@ -44,23 +28,10 @@ export function PrintersCard({
       <CardBody>
         <div className="flex flex-col gap-6">
           <PrinterAddForm
-            printerType={printerType}
-            printerName={printerName}
-            templateName={templateName}
-            isDefault={isDefault}
-            enabled={enabled}
-            availablePrinters={availablePrinters}
-            templates={templates}
-            loadingAvailable={loadingAvailable}
-            loadingTemplates={loadingTemplates}
+            formState={addFormState}
+            data={data}
+            loading={loading}
             saving={saving}
-            onPrinterTypeChange={onPrinterTypeChange}
-            onPrinterNameChange={onPrinterNameChange}
-            onTemplateNameChange={onTemplateNameChange}
-            onDefaultChange={onDefaultChange}
-            onEnabledChange={onEnabledChange}
-            onSubmit={onAdd}
-            t={t}
           />
 
           {error && (
@@ -92,14 +63,13 @@ export function PrintersCard({
               <PrinterConfigRow
                 key={config.id}
                 config={config}
-                templates={templates}
-                loadingTemplates={loadingTemplates}
+                templates={data.templates}
+                loadingTemplates={loading.templates}
                 onTemplateChange={(value) => onUpdateConfig(config.id, { templateName: value })}
                 onSetDefault={() => onSetDefaultConfig(config.id)}
                 onToggleDefault={(value) => onUpdateConfig(config.id, { isDefault: value })}
                 onToggleEnabled={(value) => onUpdateConfig(config.id, { enabled: value })}
                 onRemove={() => onDeleteConfig(config.id)}
-                t={t}
               />
             ))}
           </div>

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterAddForm.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterAddForm.test.jsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { PrinterAddForm } from "../PrinterAddForm";
 
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
 jest.mock("@heroui/react", () => ({
   Card: ({ children, ...props }) => <div {...props}>{children}</div>,
   CardBody: ({ children, ...props }) => <div {...props}>{children}</div>,
@@ -42,8 +46,6 @@ jest.mock("@heroui/react", () => ({
   ),
 }));
 
-const t = (key) => key;
-
 describe("PrinterAddForm", () => {
   it("handles field updates and submit", () => {
     const onPrinterTypeChange = jest.fn();
@@ -53,27 +55,16 @@ describe("PrinterAddForm", () => {
     const onEnabledChange = jest.fn();
     const onSubmit = jest.fn();
 
-    render(
-      <PrinterAddForm
-        printerType="CUSTOMER"
-        printerName=""
-        templateName=""
-        isDefault={false}
-        enabled
-        availablePrinters={["Printer A"]}
-        templates={[{ name: "Template A" }]}
-        loadingAvailable={false}
-        loadingTemplates={false}
-        saving={false}
-        onPrinterTypeChange={onPrinterTypeChange}
-        onPrinterNameChange={onPrinterNameChange}
-        onTemplateNameChange={onTemplateNameChange}
-        onDefaultChange={onDefaultChange}
-        onEnabledChange={onEnabledChange}
-        onSubmit={onSubmit}
-        t={t}
-      />,
-    );
+    const formState = {
+      printerType: "CUSTOMER", printerName: "", templateName: "",
+      isDefault: false, enabled: true,
+      onPrinterTypeChange, onPrinterNameChange, onTemplateNameChange,
+      onDefaultChange, onEnabledChange, onSubmit,
+    };
+    const data = { availablePrinters: ["Printer A"], templates: [{ name: "Template A" }] };
+    const loading = { available: false, templates: false };
+
+    render(<PrinterAddForm formState={formState} data={data} loading={loading} saving={false} />);
 
     fireEvent.change(screen.getByLabelText("cardPrinters.typeLabel"), {
       target: { value: "CUSTOMER" },
@@ -103,27 +94,17 @@ describe("PrinterAddForm", () => {
   it("enables submit when required data is present", () => {
     const onSubmit = jest.fn();
 
-    render(
-      <PrinterAddForm
-        printerType="CUSTOMER"
-        printerName="Printer A"
-        templateName="Template A"
-        isDefault={false}
-        enabled
-        availablePrinters={["Printer A"]}
-        templates={[{ name: "Template A" }]}
-        loadingAvailable={false}
-        loadingTemplates={false}
-        saving={false}
-        onPrinterTypeChange={jest.fn()}
-        onPrinterNameChange={jest.fn()}
-        onTemplateNameChange={jest.fn()}
-        onDefaultChange={jest.fn()}
-        onEnabledChange={jest.fn()}
-        onSubmit={onSubmit}
-        t={t}
-      />,
-    );
+    const formState = {
+      printerType: "CUSTOMER", printerName: "Printer A", templateName: "Template A",
+      isDefault: false, enabled: true,
+      onPrinterTypeChange: jest.fn(), onPrinterNameChange: jest.fn(),
+      onTemplateNameChange: jest.fn(), onDefaultChange: jest.fn(),
+      onEnabledChange: jest.fn(), onSubmit,
+    };
+    const data = { availablePrinters: ["Printer A"], templates: [{ name: "Template A" }] };
+    const loading = { available: false, templates: false };
+
+    render(<PrinterAddForm formState={formState} data={data} loading={loading} saving={false} />);
 
     const addButton = screen.getByText("cardPrinters.addButton");
     expect(addButton).not.toBeDisabled();

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { PrinterConfigRow } from "../PrinterConfigRow";
 
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
 jest.mock("@components/shared/DeleteButton", () => ({
   DeleteButton: ({ onPress }) => (
     <button type="button" onClick={onPress} aria-label="delete">delete</button>
@@ -43,8 +47,6 @@ jest.mock("@heroui/react", () => ({
   ),
 }));
 
-const t = (key) => key;
-
 describe("PrinterConfigRow", () => {
   it("renders badges and handles actions", () => {
     const onTemplateChange = jest.fn();
@@ -72,7 +74,6 @@ describe("PrinterConfigRow", () => {
         onToggleDefault={onToggleDefault}
         onToggleEnabled={onToggleEnabled}
         onRemove={onRemove}
-        t={t}
       />,
     );
 
@@ -115,7 +116,6 @@ describe("PrinterConfigRow", () => {
         onToggleDefault={onToggleDefault}
         onToggleEnabled={jest.fn()}
         onRemove={jest.fn()}
-        t={t}
       />,
     );
 

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/Printers.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/Printers.test.jsx
@@ -16,7 +16,7 @@ jest.mock("../PrintersCard", () => ({
   PrintersCard: (props) => {
     capturedProps = props;
     return (
-      <button type="button" onClick={props.onAdd}>
+      <button type="button" onClick={props.state?.onAdd}>
         add-printer
       </button>
     );
@@ -59,7 +59,7 @@ describe("Printers", () => {
 
       render(<Printers />);
 
-      await waitFor(() => expect(capturedProps?.printerName).toBe("Printer A"));
+      await waitFor(() => expect(capturedProps?.formState?.printerName).toBe("Printer A"));
     });
 
     it("initializes templateName from first template", async () => {
@@ -70,7 +70,7 @@ describe("Printers", () => {
 
       render(<Printers />);
 
-      await waitFor(() => expect(capturedProps?.templateName).toBe("Template A"));
+      await waitFor(() => expect(capturedProps?.formState?.templateName).toBe("Template A"));
     });
 
     it("auto-sets isDefault to true when no configs exist", async () => {
@@ -82,7 +82,7 @@ describe("Printers", () => {
 
       render(<Printers />);
 
-      await waitFor(() => expect(capturedProps?.isDefault).toBe(true));
+      await waitFor(() => expect(capturedProps?.formState?.isDefault).toBe(true));
     });
   });
 
@@ -101,7 +101,7 @@ describe("Printers", () => {
 
       render(<Printers />);
 
-      await waitFor(() => expect(capturedProps?.printerName).toBe("Printer A"));
+      await waitFor(() => expect(capturedProps?.formState?.printerName).toBe("Printer A"));
 
       fireEvent.click(screen.getByText("add-printer"));
 
@@ -129,7 +129,7 @@ describe("Printers", () => {
 
       render(<Printers />);
 
-      expect(capturedProps?.configRows.map((r) => r.printerName)).toEqual([
+      expect(capturedProps?.data?.configRows.map((r) => r.printerName)).toEqual([
         "Bravo",
         "Alpha",
         "Zebra",

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { PrintersCard } from "../PrintersCard";
 
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
 jest.mock("@heroui/react", () => ({
   Button: ({ onPress, children, ...props }) => (
     <button type="button" onClick={onPress} {...props}>
@@ -15,7 +19,7 @@ jest.mock("@heroui/react", () => ({
 
 jest.mock("../PrinterAddForm", () => ({
   PrinterAddForm: (props) => (
-    <button type="button" onClick={props.onSubmit}>
+    <button type="button" onClick={props.formState?.onSubmit}>
       add-form-submit
     </button>
   ),
@@ -41,32 +45,24 @@ jest.mock("../PrinterConfigRow", () => ({
   ),
 }));
 
-const t = (key) => key;
+const defaultFormState = {
+  printerType: "CUSTOMER", printerName: "", templateName: "",
+  isDefault: false, enabled: true,
+  onPrinterTypeChange: jest.fn(), onPrinterNameChange: jest.fn(),
+  onTemplateNameChange: jest.fn(), onDefaultChange: jest.fn(), onEnabledChange: jest.fn(),
+};
+const defaultData = { availablePrinters: [], configRows: [], templates: [] };
+const defaultLoading = { available: false, configs: false, templates: false };
+const defaultState = {
+  error: null, saving: false,
+  onAdd: jest.fn(), onUpdateConfig: jest.fn(), onDeleteConfig: jest.fn(), onSetDefaultConfig: jest.fn(),
+};
 
 const defaultProps = {
-  printerType: "CUSTOMER",
-  printerName: "",
-  templateName: "",
-  isDefault: false,
-  enabled: true,
-  availablePrinters: [],
-  configRows: [],
-  loadingAvailable: false,
-  loadingConfigs: false,
-  loadingTemplates: false,
-  templates: [],
-  error: null,
-  saving: false,
-  onPrinterTypeChange: jest.fn(),
-  onPrinterNameChange: jest.fn(),
-  onTemplateNameChange: jest.fn(),
-  onDefaultChange: jest.fn(),
-  onEnabledChange: jest.fn(),
-  onAdd: jest.fn(),
-  onUpdateConfig: jest.fn(),
-  onDeleteConfig: jest.fn(),
-  onSetDefaultConfig: jest.fn(),
-  t,
+  formState: defaultFormState,
+  data: defaultData,
+  loading: defaultLoading,
+  state: defaultState,
 };
 
 describe("PrintersCard", () => {
@@ -77,17 +73,17 @@ describe("PrintersCard", () => {
   });
 
   it("shows error message when error prop is truthy", () => {
-    render(<PrintersCard {...defaultProps} error />);
+    render(<PrintersCard {...defaultProps} state={{ ...defaultState, error: true }} />);
     expect(screen.getByText("cardPrinters.error")).toBeInTheDocument();
   });
 
   it("shows empty message when configRows is empty and not loading", () => {
-    render(<PrintersCard {...defaultProps} configRows={[]} loadingConfigs={false} />);
+    render(<PrintersCard {...defaultProps} data={{ ...defaultData, configRows: [] }} loading={{ ...defaultLoading, configs: false }} />);
     expect(screen.getByText("cardPrinters.empty")).toBeInTheDocument();
   });
 
   it("shows loading message when loadingConfigs is true", () => {
-    render(<PrintersCard {...defaultProps} loadingConfigs />);
+    render(<PrintersCard {...defaultProps} loading={{ ...defaultLoading, configs: true }} />);
     expect(screen.getByText("cardPrinters.loading")).toBeInTheDocument();
   });
 
@@ -96,14 +92,14 @@ describe("PrintersCard", () => {
       { id: "cfg-1", printerName: "Alpha", printerType: "KITCHEN", isDefault: false },
       { id: "cfg-2", printerName: "Bravo", printerType: "BAR", isDefault: false },
     ];
-    render(<PrintersCard {...defaultProps} configRows={configRows} />);
+    render(<PrintersCard {...defaultProps} data={{ ...defaultData, configRows }} />);
     expect(screen.getByTestId("row-cfg-1")).toBeInTheDocument();
     expect(screen.getByTestId("row-cfg-2")).toBeInTheDocument();
   });
 
   it("calls onAdd when add form is submitted", () => {
     const onAdd = jest.fn();
-    render(<PrintersCard {...defaultProps} onAdd={onAdd} />);
+    render(<PrintersCard {...defaultProps} state={{ ...defaultState, onAdd }} />);
     fireEvent.click(screen.getByText("add-form-submit"));
     expect(onAdd).toHaveBeenCalled();
   });
@@ -117,10 +113,8 @@ describe("PrintersCard", () => {
     render(
       <PrintersCard
         {...defaultProps}
-        configRows={configRows}
-        onUpdateConfig={onUpdateConfig}
-        onDeleteConfig={onDeleteConfig}
-        onSetDefaultConfig={onSetDefaultConfig}
+        data={{ ...defaultData, configRows }}
+        state={{ ...defaultState, onUpdateConfig, onDeleteConfig, onSetDefaultConfig }}
       />,
     );
 

--- a/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
+++ b/client/src/components/pages/Store/StoreLayout/Sidebar.jsx
@@ -45,7 +45,8 @@ export function SidebarContent({
             alt="ambrosia"
             width={160}
             height={160}
-            className="object-contain max-h-40 w-auto"
+            className="object-contain max-h-40"
+            style={{ width: "auto", height: "auto" }}
             priority
           />
         </Link>

--- a/client/src/components/pages/Store/Wallet/CloseChannel/CloseChannelModal.jsx
+++ b/client/src/components/pages/Store/Wallet/CloseChannel/CloseChannelModal.jsx
@@ -74,6 +74,14 @@ export function CloseChannelModal({ isOpen, onClose, channel, onSuccess }) {
 
   if (!channel) return null;
 
+  const modalForm = {
+    address,
+    feerate,
+    errors,
+    onAddressChange: setAddress,
+    onFeerateChange: setFeerate,
+  };
+
   return (
     <Modal
       isOpen={isOpen}
@@ -95,12 +103,8 @@ export function CloseChannelModal({ isOpen, onClose, channel, onSuccess }) {
           <ModalSuccess txId={txId} onClose={onClose} />
         ) : step === "form" ? (
           <ModalForm
-            address={address}
-            feerate={feerate}
-            errors={errors}
+            form={modalForm}
             isLoading={isLoading}
-            onAddressChange={setAddress}
-            onFeerateChange={setFeerate}
             onCancel={onClose}
             onNext={handleNext}
           />

--- a/client/src/components/pages/Store/Wallet/CloseChannel/ModalForm.jsx
+++ b/client/src/components/pages/Store/Wallet/CloseChannel/ModalForm.jsx
@@ -3,8 +3,9 @@
 import { Button, Input, ModalBody, ModalFooter } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
-export function ModalForm({ address, feerate, errors, isLoading, onAddressChange, onFeerateChange, onCancel, onNext }) {
+export function ModalForm({ form, isLoading, onCancel, onNext }) {
   const t = useTranslations("wallet");
+  const { address, feerate, errors, onAddressChange, onFeerateChange } = form;
 
   return (
     <>

--- a/client/src/components/pages/Store/Wallet/Transactions/AmountUnitInputFields.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/AmountUnitInputFields.jsx
@@ -2,41 +2,35 @@
 
 import { Button, NumberInput } from "@heroui/react";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
+
 import { formatFiat, formatSats } from "../utils/formatters";
 
 export function AmountUnitInputFields({
-  amountInputMode,
-  currencyAcronym,
-  currencyLocale,
+  labels,
+  amountState,
+  conversionState,
   errorMessage,
-  estimatedFiat,
-  estimatedFiatErrorText,
-  estimatedFiatHasError,
-  estimatedFiatIsLoading,
-  estimatedLabel,
-  estimatedSats,
-  fiatLabel,
-  fiatOptionLabel,
-  fiatPlaceholder,
-  fiatToSatHasError,
-  fiatToSatIsLoading,
-  inputValue,
   isDisabled = false,
-  loadingText,
-  onAmountChange,
-  onAmountModeChange,
-  satLabel,
-  satsOptionLabel,
-  satPlaceholder,
-  title,
-  conversionErrorText,
 }) {
+  const { currency } = useCurrency();
+  const { amountInputMode, inputValue, onAmountChange, onAmountModeChange } = amountState;
+  const {
+    estimatedFiat, estimatedFiatHasError, estimatedFiatIsLoading,
+    estimatedSats, fiatToSatHasError, fiatToSatIsLoading,
+  } = conversionState;
+  const {
+    title, satLabel, satsOptionLabel, satPlaceholder,
+    fiatLabel, fiatOptionLabel, fiatPlaceholder,
+    estimatedLabel, loadingText, estimatedFiatErrorText, conversionErrorText,
+  } = labels;
+
   const estimatedValue = amountInputMode === "fiat"
     ? `${formatSats(estimatedSats ?? 0)} sats`
     : formatFiat({
       value: estimatedFiat ?? 0,
-      currencyAcronym,
-      locale: currencyLocale,
+      currencyAcronym: currency.acronym,
+      locale: currency.locale,
     });
 
   const estimatedStateText = amountInputMode === "fiat"

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/PendingPaymentContent.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/PendingPaymentContent.jsx
@@ -64,6 +64,20 @@ export function PendingPaymentContent({
     locale: currency.locale,
   });
 
+  const zeroAmountState = {
+    amountInputMode,
+    customEstimateError,
+    customEstimateValue,
+    estimatedFiat,
+    estimatedFiatHasError,
+    estimatedFiatIsLoading,
+    estimatedSats,
+    fiatToSatHasError,
+    fiatToSatIsLoading,
+    onAmountChange: handleAmountChange,
+    onAmountModeChange: handleAmountModeChange,
+  };
+
   return (
     <>
       <ModalBody className="gap-0">
@@ -77,19 +91,8 @@ export function PendingPaymentContent({
         <div className="space-y-3">
           {isZeroAmount ? (
             <ZeroAmountPaymentFields
-              amountInputMode={amountInputMode}
-              currencyAcronym={currency.acronym}
-              currencyLocale={currency.locale}
-              customEstimateError={customEstimateError}
-              customEstimateValue={customEstimateValue}
-              estimatedFiat={estimatedFiat}
-              estimatedFiatHasError={estimatedFiatHasError}
-              estimatedFiatIsLoading={estimatedFiatIsLoading}
-              estimatedSats={estimatedSats}
-              fiatToSatHasError={fiatToSatHasError}
-              fiatToSatIsLoading={fiatToSatIsLoading}
-              onAmountChange={handleAmountChange}
-              onAmountModeChange={handleAmountModeChange}
+              amountState={zeroAmountState}
+              isDisabled={isLoading}
             />
           ) : (
             <>

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/ZeroAmountPaymentFields.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/ZeroAmountPaymentFields.jsx
@@ -2,51 +2,41 @@
 
 import { useTranslations } from "next-intl";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
+
 import { AmountUnitInputFields } from "../AmountUnitInputFields";
 
-export function ZeroAmountPaymentFields({
-  amountInputMode,
-  currencyAcronym,
-  currencyLocale,
-  customEstimateError,
-  customEstimateValue,
-  estimatedFiat,
-  estimatedFiatHasError,
-  estimatedFiatIsLoading,
-  estimatedSats,
-  fiatToSatHasError,
-  fiatToSatIsLoading,
-  onAmountChange,
-  onAmountModeChange,
-}) {
+export function ZeroAmountPaymentFields({ amountState, isDisabled = false }) {
   const t = useTranslations("wallet");
+  const { currency } = useCurrency();
+  const {
+    amountInputMode, customEstimateError, customEstimateValue,
+    estimatedFiat, estimatedFiatHasError, estimatedFiatIsLoading,
+    estimatedSats, fiatToSatHasError, fiatToSatIsLoading,
+    onAmountChange, onAmountModeChange,
+  } = amountState;
+
+  const fieldLabels = {
+    title: t("payments.send.confirmModal.zeroAmountTitle"),
+    satLabel: t("payments.send.confirmModal.zeroAmountLabel"),
+    satsOptionLabel: t("payments.send.confirmModal.satsOption"),
+    satPlaceholder: t("payments.send.confirmModal.zeroAmountPlaceholder"),
+    fiatLabel: t("payments.send.confirmModal.zeroAmountFiatLabel", { currency: currency.acronym }),
+    fiatOptionLabel: t("payments.send.confirmModal.fiatOption", { currency: currency.acronym }),
+    fiatPlaceholder: t("payments.send.confirmModal.zeroAmountFiatPlaceholder"),
+    estimatedLabel: t("payments.send.confirmModal.estimatedLabel"),
+    loadingText: t("payments.send.confirmModal.fiatLoading"),
+    estimatedFiatErrorText: t("payments.send.confirmModal.fiatError"),
+    conversionErrorText: t("payments.send.confirmModal.fiatToSatsError"),
+  };
 
   return (
     <AmountUnitInputFields
-      amountInputMode={amountInputMode}
-      currencyAcronym={currencyAcronym}
-      currencyLocale={currencyLocale}
+      labels={fieldLabels}
+      amountState={{ amountInputMode, inputValue: customEstimateValue, onAmountChange, onAmountModeChange }}
+      conversionState={{ estimatedFiat, estimatedFiatHasError, estimatedFiatIsLoading, estimatedSats, fiatToSatHasError, fiatToSatIsLoading }}
       errorMessage={customEstimateError}
-      estimatedFiat={estimatedFiat}
-      estimatedFiatErrorText={t("payments.send.confirmModal.fiatError")}
-      estimatedFiatHasError={estimatedFiatHasError}
-      estimatedFiatIsLoading={estimatedFiatIsLoading}
-      estimatedLabel={t("payments.send.confirmModal.estimatedLabel")}
-      estimatedSats={estimatedSats}
-      fiatLabel={t("payments.send.confirmModal.zeroAmountFiatLabel", { currency: currencyAcronym })}
-      fiatOptionLabel={t("payments.send.confirmModal.fiatOption", { currency: currencyAcronym })}
-      fiatPlaceholder={t("payments.send.confirmModal.zeroAmountFiatPlaceholder")}
-      fiatToSatHasError={fiatToSatHasError}
-      fiatToSatIsLoading={fiatToSatIsLoading}
-      inputValue={customEstimateValue}
-      loadingText={t("payments.send.confirmModal.fiatLoading")}
-      onAmountChange={onAmountChange}
-      onAmountModeChange={onAmountModeChange}
-      satLabel={t("payments.send.confirmModal.zeroAmountLabel")}
-      satsOptionLabel={t("payments.send.confirmModal.satsOption")}
-      satPlaceholder={t("payments.send.confirmModal.zeroAmountPlaceholder")}
-      title={t("payments.send.confirmModal.zeroAmountTitle")}
-      conversionErrorText={t("payments.send.confirmModal.fiatToSatsError")}
+      isDisabled={isDisabled}
     />
   );
 }

--- a/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
@@ -72,36 +72,30 @@ export function ReceiveTab({ invoiceActions }) {
     }
   };
 
+  const fieldLabels = {
+    title: t("payments.receive.invoiceAmountTitle"),
+    satLabel: t("payments.receive.invoiceAmountSatLabel"),
+    satsOptionLabel: t("payments.receive.satsOption"),
+    satPlaceholder: t("payments.receive.invoiceAmountSatPlaceholder"),
+    fiatLabel: t("payments.receive.invoiceAmountFiatLabel", { currency: currency.acronym }),
+    fiatOptionLabel: t("payments.receive.fiatOption", { currency: currency.acronym }),
+    fiatPlaceholder: t("payments.receive.invoiceAmountFiatPlaceholder"),
+    estimatedLabel: t("payments.receive.invoiceEstimatedLabel"),
+    loadingText: t("payments.receive.invoiceFiatLoading"),
+    estimatedFiatErrorText: t("payments.receive.invoiceSatsToFiatError"),
+    conversionErrorText: t("payments.receive.invoiceFiatToSatsError"),
+  };
+
   return (
     <div className="p-6">
       <div className="mx-auto max-w-2xl space-y-5">
         <div id="wallet-receive-amount" className="mx-auto w-full max-w-xl">
           <AmountUnitInputFields
-            amountInputMode={amountInputMode}
-            currencyAcronym={currency.acronym}
-            currencyLocale={currency.locale}
+            labels={fieldLabels}
+            amountState={{ amountInputMode, inputValue: customEstimateValue, onAmountChange: handleAmountChange, onAmountModeChange: handleAmountModeChange }}
+            conversionState={{ estimatedFiat, estimatedFiatHasError, estimatedFiatIsLoading, estimatedSats, fiatToSatHasError, fiatToSatIsLoading }}
             errorMessage={customEstimateError}
-            estimatedFiat={estimatedFiat}
-            estimatedFiatErrorText={t("payments.receive.invoiceSatsToFiatError")}
-            estimatedFiatHasError={estimatedFiatHasError}
-            estimatedFiatIsLoading={estimatedFiatIsLoading}
-            estimatedLabel={t("payments.receive.invoiceEstimatedLabel")}
-            estimatedSats={estimatedSats}
-            fiatLabel={t("payments.receive.invoiceAmountFiatLabel", { currency: currency.acronym })}
-            fiatOptionLabel={t("payments.receive.fiatOption", { currency: currency.acronym })}
-            fiatPlaceholder={t("payments.receive.invoiceAmountFiatPlaceholder")}
-            fiatToSatHasError={fiatToSatHasError}
-            fiatToSatIsLoading={fiatToSatIsLoading}
-            inputValue={customEstimateValue}
             isDisabled={isLoading}
-            loadingText={t("payments.receive.invoiceFiatLoading")}
-            onAmountChange={handleAmountChange}
-            onAmountModeChange={handleAmountModeChange}
-            satLabel={t("payments.receive.invoiceAmountSatLabel")}
-            satsOptionLabel={t("payments.receive.satsOption")}
-            satPlaceholder={t("payments.receive.invoiceAmountSatPlaceholder")}
-            title={t("payments.receive.invoiceAmountTitle")}
-            conversionErrorText={t("payments.receive.invoiceFiatToSatsError")}
           />
         </div>
         <div id="wallet-receive-description" className="mx-auto w-full max-w-xl">

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/ZeroAmountPaymentFields.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/ZeroAmountPaymentFields.test.jsx
@@ -4,11 +4,15 @@ import { I18nProvider } from "@i18n/I18nProvider";
 
 import { ZeroAmountPaymentFields } from "../Payment/ZeroAmountPaymentFields";
 
-function renderZeroAmountPaymentFields(props = {}) {
-  const defaultProps = {
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: () => ({
+    currency: { acronym: "USD", symbol: "$", locale: "en-US" },
+  }),
+}));
+
+function renderZeroAmountPaymentFields(amountStateOverrides = {}) {
+  const defaultAmountState = {
     amountInputMode: "sat",
-    currencyAcronym: "USD",
-    currencyLocale: "en-US",
     customEstimateError: "",
     customEstimateValue: "",
     estimatedFiat: null,
@@ -23,7 +27,7 @@ function renderZeroAmountPaymentFields(props = {}) {
 
   return render(
     <I18nProvider>
-      <ZeroAmountPaymentFields {...defaultProps} {...props} />
+      <ZeroAmountPaymentFields amountState={{ ...defaultAmountState, ...amountStateOverrides }} />
     </I18nProvider>,
   );
 }
@@ -69,11 +73,7 @@ describe("ZeroAmountPaymentFields", () => {
   });
 
   it("renders fiat labels and estimated sats when in fiat mode", () => {
-    renderZeroAmountPaymentFields({
-      amountInputMode: "fiat",
-      customEstimateValue: "1.5",
-      estimatedSats: 5000,
-    });
+    renderZeroAmountPaymentFields({ amountInputMode: "fiat", customEstimateValue: "1.5", estimatedSats: 5000 });
 
     expect(screen.getByLabelText("payments.send.confirmModal.zeroAmountFiatLabel")).toBeInTheDocument();
     expect(screen.getByText("payments.send.confirmModal.estimatedLabel")).toBeInTheDocument();
@@ -81,22 +81,14 @@ describe("ZeroAmountPaymentFields", () => {
   });
 
   it("renders 0 sats when fiat mode has no estimated value yet", () => {
-    renderZeroAmountPaymentFields({
-      amountInputMode: "fiat",
-      customEstimateValue: "",
-      estimatedSats: null,
-    });
+    renderZeroAmountPaymentFields({ amountInputMode: "fiat", customEstimateValue: "", estimatedSats: null });
 
     expect(screen.getByText("payments.send.confirmModal.estimatedLabel")).toBeInTheDocument();
     expect(screen.getByText("0 sats")).toBeInTheDocument();
   });
 
   it("renders fiat estimate when sat mode has a converted value", () => {
-    renderZeroAmountPaymentFields({
-      amountInputMode: "sat",
-      customEstimateValue: "1000",
-      estimatedFiat: 1.5,
-    });
+    renderZeroAmountPaymentFields({ amountInputMode: "sat", customEstimateValue: "1000", estimatedFiat: 1.5 });
 
     expect(screen.getByText("payments.send.confirmModal.estimatedLabel")).toBeInTheDocument();
     expect(screen.getByText("$1.50")).toBeInTheDocument();


### PR DESCRIPTION
## Changes:
- Refactor `AmountUnitInputFields`, `ZeroAmountPaymentFields`, and `CloseChannel/ModalForm` to group related props into objects and move `useCurrency`/`useTranslations` inside components
- Refactor `SummaryContent` to group `btcPayment`, `cashPayment`, and `cardPayment` props into objects
- Refactor `PrintersCard`, `PrinterAddForm`, and `PrinterConfigRow` to group props into `formState`, `data`, `loading`, and `state` objects, and move `useTranslations` inside components
- Refactor `OrdersFilterBar` to group `search` and `pagination` props into objects
- Fix test suite noise: remove `act()` warnings in `useReports` tests, filter Next.js-specific props in global image mock, and fix Next.js Image aspect ratio warning in Sidebar