### PR TITLE
Feature: add product images in products, summary and cart

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -100,6 +100,7 @@ export function Cart() {
         cart.map((item) => (item.id === product.id
           ? {
               ...item,
+              imageUrl: item.imageUrl ?? product.imageUrl,
               quantity: item.quantity + 1,
               subtotal: (item.quantity + 1) * item.price,
             }
@@ -111,6 +112,7 @@ export function Cart() {
         ...cart,
         {
           id: product.id,
+          imageUrl: product.imageUrl,
           name: product.name,
           price: product.priceCents,
           quantity: 1,

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -47,13 +47,13 @@ export function ProductList({ products, onAddProduct, categories }) {
             className="bg-white rounded-lg"
             key={product.id}
           >
-            <div className="h-28 md:h-36 bg-gray-100 rounded-t-lg overflow-hidden flex items-center justify-center">
+            <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
               {imageUrl ? (
                 <Image
                   removeWrapper
                   alt={product.name}
                   src={imageUrl}
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-cover rounded-none"
                 />
               ) : (
                 <div data-testid={`product-image-placeholder-${product.id}`}>

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -1,7 +1,9 @@
-import { Button, Card, CardBody, CardFooter, CardHeader, Chip } from "@heroui/react";
+import { Button, Card, CardBody, CardFooter, CardHeader, Chip, Image } from "@heroui/react";
+import { ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
+import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
 export function ProductList({ products, onAddProduct, categories }) {
   const t = useTranslations("cart");
@@ -38,12 +40,27 @@ export function ProductList({ products, onAddProduct, categories }) {
     <div className="grid grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4">
       {products.map((product) => {
         const status = stockStatus(product);
+        const imageUrl = storedAssetUrl(product.imageUrl);
         return (
           <Card
             shadow="none"
             className="bg-white rounded-lg"
             key={product.id}
           >
+            <div className="h-28 md:h-36 bg-gray-100 rounded-t-lg overflow-hidden flex items-center justify-center">
+              {imageUrl ? (
+                <Image
+                  removeWrapper
+                  alt={product.name}
+                  src={imageUrl}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div data-testid={`product-image-placeholder-${product.id}`}>
+                  <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
+                </div>
+              )}
+            </div>
             <CardHeader className="flex flex-col items-start pb-1">
               <h2 className="text-sm md:text-lg font-medium">{product.name}</h2>
               <p className="text-xs">{getCategoryNames(product.categoryIds)}</p>

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from "react";
 
-import { Button, Card, CardBody, CardHeader, Divider, NumberInput, Select, SelectItem } from "@heroui/react";
+import { Button, Card, CardBody, CardHeader, Divider, Image, NumberInput, Select, SelectItem } from "@heroui/react";
+import { ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { DeleteButton } from "@/components/shared/DeleteButton";
+import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
 import { BitcoinPaymentModal } from "../BitcoinPaymentModal";
 import { CardPaymentModal } from "../CardPaymentModal";
@@ -65,39 +67,58 @@ export function SummaryContent({
   return (
     <>
       <div className="space-y-4">
-        {items.map((item) => (
-          <Card key={item.id} className="shadow-none border-1 border-green-600">
-            <CardHeader>
-              <div className="flex w-full items-start justify-between gap-3">
-                <div className="flex min-w-0 flex-col">
-                  <h3 className="text-sm font-medium text-green-900">
-                    {item.name}
-                  </h3>
-                  <div className="text-xs text-gray-700">
-                    {formatAmount(item.price)} {t("summary.each")}
+        {items.map((item) => {
+          const imageUrl = storedAssetUrl(item.imageUrl);
+          return (
+            <Card key={item.id} className="shadow-none border-1 border-green-600">
+              <CardHeader>
+                <div className="flex w-full items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+                      {imageUrl ? (
+                        <Image
+                          removeWrapper
+                          alt={item.name}
+                          src={imageUrl}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div data-testid={`summary-image-placeholder-${item.id}`}>
+                          <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex min-w-0 flex-col">
+                      <h3 className="text-sm font-medium text-green-900">
+                        {item.name}
+                      </h3>
+                      <div className="text-xs text-gray-700">
+                        {formatAmount(item.price)} {t("summary.each")}
+                      </div>
+                    </div>
+                  </div>
+                  <DeleteButton onPress={() => onRemoveProduct(item.id)} />
+                </div>
+              </CardHeader>
+              <CardBody>
+                <div className="flex items-center justify-between">
+                  <NumberInput
+                    className="w-1/2"
+                    label={t("summary.quantity")}
+                    minValue={1}
+                    size="sm"
+                    placeholder="Enter the amount"
+                    value={item.quantity}
+                    onChange={(value) => onUpdateQuantity(item.id, Number(value))}
+                  />
+                  <div className="text-sm font-semibold text-green-900">
+                    {formatAmount(item.subtotal)}
                   </div>
                 </div>
-                <DeleteButton onPress={() => onRemoveProduct(item.id)} />
-              </div>
-            </CardHeader>
-            <CardBody>
-              <div className="flex items-center justify-between">
-                <NumberInput
-                  className="w-1/2"
-                  label={t("summary.quantity")}
-                  minValue={1}
-                  size="sm"
-                  placeholder="Enter the amount"
-                  value={item.quantity}
-                  onChange={(value) => onUpdateQuantity(item.id, Number(value))}
-                />
-                <div className="text-sm font-semibold text-green-900">
-                  {formatAmount(item.subtotal)}
-                </div>
-              </div>
-            </CardBody>
-          </Card>
-        ))}
+              </CardBody>
+            </Card>
+          );
+        })}
 
         <div className="space-y-2 text-sm text-gray-800">
           <div className="flex justify-between">

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -74,7 +74,7 @@ export function SummaryContent({
               <CardHeader>
                 <div className="flex w-full items-start justify-between gap-3">
                   <div className="flex min-w-0 items-center gap-3">
-                    <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
                       {imageUrl ? (
                         <Image
                           removeWrapper

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -55,7 +55,7 @@ jest.mock("../../CardPaymentModal", () => ({
   CardPaymentModal: ({ isOpen }) => (isOpen ? <div>card-modal</div> : null),
 }));
 
-const cartItems = [{ id: 1, name: "Jade Wallet", price: 1000, quantity: 2, subtotal: 2000 }];
+const cartItems = [{ id: 1, imageUrl: "/uploads/jade-wallet.png", name: "Jade Wallet", price: 1000, quantity: 2, subtotal: 2000 }];
 
 const defaultProps = {
   cartItems,
@@ -77,8 +77,20 @@ describe("SummaryContent", () => {
     render(<SummaryContent {...defaultProps} />);
 
     expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Jade Wallet" })).toHaveAttribute("src", "/uploads/jade-wallet.png");
     expect(screen.getByText(/fmt-1000/)).toBeInTheDocument();
     expect(screen.getAllByText("fmt-2000")).toHaveLength(2);
+  });
+
+  it("renders a placeholder when an item image is missing", () => {
+    render(
+      <SummaryContent
+        {...defaultProps}
+        cartItems={[{ id: 2, name: "M5 Stick", price: 500, quantity: 1, subtotal: 500 }]}
+      />,
+    );
+
+    expect(screen.getByTestId("summary-image-placeholder-2")).toBeInTheDocument();
   });
 
   it("renders computed totals with discount", () => {

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -15,10 +15,10 @@ const mockHandlePay = jest.fn();
 jest.mock("../SearchProducts", () => ({
   SearchProducts: ({ onAddProduct }) => (
     <div>
-      <button onClick={() => onAddProduct({ id: 1, name: "Jade Wallet", priceCents: 100 })}>
+      <button onClick={() => onAddProduct({ id: 1, imageUrl: "/uploads/jade.png", name: "Jade Wallet", priceCents: 100 })}>
         add-existing
       </button>
-      <button onClick={() => onAddProduct({ id: 2, name: "M5 Stick", priceCents: 200 })}>
+      <button onClick={() => onAddProduct({ id: 2, imageUrl: "/uploads/m5.png", name: "M5 Stick", priceCents: 200 })}>
         add-new
       </button>
     </div>
@@ -175,13 +175,13 @@ describe("Cart page", () => {
 
     fireEvent.click(screen.getByText("add-existing"));
     expect(mockSetCart).toHaveBeenCalledWith([
-      { id: 1, name: "Jade Wallet", price: 100, quantity: 2, subtotal: 200 },
+      { id: 1, imageUrl: "/uploads/jade.png", name: "Jade Wallet", price: 100, quantity: 2, subtotal: 200 },
     ]);
 
     fireEvent.click(screen.getByText("add-new"));
     expect(mockSetCart).toHaveBeenCalledWith([
       { id: 1, name: "Jade Wallet", price: 100, quantity: 1, subtotal: 100 },
-      { id: 2, name: "M5 Stick", price: 200, quantity: 1, subtotal: 200 },
+      { id: 2, imageUrl: "/uploads/m5.png", name: "M5 Stick", price: 200, quantity: 1, subtotal: 200 },
     ]);
   });
 

--- a/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
@@ -16,6 +16,7 @@ const products = [
     name: "Jade Wallet",
     SKU: "jade-wallet",
     categoryIds: ["cat-1"],
+    imageUrl: "/uploads/jade-wallet.png",
     priceCents: 1600,
     quantity: 3,
   },
@@ -55,6 +56,8 @@ describe("ProductList", () => {
     expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
     expect(screen.getByText("Hardware")).toBeInTheDocument();
     expect(screen.getByText("fmt-1600")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Jade Wallet" })).toHaveAttribute("src", "/uploads/jade-wallet.png");
+    expect(screen.getByTestId("product-image-placeholder-2")).toBeInTheDocument();
     expect(screen.getAllByText("SKU:")).toHaveLength(2);
     expect(screen.getByText("jade-wallet")).toBeInTheDocument();
     expect(screen.getByText("card.errors.unknownCategory")).toBeInTheDocument();

--- a/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card, CardBody, Chip, Image } from "@heroui/react";
+import { ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { DeleteButton } from "@/components/shared/DeleteButton";
@@ -10,17 +11,25 @@ import { RequirePermission } from "@/hooks/usePermission";
 
 export function ProductsCard({ product, status, normalizeNumber, formatAmount, canManageProducts, onEditProduct, onDeleteProduct }) {
   const t = useTranslations("products");
+  const imageUrl = storedAssetUrl(product?.imageUrl);
 
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-row items-center gap-3 p-3">
-        <Image
-          src={storedAssetUrl(product?.imageUrl)}
-          width={56}
-          height={56}
-          alt={product.name}
-          className="rounded-md object-cover shrink-0"
-        />
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+          {imageUrl ? (
+            <Image
+              removeWrapper
+              src={imageUrl}
+              alt={product.name}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div data-testid={`product-card-image-placeholder-${product.id}`}>
+              <ImageIcon aria-hidden="true" className="h-6 w-6 text-gray-400" />
+            </div>
+          )}
+        </div>
         <div className="flex-1 min-w-0">
           <p className="font-medium truncate text-sm">{product.name}</p>
           <p className="text-green-800 font-semibold text-sm mt-0.5">{formatAmount(product.priceCents)}</p>

--- a/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
@@ -16,7 +16,7 @@ export function ProductsCard({ product, status, normalizeNumber, formatAmount, c
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-row items-center gap-3 p-3">
-        <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
           {imageUrl ? (
             <Image
               removeWrapper

--- a/client/src/components/pages/Store/Products/ProductsList/ProductsTable.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsTable.jsx
@@ -10,6 +10,7 @@ import {
   Chip,
   Image,
 } from "@heroui/react";
+import { ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { DeleteButton } from "@/components/shared/DeleteButton";
@@ -36,16 +37,24 @@ export function ProductsTable({ products, categoryNameById, status, normalizeNum
       <TableBody>
         {products.map((product) => {
           const productStatus = status(product);
+          const imageUrl = storedAssetUrl(product?.imageUrl);
           return (
             <TableRow key={product.id}>
               <TableCell>
-                <Image
-                  alt={product.name}
-                  className="rounded-md object-cover shrink-0"
-                  src={storedAssetUrl(product?.imageUrl)}
-                  width={40}
-                  height={40}
-                />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+                  {imageUrl ? (
+                    <Image
+                      removeWrapper
+                      alt={product.name}
+                      className="h-full w-full object-cover"
+                      src={imageUrl}
+                    />
+                  ) : (
+                    <div data-testid={`product-table-image-placeholder-${product.id}`}>
+                      <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
+                    </div>
+                  )}
+                </div>
               </TableCell>
               <TableCell>
                 <span className="block max-w-[120px] truncate">{product.name}</span>

--- a/client/src/components/pages/Store/Products/ProductsList/ProductsTable.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsTable.jsx
@@ -41,7 +41,7 @@ export function ProductsTable({ products, categoryNameById, status, normalizeNum
           return (
             <TableRow key={product.id}>
               <TableCell>
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
                   {imageUrl ? (
                     <Image
                       removeWrapper

--- a/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsCard.test.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsCard.test.jsx
@@ -25,7 +25,7 @@ jest.mock("@/hooks/usePermission", () => ({
   RequirePermission: ({ children }) => children,
 }));
 
-const mockStoredAssetUrl = jest.fn((url) => `cdn${url}`);
+const mockStoredAssetUrl = jest.fn((url) => (url ? `cdn${url}` : null));
 jest.mock("@/components/utils/storedAssetUrl", () => ({
   __esModule: true,
   storedAssetUrl: (...args) => mockStoredAssetUrl(...args),
@@ -91,6 +91,12 @@ describe("ProductsCard", () => {
 
     expect(mockStoredAssetUrl).toHaveBeenCalledWith("/images/jade.png");
     expect(screen.getByRole("img", { name: "Jade Wallet" }).getAttribute("data-src")).toBe("cdn/images/jade.png");
+  });
+
+  it("renders an image placeholder when imageUrl is missing", () => {
+    renderCard({ product: { ...product, imageUrl: null } });
+
+    expect(screen.getByTestId("product-card-image-placeholder-1")).toBeInTheDocument();
   });
 
   it("renders edit and delete icon buttons", () => {

--- a/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsTable.test.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsTable.test.jsx
@@ -29,7 +29,7 @@ jest.mock("@/hooks/usePermission", () => ({
   RequirePermission: ({ children }) => children,
 }));
 
-const mockStoredAssetUrl = jest.fn((url) => `cdn${url}`);
+const mockStoredAssetUrl = jest.fn((url) => (url ? `cdn${url}` : null));
 jest.mock("@/components/utils/storedAssetUrl", () => ({
   __esModule: true,
   storedAssetUrl: (...args) => mockStoredAssetUrl(...args),
@@ -137,6 +137,14 @@ describe("ProductsTable", () => {
 
     expect(mockStoredAssetUrl).toHaveBeenCalledWith("/images/jade.png");
     expect(screen.getByRole("img", { name: "Jade Wallet" }).getAttribute("data-src")).toBe("cdn/images/jade.png");
+  });
+
+  it("renders an image placeholder when imageUrl is missing", () => {
+    renderTable({
+      products: [{ ...products[0], imageUrl: null }],
+    });
+
+    expect(screen.getByTestId("product-table-image-placeholder-1")).toBeInTheDocument();
   });
 
   it("calls onEditProduct when edit button is clicked", () => {


### PR DESCRIPTION
  - Preserve each product’s `imageUrl` when it is added to the cart, so cart state and persisted cart items can carry product images through checkout
  - Backfill `imageUrl` for existing cart items when the same product is added again
  - Render product images in the Store cart product grid using the existing `storedAssetUrl` helper for uploaded asset paths
  - Add neutral image placeholders for products without images so the cart product card layout stays consistent
  - Show small product thumbnails in cart summary item cards beside the product name and unit price
  - Add placeholder thumbnails in the summary when a cart item has no image
  - Add placeholder support to the main Products list card and table views for products without images
  - Remove rounded corners from cart product images so the card shape controls the visual framing cleanly


Fixes #519 

<img width="1029" height="370" alt="Screenshot From 2026-05-18 20-07-55" src="https://github.com/user-attachments/assets/aa4beb28-1d68-444a-8c6f-66d60c5e715d" />

<img width="1012" height="580" alt="Screenshot From 2026-05-19 11-42-21" src="https://github.com/user-attachments/assets/b5d93b55-0c26-4c25-ac24-190929a1cef9" />

It also works using a URL, not only on localhost:
<img width="1046" height="691" alt="Screenshot From 2026-05-21 13-27-59" src="https://github.com/user-attachments/assets/f85da364-0d21-494d-9b91-789ba1a805fe" />


