### PR TITLE
Fix/cart phoenixd down

### DIFF
--- a/client/src/components/pages/Store/Cart/BitcoinPaymentModal.jsx
+++ b/client/src/components/pages/Store/Cart/BitcoinPaymentModal.jsx
@@ -9,7 +9,7 @@ import {
   ModalHeader,
   Spinner,
 } from "@heroui/react";
-import { CheckCircle } from "lucide-react";
+import { AlertCircle, CheckCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { QRCode } from "react-qr-code";
 
@@ -29,7 +29,7 @@ export function BitcoinPaymentModal({
   invoiceDescription,
   displayTotal,
 }) {
-  const t = useTranslations("cart.paymentModal.bitcoin");
+  const bitcoinTranslations = useTranslations("cart.paymentModal.bitcoin");
   const { setInvoiceHash, onPayment, connected } = usePaymentWebsocket();
 
   const [paymentReceived, setPaymentReceived] = useState(false);
@@ -42,7 +42,6 @@ export function BitcoinPaymentModal({
     invoice,
     satsAmount,
     loading,
-    error,
     generateInvoice,
     reset,
   } = useBitcoinInvoice({
@@ -106,31 +105,31 @@ export function BitcoinPaymentModal({
       <ModalContent>
         <ModalHeader className="flex flex-col">
           <span className="text-base font-semibold text-green-900">
-            {t("title")}
+            {bitcoinTranslations("title")}
           </span>
-          {!paymentReceived && (
+          {!paymentReceived && invoice?.serialized && (
             <span className="text-sm text-gray-600">
-              {t("subtitle")}
+              {bitcoinTranslations("subtitle")}
             </span>
           )}
         </ModalHeader>
         <ModalBody className="space-y-4">
           {loading && !paymentReceived && (
             <div className="flex items-center justify-center py-6">
-              <Spinner color="warning" label={t("generating")} />
+              <Spinner color="warning" label={bitcoinTranslations("generating")} />
             </div>
           )}
 
-          {!loading && !paymentReceived && error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded">
-              <p className="text-sm">{error}</p>
-              <Button className="mt-3" color="warning" onPress={generateInvoice}>
-                {t("retry")}
-              </Button>
+          {!loading && !paymentReceived && !invoice?.serialized && (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+                <p className="text-sm">{bitcoinTranslations("serviceUnavailable")}</p>
+              </div>
             </div>
           )}
 
-          {!loading && !paymentReceived && !error && invoice && (
+          {!loading && !paymentReceived && invoice?.serialized && (
             <>
               <div className="flex flex-col space-y-4 justify-center items-center">
                 <div className="bg-white p-4 rounded-lg border w-full max-w-60 sm:max-w-[280px] mx-auto">
@@ -141,11 +140,11 @@ export function BitcoinPaymentModal({
                 </div>
                 <div className="flex items-center justify-between w-full max-w-60 sm:max-w-[280px]">
                   <span className="text-sm text-gray-500 font-medium">
-                    {t("invoice")}
+                    {bitcoinTranslations("invoice")}
                   </span>
                   <CopyButton
                     value={invoice.serialized}
-                    label={t("copyButton")}
+                    label={bitcoinTranslations("copyButton")}
                     size="sm"
                   />
                 </div>
@@ -154,7 +153,7 @@ export function BitcoinPaymentModal({
                 </div>
               </div>
               <div className="text-center">
-                <p className="text-sm text-gray-600">{t("totalLabel")}</p>
+                <p className="text-sm text-gray-600">{bitcoinTranslations("totalLabel")}</p>
                 <p className="text-xl font-semibold text-green-900">
                   {displayTotal}
                 </p>
@@ -165,7 +164,7 @@ export function BitcoinPaymentModal({
               {paymentAwaiting && (
                 <div className="flex items-center justify-center space-x-2 text-sm text-forest">
                   <Spinner size="sm" color="success" />
-                  <span>{t("waitingPayment")}</span>
+                  <span>{bitcoinTranslations("waitingPayment")}</span>
                 </div>
               )}
             </>
@@ -176,11 +175,11 @@ export function BitcoinPaymentModal({
               <CheckCircle className="h-16 w-16 text-forest" />
               <div className="text-center space-y-1">
                 <p className="text-xl font-semibold text-deep">
-                  {t("confirmed")}
+                  {bitcoinTranslations("confirmed")}
                 </p>
                 {paymentCompletedAt && (
                   <p className="text-sm text-gray-500">
-                    {t("paidAt", { time: new Date(paymentCompletedAt).toLocaleTimeString() })}
+                    {bitcoinTranslations("paidAt", { time: new Date(paymentCompletedAt).toLocaleTimeString() })}
                   </p>
                 )}
               </div>
@@ -195,13 +194,19 @@ export function BitcoinPaymentModal({
             isDisabled={loading}
             onPress={handleClose}
           >
-            {paymentReceived ? t("close") : t("cancel")}
+            {paymentReceived ? bitcoinTranslations("close") : bitcoinTranslations("cancel")}
           </Button>
-          {paymentAwaiting && !connected && (
+          {!loading && !paymentReceived && !invoice?.serialized && (
+            <Button color="danger" onPress={generateInvoice}>
+              {bitcoinTranslations("retry")}
+            </Button>
+          )}
+          {!loading && paymentAwaiting && !connected && (
             <Button
               color="primary"
               className="bg-green-800"
               onPress={() => {
+                if (completedRef.current) return;
                 completedRef.current = true;
                 setPaymentReceived(true);
                 setPaymentAwaiting(false);
@@ -209,7 +214,7 @@ export function BitcoinPaymentModal({
                 onComplete?.({ invoice, satoshis: satsAmount, paymentId, auto: false });
               }}
             >
-              {t("markAsPaid")}
+              {bitcoinTranslations("markAsPaid")}
             </Button>
           )}
         </ModalFooter>

--- a/client/src/components/pages/Store/Cart/__tests__/BitcoinPaymentModal.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/BitcoinPaymentModal.test.jsx
@@ -88,11 +88,11 @@ describe("BitcoinPaymentModal", () => {
   });
 
   describe("Error state", () => {
-    it("shows error message", () => {
+    it("shows service unavailable message when invoice is missing", () => {
       mockInvoiceState = { ...mockInvoiceState, error: "invoice-error" };
       renderModal();
 
-      expect(screen.getByText("invoice-error")).toBeInTheDocument();
+      expect(screen.getByText("serviceUnavailable")).toBeInTheDocument();
     });
 
     it("calls generateInvoice on retry", () => {
@@ -300,6 +300,13 @@ describe("BitcoinPaymentModal", () => {
       renderModal();
 
       fireEvent.click(screen.getByText("markAsPaid"));
+
+      expect(screen.queryByText("markAsPaid")).not.toBeInTheDocument();
+    });
+
+    it("hides button while loading even when awaiting payment", () => {
+      mockInvoiceState = { ...mockInvoiceState, loading: true };
+      renderModal();
 
       expect(screen.queryByText("markAsPaid")).not.toBeInTheDocument();
     });

--- a/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
@@ -47,9 +47,8 @@ export function useBitcoinInvoice({
       onInvoiceReady?.({ invoice: createdInvoice, satoshis: sats, paymentId });
 
       return createdInvoice;
-    } catch (err) {
-      const message = err?.message;
-      setError(message);
+    } catch (caughtError) {
+      setError(caughtError?.message);
       return null;
     } finally {
       setLoading(false);

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -61,6 +61,7 @@ const cartEn = {
         subtitle: "Ask the customer to scan the QR to complete the payment",
         generating: "Generating invoice...",
         retry: "Retry",
+        serviceUnavailable: "Lightning payment service is unavailable. Please try again.",
         totalLabel: "Total",
         cancel: "Cancel",
         copyButton: "Copy",

--- a/client/src/components/pages/Store/Cart/locales/es.js
+++ b/client/src/components/pages/Store/Cart/locales/es.js
@@ -61,6 +61,7 @@ const cartEs = {
         subtitle: "Pídele al cliente que escanee el QR para completar el pago",
         generating: "Generando invoice...",
         retry: "Reintentar",
+        serviceUnavailable: "El servicio de pago Lightning no está disponible. Por favor, inténtalo de nuevo.",
         totalLabel: "Total",
         cancel: "Cancelar",
         confirm: "Confirmar pago",

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -51,7 +51,14 @@ export async function createInvoiceForCart(invoiceAmount, invoiceDesc) {
       amountSat: parseInt(invoiceAmount),
     }),
   });
-  return await parseJsonResponse(response, null);
+  const invoice = await parseJsonResponse(response, null);
+  if (!response.ok) {
+    throw createWalletServiceError(
+      invoice?.message,
+      { status: response.status },
+    );
+  }
+  return invoice;
 }
 
 export async function createInvoice({


### PR DESCRIPTION
## Changes:
- Add `response.ok` check to `createInvoiceForCart` in `walletService` so a phoenixd 503 response throws a proper error instead of being stored as a valid invoice
- Merge error and empty-invoice states in `BitcoinPaymentModal` into a single block using `!invoice?.serialized` as the unified condition, eliminating a silent empty modal state
- Show a translated `serviceUnavailable` message (EN/ES) in the error block instead of raw server error strings
- Move the Retry button to the modal footer, aligned with Cancel, consistent with other payment modals
- Add `!loading` guard to the "Mark as Paid" button to prevent it from appearing while a new invoice is being generated
- Add `completedRef.current` guard to the manual "Mark as Paid" handler, matching the existing double-fire protection on the WebSocket payment handler
- Remove `error` from `useBitcoinInvoice` destructuring in the modal since the UI no longer renders raw error messages

**Screenshots**:

<img width="620" height="282" alt="Screenshot 2026-05-21 at 2 30 39 p m" src="https://github.com/user-attachments/assets/34dc18fd-12bc-41ee-b8bb-4977c311ce98" />

**Related issues**:
https://github.com/olympus-btc/ambrosia/issues/566