### PR TITLE
fix silent refresh error and /auth/refresh race condition. Remove isL…

### DIFF
--- a/client/src/hooks/useNavigation.jsx
+++ b/client/src/hooks/useNavigation.jsx
@@ -12,15 +12,9 @@ export function useNavigation() {
   const isAdmin = user?.isAdmin || false;
   const { businessType } = useConfigurations();
 
-  const availableFeatures = useMemo(() => {
-    if (isLoading) return {};
-    return getAvailableFeatures(isAuth, isAdmin, permissions, businessType);
-  }, [isAuth, isAdmin, isLoading, permissions, businessType]);
+  const availableFeatures = useMemo(() => getAvailableFeatures(isAuth, isAdmin, permissions, businessType), [isAuth, isAdmin, permissions, businessType]);
 
-  const availableNavigation = useMemo(() => {
-    if (isLoading) return [];
-    return getAvailableNavigation(isAuth, isAdmin, permissions, businessType);
-  }, [isAuth, isAdmin, isLoading, permissions, businessType]);
+  const availableNavigation = useMemo(() => getAvailableNavigation(isAuth, isAdmin, permissions, businessType), [isAuth, isAdmin, permissions, businessType]);
 
   return {
     availableFeatures,

--- a/client/src/lib/http/httpClient.js
+++ b/client/src/lib/http/httpClient.js
@@ -1,5 +1,15 @@
 import { httpWrapper } from "./httpWrapper";
 
+let refreshPromise = null;
+
+async function refreshToken() {
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = httpWrapper("/auth/refresh", { method: "POST" }).finally(() => {
+    refreshPromise = null;
+  });
+  return refreshPromise;
+}
+
 export async function httpClient(endpoint, options = {}) {
   const { skipRefresh = false, ...httpOptions } = options;
 
@@ -13,9 +23,7 @@ export async function httpClient(endpoint, options = {}) {
   const response = await httpWrapper(endpoint, httpOptions);
 
   if (shouldRefreshToken(response.status, endpoint, skipRefresh)) {
-    const refreshResponse = await httpWrapper("/auth/refresh", {
-      method: "POST",
-    });
+    const refreshResponse = await refreshToken();
 
     if (refreshResponse.status === 401) {
       window.dispatchEvent(new Event("auth:expired"));

--- a/client/src/providers/auth/AuthProvider.jsx
+++ b/client/src/providers/auth/AuthProvider.jsx
@@ -33,7 +33,7 @@ export function AuthProvider({ children }) {
       return session;
     } catch (error) {
       if (isMountedRef.current) {
-        dispatch({ type: "INIT_ERROR", payload: error });
+        dispatch({ type: silent ? "SILENT_REFRESH_ERROR" : "INIT_ERROR", payload: error });
       }
       return null;
     } finally {

--- a/client/src/reducers/auth/authReducer.js
+++ b/client/src/reducers/auth/authReducer.js
@@ -28,6 +28,8 @@ function authReducer(state, action) {
         isLoading: false,
         error: action.payload || null,
       };
+    case "SILENT_REFRESH_ERROR":
+      return { ...state, error: action.payload || null };
     case "LOGIN_SUCCESS":
       return {
         ...state,


### PR DESCRIPTION
## Changes:
- Fix nav items disappearing during use: silent refresh errors (`focus`/`visibilitychange`) no longer reset auth state — a new `SILENT_REFRESH_ERROR` action preserves `isAuth` and `permissions` on transient network failures
- Fix race condition on token expiry: concurrent requests sharing an expired token now share a single `/auth/refresh` call via a module-level promise mutex, preventing a second refresh attempt from dispatching a false `auth:expired` event
- Remove redundant `isLoading` guard from `useNavigation` that was blanking the nav unnecessarily when `isLoading` and `isAuth` were both true simultaneously

**Related Issues**:
https://github.com/olympus-btc/ambrosia/issues/523