### PR TITLE
fix(client): solve step, and maxValue limits

### DIFF
--- a/client/src/components/pages/Store/Cart/CashPaymentModal.jsx
+++ b/client/src/components/pages/Store/Cart/CashPaymentModal.jsx
@@ -84,18 +84,32 @@ export function CashPaymentModal({
           <NumberInput
             label={t("receivedLabel")}
             value={cashReceived}
-            onValueChange={(value) => {
-              setCashReceived(value ?? 0);
+            onValueChange={(receivedAmount) => {
+              setCashReceived(receivedAmount ?? 0);
               setError("");
             }}
             onChange={(e) => {
               if (e?.target) {
-                setCashReceived(parseFloat(e.target.value) || 0);
+                const parsedAmount = parseFloat(e.target.value.replace(/[^0-9.]/g, "")) || 0;
+                setCashReceived(Math.min(parsedAmount, 9999999));
                 setError("");
               }
             }}
+            onKeyDown={(e) => {
+              if (!/^[0-9]$/.test(e.key)) return;
+              const currentInputText = (e.target.value || "").replace(/[^0-9.]/g, "");
+              if (parseFloat(currentInputText + e.key) > 9999999) {
+                e.preventDefault();
+              }
+            }}
             minValue={0}
-            step={0.10}
+            maxValue={9999999}
+            formatOptions={{
+              useGrouping: true,
+              maximumFractionDigits: 2,
+            }}
+
+            step={0.01}
             size="lg"
             classNames={{ inputWrapper: "shadow-none" }}
             startContent={


### PR DESCRIPTION
This pull request updates the cash input handling in the `CashPaymentModal` to improve input validation, enforce a maximum allowed value, and enhance formatting for user experience. The changes ensure that users cannot enter values above 9,999,999, restrict input to valid numbers, and format the input with grouping and two decimal places.

**Input validation and value enforcement:**
- Updated the `onChange` handler to sanitize input by removing non-numeric characters, parse the value, and cap it at 9,999,999.
- Added an `onKeyDown` handler to prevent entering digits that would cause the value to exceed 9,999,999.
- Set the `maxValue` prop to 9,999,999 to enforce the upper limit at the component level.

**Formatting improvements:**
- Added `formatOptions` to display the input with digit grouping and a maximum of two decimal places.
- Changed the input step value from 0.10 to 0.01 for finer increments.

**Code clarity:**
- Renamed the `onValueChange` parameter from `value` to `receivedAmount` for clarity.

**Screenshots**
<img width="491" height="427" alt="image" src="https://github.com/user-attachments/assets/ecf2c920-95d4-4f7c-a42d-c63512e807fc" />
<img width="485" height="450" alt="image" src="https://github.com/user-attachments/assets/b10f3daa-3665-4294-84e7-18f519e62de2" />

**Related Issues**
Resolves #553
Resolves #552
