### PR TITLE
Fix (client): backend down resilience

### DIFF
--- a/client/src/components/pages/Store/Cart/hooks/__tests__/usePaymentMethod.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/usePaymentMethod.test.jsx
@@ -9,6 +9,15 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 function TestComponent() {
   const { paymentMethods, loading, error } = usePaymentMethods();
   return (
@@ -26,7 +35,7 @@ describe("usePaymentMethods", () => {
   });
 
   it("loads payment methods when response returns array", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
     render(<TestComponent />);
 
@@ -36,7 +45,7 @@ describe("usePaymentMethods", () => {
   });
 
   it("sets empty list when response returns non-array", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ data: [] });
     render(<TestComponent />);
 

--- a/client/src/components/pages/Store/Cart/hooks/usePaymentMethod.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/usePaymentMethod.jsx
@@ -1,9 +1,10 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
 
-import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function usePaymentMethods() {
+  const { fetchList } = useFetchList();
   const [paymentMethods, setPaymentMethods] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -13,10 +14,8 @@ export function usePaymentMethods() {
     setError(null);
 
     try {
-      const paymentMethodsResponse = await httpClient("/payments/methods");
-
-      const paymentMethodsData = await parseJsonResponse(paymentMethodsResponse, []);
-
+      const paymentMethodsData = await fetchList("/payments/methods");
+      if (paymentMethodsData === null) return;
       if (Array.isArray(paymentMethodsData)) {
         const sorted = [...paymentMethodsData].sort((a, b) => {
           const nameA = a?.name || "";
@@ -33,7 +32,7 @@ export function usePaymentMethods() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   useEffect(() => {
     fetchPaymentMethods();

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -11,6 +11,15 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 const handlers = {};
 
 function TestComponent() {
@@ -50,7 +59,7 @@ describe("useCategories", () => {
   });
 
   it("loads categories on mount", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([
       { id: "cat-1", name: "Hardware" },
       { id: "cat-2", name: "Gadgets" },
@@ -66,7 +75,7 @@ describe("useCategories", () => {
   });
 
   it("sets empty categories when api returns non-array", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(null);
 
     render(<TestComponent />);
@@ -85,7 +94,7 @@ describe("useCategories", () => {
   });
 
   it("creates a category, refetches, and returns the new id", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "cat-3", message: "Category added successfully" });
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-3", name: "Electronics" }]);
@@ -109,7 +118,7 @@ describe("useCategories", () => {
   });
 
   it("creates a category with an explicit type override", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "cat-4", message: "Category added successfully" });
     parseJsonResponse.mockResolvedValueOnce([]);
@@ -127,7 +136,7 @@ describe("useCategories", () => {
   });
 
   it("updates a category and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware Updated" }]);
 
@@ -147,7 +156,7 @@ describe("useCategories", () => {
   });
 
   it("deletes a category and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);
     parseJsonResponse.mockResolvedValueOnce([]);
 

--- a/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
@@ -11,6 +11,16 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+const mockAddToast = jest.fn();
+jest.mock("@heroui/react", () => ({
+  addToast: (...args) => mockAddToast(...args),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 const handlers = {};
 
 function TestComponent() {
@@ -33,15 +43,10 @@ function TestComponent() {
 describe("useOrders", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   it("loads orders on mount", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
     render(<TestComponent />);
 
@@ -60,7 +65,7 @@ describe("useOrders", () => {
   });
 
   it("sets empty orders when apiClient returns non-array", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ data: [] });
     render(<TestComponent />);
 
@@ -69,7 +74,7 @@ describe("useOrders", () => {
   });
 
   it("fetchOrdersFiltered sends status query params", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -85,7 +90,7 @@ describe("useOrders", () => {
   });
 
   it("fetchOrdersFiltered sends sorting query params", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -101,7 +106,7 @@ describe("useOrders", () => {
   });
 
   it("fetchOrdersFiltered omits empty params", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -116,17 +121,22 @@ describe("useOrders", () => {
     expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments");
   });
 
-  it("sets error when filtered fetch returns non-ok response", async () => {
-    httpClient.mockResolvedValueOnce({});
+  it("shows connection toast and returns null when filtered fetch returns non-ok response", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
     httpClient.mockResolvedValueOnce({ ok: false });
     parseJsonResponse.mockResolvedValueOnce([]);
-    parseJsonResponse.mockResolvedValueOnce({ message: "bad request" });
 
     render(<TestComponent />);
 
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
 
-    await expect(handlers.fetchOrdersFiltered({ status: "paid" })).rejects.toThrow("bad request");
-    await waitFor(() => expect(screen.getByTestId("error")).toHaveTextContent("yes"));
+    let result;
+    await act(async () => {
+      result = await handlers.fetchOrdersFiltered({ status: "paid" });
+    });
+
+    expect(result).toBeNull();
+    expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ color: "danger" }));
+    expect(screen.getByTestId("error")).toHaveTextContent("no");
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
@@ -1,0 +1,129 @@
+import { act, useEffect } from "react";
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+import { usePayments } from "../usePayments";
+
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
+const handlers = {};
+
+function TestComponent() {
+  const { payments, loading, error, refetch, getPaymentCurrencyById } = usePayments();
+
+  useEffect(() => {
+    handlers.refetch = refetch;
+    handlers.getPaymentCurrencyById = getPaymentCurrencyById;
+  }, [refetch, getPaymentCurrencyById]);
+
+  return (
+    <div>
+      <span data-testid="loading">{loading ? "yes" : "no"}</span>
+      <span data-testid="count">{payments.length}</span>
+      <span data-testid="first-payment">{payments[0]?.id ?? ""}</span>
+      <span data-testid="error">{error ? "yes" : "no"}</span>
+    </div>
+  );
+}
+
+describe("usePayments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads payments on mount", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: "p1" }, { id: "p2" }]);
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+    expect(screen.getByTestId("first-payment")).toHaveTextContent("p1");
+  });
+
+  it("sets empty payments when response is null", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("returns null and shows no toast when connection fails", async () => {
+    const { addToast } = require("@heroui/react");
+    httpClient.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ color: "danger" }),
+    );
+  });
+
+  it("refetches payments", async () => {
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: "p1" }]);
+    parseJsonResponse.mockResolvedValueOnce([{ id: "p1" }, { id: "p2" }]);
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await act(async () => {
+      await handlers.refetch();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("2"));
+  });
+
+  it("fetches payment currency by id", async () => {
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+    parseJsonResponse.mockResolvedValueOnce({ id: "c1", acronym: "USD" });
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+
+    let result;
+    await act(async () => {
+      result = await handlers.getPaymentCurrencyById("c1");
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/payments/currencies/c1");
+    expect(result).toEqual({ id: "c1", acronym: "USD" });
+  });
+
+  it("returns null when getPaymentCurrencyById called with no id", async () => {
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+
+    let result;
+    await act(async () => {
+      result = await handlers.getPaymentCurrencyById(null);
+    });
+
+    expect(result).toBeNull();
+    expect(httpClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
@@ -11,6 +11,15 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 const handlers = {};
 
 function TestComponent() {
@@ -82,7 +91,7 @@ describe("usePrinters", () => {
   });
 
   it("loads printers and configs on mount", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(["Printer A"]);
     parseJsonResponse.mockResolvedValueOnce([{ id: "cfg-1" }]);
 
@@ -96,7 +105,7 @@ describe("usePrinters", () => {
   });
 
   it("sets empty lists when apiClient returns non-array values", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(null);
 
@@ -122,7 +131,7 @@ describe("usePrinters", () => {
   });
 
   it("creates a printer config and appends it", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "cfg-9" });
@@ -150,7 +159,7 @@ describe("usePrinters", () => {
   });
 
   it("updates a printer config in state", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([
       { id: "cfg-1", printerName: "Old", printerType: "KITCHEN" },
@@ -176,7 +185,7 @@ describe("usePrinters", () => {
   });
 
   it("deletes a printer config from state", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([
       { id: "cfg-1", printerName: "A" },
@@ -199,7 +208,7 @@ describe("usePrinters", () => {
   });
 
   it("sets default printer config for a type", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([
       { id: "cfg-1", printerName: "A", printerType: "KITCHEN", isDefault: true },
@@ -222,7 +231,7 @@ describe("usePrinters", () => {
   });
 
   it("validates required args when setting default by name", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -237,7 +246,7 @@ describe("usePrinters", () => {
   });
 
   it("prints a ticket with the provided body", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -260,7 +269,7 @@ describe("usePrinters", () => {
   });
 
   it("refetches all printer data", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
@@ -366,7 +375,7 @@ describe("usePrinters", () => {
   });
 
   it("keeps defaults when config id is not found", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([
       { id: "cfg-1", printerName: "A", printerType: "KITCHEN", isDefault: true },

--- a/client/src/components/pages/Store/hooks/__tests__/useProducts.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useProducts.test.jsx
@@ -70,7 +70,7 @@ describe("useProducts", () => {
 
   it("loads products on mount", async () => {
     useUpload.mockReturnValue({ upload: jest.fn(), isUploading: false });
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
 
     renderWithProvider();
@@ -82,7 +82,7 @@ describe("useProducts", () => {
 
   it("sets empty products when apiClient returns non-array", async () => {
     useUpload.mockReturnValue({ upload: jest.fn(), isUploading: false });
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ data: [] });
 
     renderWithProvider();

--- a/client/src/components/pages/Store/hooks/__tests__/useRoles.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useRoles.test.jsx
@@ -11,6 +11,15 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 jest.mock("@/hooks/usePermission", () => ({
   usePermission: () => true,
 }));
@@ -44,7 +53,7 @@ describe("useRoles", () => {
   });
 
   it("loads roles on mount", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "1", role: "cashier" }]);
 
     render(<TestComponent />);
@@ -55,7 +64,7 @@ describe("useRoles", () => {
   });
 
   it("sets empty roles when response is null", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(null);
 
     render(<TestComponent />);
@@ -65,7 +74,7 @@ describe("useRoles", () => {
   });
 
   it("creates a role without permissions and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "abc" });
     parseJsonResponse.mockResolvedValueOnce([{ id: "abc", role: "seller" }]);
@@ -86,7 +95,7 @@ describe("useRoles", () => {
   });
 
   it("creates a role with password and permissions", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "xyz" });
     parseJsonResponse.mockResolvedValueOnce([]);
@@ -111,7 +120,7 @@ describe("useRoles", () => {
   });
 
   it("updates role with permissions and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "1", role: "cashier" }]);
     parseJsonResponse.mockResolvedValueOnce([{ id: "1", role: "updated" }]);
 
@@ -139,7 +148,7 @@ describe("useRoles", () => {
   });
 
   it("deletes a role and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "1", role: "cashier" }]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -155,7 +164,7 @@ describe("useRoles", () => {
   });
 
   it("throws conflict when deleting role is rejected", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "1", role: "admin" }]);
     httpClient.mockResolvedValueOnce({ ok: false, status: 409 });
 
@@ -175,7 +184,7 @@ describe("useRoles", () => {
   });
 
   it("fetches role permissions by id", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([{ name: "orders_read" }, { name: "products_read" }]);
 
@@ -192,7 +201,7 @@ describe("useRoles", () => {
   });
 
   it("returns empty array when getRolePermissions called with no id", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
 
     render(<TestComponent />);
@@ -207,7 +216,7 @@ describe("useRoles", () => {
   });
 
   it("does nothing when assignPermissions called with no roleId", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
 
     render(<TestComponent />);

--- a/client/src/components/pages/Store/hooks/__tests__/useTemplates.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useTemplates.test.jsx
@@ -11,6 +11,15 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
 const handlers = {};
 
 function TestComponent() {
@@ -50,7 +59,7 @@ describe("useTemplates", () => {
   });
 
   it("loads templates on mount", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "t1", name: "Default" }]);
 
     render(<TestComponent />);
@@ -62,7 +71,7 @@ describe("useTemplates", () => {
   });
 
   it("sets empty templates when apiClient returns non-array", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ ok: true });
 
     render(<TestComponent />);
@@ -83,7 +92,7 @@ describe("useTemplates", () => {
   });
 
   it("creates a template and appends it", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce({ id: "t-2" });
 
@@ -107,7 +116,7 @@ describe("useTemplates", () => {
   });
 
   it("updates a template in state", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "t-1", name: "Old" }]);
 
     render(<TestComponent />);
@@ -130,7 +139,7 @@ describe("useTemplates", () => {
   });
 
   it("deletes a template from state", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([
       { id: "t-1", name: "A" },
       { id: "t-2", name: "B" },
@@ -152,7 +161,7 @@ describe("useTemplates", () => {
   });
 
   it("validates template id for update and delete", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
 
     render(<TestComponent />);

--- a/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
@@ -16,9 +16,10 @@ jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
 }));
 
-jest.mock("next-intl", () => ({
-  useTranslations: () => (key) => key,
-}));
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
 
 const handlers = {};
 
@@ -47,7 +48,7 @@ describe("useUsers", () => {
   });
 
   it("loads users on mount", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 1, name: "Ana" }]);
     render(<TestComponent />);
 
@@ -57,7 +58,7 @@ describe("useUsers", () => {
   });
 
   it("sets empty users when apiClient returns null", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(null);
     render(<TestComponent />);
 
@@ -66,7 +67,7 @@ describe("useUsers", () => {
   });
 
   it("adds a user and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
     parseJsonResponse.mockResolvedValueOnce([{ id: 9, name: "Luis" }]);
 
@@ -85,7 +86,7 @@ describe("useUsers", () => {
       });
     });
 
-    expect(response).toEqual({});
+    expect(response).toEqual({ ok: true });
     expect(httpClient).toHaveBeenCalledWith("/users", {
       method: "POST",
       headers: {
@@ -104,7 +105,7 @@ describe("useUsers", () => {
   });
 
   it("updates a user and includes pin when provided", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 3, name: "Paula" }]);
     parseJsonResponse.mockResolvedValueOnce([{ id: 3, name: "Paula" }]);
     parseJsonResponse.mockResolvedValueOnce({ id: 3, name: "Paula" });
@@ -140,7 +141,7 @@ describe("useUsers", () => {
   });
 
   it("updates a user without pin when blank", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 4, name: "Rosa" }]);
     parseJsonResponse.mockResolvedValueOnce([{ id: 4, name: "Rosa" }]);
     parseJsonResponse.mockResolvedValueOnce({ id: 4, name: "Rosa" });
@@ -175,7 +176,7 @@ describe("useUsers", () => {
   });
 
   it("deletes a user and refetches", async () => {
-    httpClient.mockResolvedValue({});
+    httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 6, name: "Tomas" }]);
     parseJsonResponse.mockResolvedValueOnce([]);
 
@@ -193,7 +194,7 @@ describe("useUsers", () => {
   });
 
   it("shows last admin toast when deleting user returns conflict", async () => {
-    httpClient.mockResolvedValueOnce({});
+    httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 6, name: "Tomas" }]);
     httpClient.mockResolvedValueOnce({ ok: false, status: 409 });
     parseJsonResponse.mockResolvedValueOnce({ message: "Cannot remove the last admin user" });

--- a/client/src/components/pages/Store/hooks/useCategories.jsx
+++ b/client/src/components/pages/Store/hooks/useCategories.jsx
@@ -3,8 +3,10 @@ import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function useCategories(type = "product") {
+  const { fetchList } = useFetchList();
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -14,8 +16,8 @@ export function useCategories(type = "product") {
     setError(null);
 
     try {
-      const response = await httpClient(`/categories?type=${type}`);
-      const categoryList = await parseJsonResponse(response, []);
+      const categoryList = await fetchList(`/categories?type=${type}`);
+      if (categoryList === null) return;
       setCategories(toArray(categoryList));
     } catch (error) {
       console.error("Error fetching categories:", error);
@@ -23,7 +25,7 @@ export function useCategories(type = "product") {
     } finally {
       setLoading(false);
     }
-  }, [type]);
+  }, [fetchList, type]);
 
   const createCategory = useCallback(
     async (name, categoryType) => {

--- a/client/src/components/pages/Store/hooks/useOrders.jsx
+++ b/client/src/components/pages/Store/hooks/useOrders.jsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
-import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 function buildOrdersQueryString(filters = {}) {
   const queryParams = new URLSearchParams();
@@ -30,6 +30,7 @@ function buildOrdersQueryString(filters = {}) {
 }
 
 export function useOrders() {
+  const { fetchList } = useFetchList();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -40,30 +41,21 @@ export function useOrders() {
 
     try {
       const endpoint = buildOrdersQueryString(filters);
-      const ordersResponse = await httpClient(endpoint);
-      if (ordersResponse?.ok === false) {
-        const errorResponse = await parseJsonResponse(ordersResponse, null);
-        throw new Error(errorResponse?.message || "Failed to fetch orders");
-      }
-      const ordersData = await parseJsonResponse(ordersResponse, []);
+      const ordersData = await fetchList(endpoint);
+      if (ordersData === null) return null;
       setOrders(toArray(ordersData));
       return toArray(ordersData);
-    } catch (error) {
-      console.error("Error fetching orders:", error);
-      setError(error);
+    } catch (err) {
+      setError(err);
       setOrders([]);
-      throw error;
+      return null;
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const fetchOrders = useCallback(async () => {
-    try {
-      await fetchOrdersRequest();
-    } catch {
-      return [];
-    }
+    await fetchOrdersRequest();
   }, [fetchOrdersRequest]);
 
   const fetchOrdersFiltered = useCallback(

--- a/client/src/components/pages/Store/hooks/usePayments.jsx
+++ b/client/src/components/pages/Store/hooks/usePayments.jsx
@@ -3,8 +3,10 @@ import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function usePayments() {
+  const { fetchList } = useFetchList();
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -13,8 +15,8 @@ export function usePayments() {
     setLoading(true);
     setError(null);
     try {
-      const payments = await httpClient("/payments");
-      const paymentsData = await parseJsonResponse(payments, []);
+      const paymentsData = await fetchList("/payments");
+      if (paymentsData === null) return;
       setPayments(toArray(paymentsData));
     } catch (error) {
       console.error("Error fetching payments:", error);
@@ -22,7 +24,7 @@ export function usePayments() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const getPaymentCurrencyById = useCallback(
     async (currencyId) => {

--- a/client/src/components/pages/Store/hooks/usePrinter.jsx
+++ b/client/src/components/pages/Store/hooks/usePrinter.jsx
@@ -3,8 +3,10 @@ import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function usePrinters() {
+  const { fetchList } = useFetchList();
   const [loadingAvailable, setLoadingAvailable] = useState(true);
   const [loadingConfigs, setLoadingConfigs] = useState(true);
   const [error, setError] = useState(null);
@@ -16,8 +18,8 @@ export function usePrinters() {
     setError(null);
 
     try {
-      const printers = await httpClient("/printers/available");
-      const printersData = await parseJsonResponse(printers, []);
+      const printersData = await fetchList("/printers/available");
+      if (printersData === null) return;
       setAvailablePrinters(toArray(printersData));
     } catch (error) {
       console.error("Error fetching printers:", error);
@@ -25,15 +27,15 @@ export function usePrinters() {
     } finally {
       setLoadingAvailable(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const fetchPrinterConfigs = useCallback(async () => {
     setLoadingConfigs(true);
     setError(null);
 
     try {
-      const printerConfigs = await httpClient("/printers/configs");
-      const printerDataConfigs = await parseJsonResponse(printerConfigs, []);
+      const printerDataConfigs = await fetchList("/printers/configs");
+      if (printerDataConfigs === null) return;
       setPrinterConfigs(toArray(printerDataConfigs));
     } catch (error) {
       console.error("Error fetching printer configs:", error);
@@ -41,7 +43,7 @@ export function usePrinters() {
     } finally {
       setLoadingConfigs(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const createPrinterConfig = useCallback(async (configBody) => {
     try {

--- a/client/src/components/pages/Store/hooks/useProducts.jsx
+++ b/client/src/components/pages/Store/hooks/useProducts.jsx
@@ -7,9 +7,11 @@ import { useTranslations } from "next-intl";
 import { useUpload } from "@/components/hooks/useUpload";
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function useProducts() {
   const t = useTranslations("products");
+  const { fetchList } = useFetchList();
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -72,8 +74,8 @@ export function useProducts() {
     setError(null);
 
     try {
-      const response = await httpClient("/products");
-      const productsData = await parseJsonResponse(response, []);
+      const productsData = await fetchList("/products");
+      if (productsData === null) return;
       setProducts(toArray(productsData));
     } catch (error) {
       console.error("Error fetching products:", error);
@@ -81,7 +83,7 @@ export function useProducts() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const addProduct = async (product) => {
     try {

--- a/client/src/components/pages/Store/hooks/useRoles.jsx
+++ b/client/src/components/pages/Store/hooks/useRoles.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { toArray } from "@/components/utils/array";
 import { usePermission } from "@/hooks/usePermission";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 function createHttpStatusError(response, errorMessage) {
   const requestError = new Error(errorMessage);
@@ -18,6 +19,7 @@ function ensureSuccessfulResponse(response, errorMessage) {
 }
 
 export function useRoles() {
+  const { fetchList } = useFetchList();
   const [roles, setRoles] = useState([]);
   const canRead = usePermission({ allOf: ["roles_read"] });
   const [loading, setLoading] = useState(canRead);
@@ -29,15 +31,15 @@ export function useRoles() {
     setError(null);
 
     try {
-      const rolesRequest = await httpClient("/roles");
-      const rolesData = await parseJsonResponse(rolesRequest, []);
+      const rolesData = await fetchList("/roles");
+      if (rolesData === null) return;
       setRoles(toArray(rolesData));
     } catch (error) {
       console.error("Error fetching roles:", error);
     } finally {
       setLoading(false);
     }
-  }, [canRead]);
+  }, [canRead, fetchList]);
 
   const updateRole = useCallback(async (roleId, role) => {
     try {

--- a/client/src/components/pages/Store/hooks/useTemplates.jsx
+++ b/client/src/components/pages/Store/hooks/useTemplates.jsx
@@ -3,8 +3,10 @@ import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 export function useTemplates() {
+  const { fetchList } = useFetchList();
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -13,8 +15,8 @@ export function useTemplates() {
     setLoading(true);
     setError(null);
     try {
-      const templates = await httpClient("/templates");
-      const templatesData = await parseJsonResponse(templates, []);
+      const templatesData = await fetchList("/templates");
+      if (templatesData === null) return;
       setTemplates(toArray(templatesData));
     } catch (error) {
       console.error("Error fetching templates:", error);
@@ -22,7 +24,7 @@ export function useTemplates() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const createTemplate = useCallback(async (templateBody) => {
     try {

--- a/client/src/components/pages/Store/hooks/useUsers.jsx
+++ b/client/src/components/pages/Store/hooks/useUsers.jsx
@@ -4,7 +4,9 @@ import { useState, useEffect, useCallback } from "react";
 import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
+import { useFetchList } from "@/lib/http/useFetchList";
 
 async function buildHttpRequestError(response, fallbackMessage) {
   const responsePayload = await parseJsonResponse(response, null);
@@ -20,6 +22,7 @@ function isLastAdminConflict(requestError) {
 
 export function useUsers() {
   const t = useTranslations("users");
+  const { fetchList } = useFetchList();
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -50,18 +53,13 @@ export function useUsers() {
     setError(null);
 
     try {
-      const users = await httpClient("/users");
-      const usersData = await parseJsonResponse(users, []);
-
-      if (usersData === null) {
-        setUsers([]);
-      } else {
-        setUsers(usersData);
-      }
+      const usersData = await fetchList("/users");
+      if (usersData === null) return;
+      setUsers(toArray(usersData));
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchList]);
 
   const updateUser = async (user) => {
     try {

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -7,6 +7,10 @@ import usersEn from "../Users/locales/en";
 import walletEn from "../Wallet/locales/en";
 
 const storeEn = {
+  errors: {
+    connectionErrorTitle: "Connection error",
+    connectionErrorDescription: "Could not reach the server. Please check your connection.",
+  },
   navbar: {
     users: "Users",
     roles: "Roles",

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -7,6 +7,10 @@ import usersEs from "../Users/locales/es";
 import walletEs from "../Wallet/locales/es";
 
 const storeEs = {
+  errors: {
+    connectionErrorTitle: "Error de conexión",
+    connectionErrorDescription: "No se pudo conectar al servidor. Verifica tu conexión.",
+  },
   navbar: {
     users: "Usuarios",
     roles: "Roles",

--- a/client/src/lib/http/__tests__/useFetchList.test.js
+++ b/client/src/lib/http/__tests__/useFetchList.test.js
@@ -1,0 +1,96 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+import { useFetchList } from "../useFetchList";
+
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+const mockAddToast = jest.fn();
+jest.mock("@heroui/react", () => ({
+  addToast: (...args) => mockAddToast(...args),
+}));
+
+jest.mock("next-intl", () => {
+  const t = (key) => key;
+  return { useTranslations: () => t };
+});
+
+describe("useFetchList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns parsed data when response is ok", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: 1 }]);
+
+    const { result } = renderHook(() => useFetchList());
+
+    let data;
+    await act(async () => {
+      data = await result.current.fetchList("/items");
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/items");
+    expect(data).toEqual([{ id: 1 }]);
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it("returns null and shows toast when response is not ok", async () => {
+    httpClient.mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() => useFetchList());
+
+    let data;
+    await act(async () => {
+      data = await result.current.fetchList("/items");
+    });
+
+    expect(data).toBeNull();
+    expect(mockAddToast).toHaveBeenCalledWith({
+      title: "connectionErrorTitle",
+      description: "connectionErrorDescription",
+      color: "danger",
+    });
+    expect(parseJsonResponse).not.toHaveBeenCalled();
+  });
+
+  it("uses the provided fallback when response is ok but data is empty", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useFetchList());
+
+    let data;
+    await act(async () => {
+      data = await result.current.fetchList("/items", []);
+    });
+
+    expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, []);
+    expect(data).toBeNull();
+  });
+
+  it("defaults fallback to empty array", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useFetchList());
+
+    await act(async () => {
+      await result.current.fetchList("/items");
+    });
+
+    expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, []);
+  });
+
+  it("returns a stable fetchList reference between renders", () => {
+    const { result, rerender } = renderHook(() => useFetchList());
+    const first = result.current.fetchList;
+    rerender();
+    expect(result.current.fetchList).toBe(first);
+  });
+});

--- a/client/src/lib/http/useFetchList.js
+++ b/client/src/lib/http/useFetchList.js
@@ -1,0 +1,26 @@
+"use client";
+import { useCallback } from "react";
+
+import { addToast } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { httpClient, parseJsonResponse } from "./index";
+
+export function useFetchList() {
+  const tErrors = useTranslations("errors");
+
+  const fetchList = useCallback(async (url, fallback = []) => {
+    const listResponse = await httpClient(url);
+    if (!listResponse.ok) {
+      addToast({
+        title: tErrors("connectionErrorTitle"),
+        description: tErrors("connectionErrorDescription"),
+        color: "danger",
+      });
+      return null;
+    }
+    return parseJsonResponse(listResponse, fallback);
+  }, [tErrors]);
+
+  return { fetchList };
+}


### PR DESCRIPTION
## Changes:
- Extract `useFetchList` hook (`src/lib/http/useFetchList.js`) that centralizes `response.ok` check, danger toast on connection error, and JSON parsing — preventing crashes and silent failures when the backend is down
- Add shared `errors` locale namespace in Store locales (en/es) for connection error messages
- Migrate all data-fetching hooks to `useFetchList`: `usePaymentMethod`, `useCategories`, `useProducts`, `useUsers`, `useRoles`, `useTemplates`, `usePayments`, `useOrders`, `usePrinter`
- Add tests for `useFetchList` and `usePayments`