### PR TITLE
Feature/product image photo

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2088,7 +2087,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2112,7 +2110,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2134,7 +2131,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3528,7 +3524,6 @@
       "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.23.tgz",
       "integrity": "sha512-kgYvfkIOQKM6CCBIlNSE2tXMtNrS1mvEUbvwnaU3pEYbMlceBtwA5v7SlpaJy/5dqKcTbfmVMUCmXnY/Kw4vaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@heroui/react-utils": "2.1.14",
         "@heroui/system-rsc": "2.3.20",
@@ -3614,7 +3609,6 @@
       "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.23.tgz",
       "integrity": "sha512-5hoaRWG+/d/t06p7Pfhz70DUP0Uggjids7/z2Ytgup4A8KAOvDIXxvHUDlk6rRHKiN1wDMNA5H+EWsSXB/m03Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@heroui/shared-utils": "2.1.12",
         "clsx": "^1.2.1",
@@ -8019,6 +8013,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -8108,7 +8103,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8294,7 +8290,6 @@
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -8387,7 +8382,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -8868,7 +8862,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9415,7 +9408,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10145,6 +10137,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10186,7 +10179,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/driver.js": {
       "version": "1.4.0",
@@ -10510,7 +10504,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10696,7 +10689,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11341,7 +11333,6 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
       "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "motion-dom": "^12.23.12",
         "motion-utils": "^12.23.6",
@@ -13561,7 +13552,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -14159,6 +14149,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14370,7 +14361,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -15127,6 +15117,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15142,6 +15133,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15154,7 +15146,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -15225,7 +15218,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15235,7 +15227,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15247,8 +15238,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-qr-code": {
       "version": "2.0.18",
@@ -15268,7 +15258,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15361,8 +15350,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16480,7 +16468,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -16640,7 +16627,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16876,7 +16862,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17618,7 +17603,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -47,6 +47,7 @@ const componentsEn = {
   },
   imageUploader: {
     removeImage: "Remove image",
+    takePhoto: "Take a photo",
   },
   shifts: {
     requiredOpenShiftTitle: "Open Shift Required",

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -47,6 +47,7 @@ const componentsEs = {
   },
   imageUploader: {
     removeImage: "Eliminar imagen",
+    takePhoto: "Tomar una foto",
   },
   shifts: {
     requiredOpenShiftTitle: "Abrir Turno Requerido",

--- a/client/src/components/pages/Onboarding/AddBusinessData.jsx
+++ b/client/src/components/pages/Onboarding/AddBusinessData.jsx
@@ -120,7 +120,7 @@ export function BusinessDetailsStep({ data, onChange }) {
           uploadText={t("step3.fields.businessLogoUpload")}
           uploadDescription={t("step3.fields.businessLogoUploadMessage")}
           onChange={(file) => onChange({ ...data, businessLogo: file })}
-          value={data.businessLogo}
+          image={data.businessLogo}
         />
 
       </div>

--- a/client/src/components/pages/Store/Cart/__tests__/CashPaymentModal.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/CashPaymentModal.test.jsx
@@ -21,7 +21,7 @@ jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   return {
     ...actual,
-    NumberInput: ({ label, value, onValueChange, onChange, minValue, startContent, size, step, classNames, ...props }) => (
+    NumberInput: ({ label, value, onValueChange, onChange, minValue, maxValue, startContent, size, step, classNames, formatOptions, ...props }) => (
       <input
         type="number"
         aria-label={label}

--- a/client/src/components/pages/Store/Products/AddProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/AddProductsModal.jsx
@@ -149,7 +149,7 @@ export function AddProductsModal({
               uploadText={t("modal.productImageUpload")}
               uploadDescription={t("modal.productImageUploadMessage")}
               onChange={(file) => onChange({ productImage: file })}
-              value={data.productImage || data.productImageUrl}
+              image={data.productImage || data.productImageUrl}
             />
 
             <ModalFooter className="flex justify-between p-0 my-4">

--- a/client/src/components/pages/Store/Products/EditProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/EditProductsModal.jsx
@@ -148,7 +148,7 @@ export function EditProductsModal({
               uploadText={t("modal.productImageUpload")}
               uploadDescription={t("modal.productImageUploadMessage")}
               onChange={(file) => onChange({ productImage: file, productImageRemoved: file === null })}
-              value={data.productImageRemoved ? null : (data.productImage || data.productImageUrl)}
+              image={data.productImageRemoved ? null : (data.productImage || data.productImageUrl)}
             />
 
             <ModalFooter className="flex justify-between p-0 my-4">

--- a/client/src/components/pages/Store/Settings/StoreInfo/EditStoreInfoModal.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/EditStoreInfoModal.jsx
@@ -103,7 +103,7 @@ export function EditStoreInfoModal({ data, setData, onChange, onSubmit, isOpen, 
               uploadText={t("modal.logoUpload")}
               uploadDescription={t("modal.logoUploadMessage")}
               onChange={(file) => onChange({ ...data, businessLogo: file, businessLogoRemoved: file === null })}
-              value={data.businessLogoRemoved ? null : (data.businessLogo || data.businessLogoUrl)}
+              image={data.businessLogoRemoved ? null : (data.businessLogo || data.businessLogoUrl)}
             />
 
             <ModalFooter className="flex justify-between p-0 my-4">

--- a/client/src/components/shared/ImageUploader.jsx
+++ b/client/src/components/shared/ImageUploader.jsx
@@ -1,45 +1,46 @@
 import { useState, useRef, useEffect } from "react";
 
 import { Button, Image } from "@heroui/react";
-import { Upload, X } from "lucide-react";
+import { Camera, Upload, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-export function ImageUploader({ title, uploadText, uploadDescription, onChange, value }) {
-  const t = useTranslations("imageUploader");
+export function ImageUploader({ title, uploadText, uploadDescription, onChange, image }) {
+  const imageUploaderTranslations = useTranslations("imageUploader");
   const [filePreview, setFilePreview] = useState(null);
-  const fileInputRef = useRef(null);
+  const [isTouchDevice] = useState(() => typeof window !== "undefined" && navigator.maxTouchPoints > 0);
+  const galleryInputRef = useRef(null);
+  const cameraInputRef = useRef(null);
 
   useEffect(() => {
-    if (value instanceof File) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setFilePreview(reader.result);
+    if (image instanceof File) {
+      const fileReader = new FileReader();
+      fileReader.onloadend = () => {
+        setFilePreview(fileReader.result);
       };
-      reader.readAsDataURL(value);
+      fileReader.readAsDataURL(image);
     }
-  }, [value]);
+  }, [image]);
 
-  const imagePreview = filePreview || (typeof value === "string" ? value : null);
+  const imagePreview = filePreview || (typeof image === "string" ? image : null);
 
-  const handleImageChange = (e) => {
-    const file = e.target.files?.[0];
+  const handleImageChange = (event) => {
+    const file = event.target.files?.[0];
     if (file) {
       onChange(file);
 
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setFilePreview(reader.result);
+      const fileReader = new FileReader();
+      fileReader.onloadend = () => {
+        setFilePreview(fileReader.result);
       };
-      reader.readAsDataURL(file);
+      fileReader.readAsDataURL(file);
     }
   };
 
   const handleRemoveImage = () => {
     onChange(null);
     setFilePreview(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
+    if (galleryInputRef.current) galleryInputRef.current.value = "";
+    if (cameraInputRef.current) cameraInputRef.current.value = "";
   };
 
   return (
@@ -57,12 +58,12 @@ export function ImageUploader({ title, uploadText, uploadDescription, onChange, 
               relative w-32 h-32 md:w-48 md:h-48 rounded-lg border border-gray-200 overflow-hidden
             "
           >
-            <Image src={imagePreview || "/placeholder.svg"} alt="Image preview" className="w-full h-full object-contain" />
+            <Image src={imagePreview} alt="Image preview" className="w-full h-full object-contain" />
             <Button
               isIconOnly
               size="sm"
               color="danger"
-              aria-label={t("removeImage")}
+              aria-label={imageUploaderTranslations("removeImage")}
               data-testid="remove-image-button"
               className="absolute top-1 right-1 z-10 min-w-0 w-6 h-6"
               onPress={handleRemoveImage}
@@ -70,23 +71,37 @@ export function ImageUploader({ title, uploadText, uploadDescription, onChange, 
               <X className="w-3 h-3" />
             </Button>
           </div>
-          {value instanceof File && (
-            <p className="text-xs text-gray-500 truncate max-w-48">{value.name}</p>
+          {image instanceof File && (
+            <p className="text-xs text-gray-500 truncate max-w-48">{image.name}</p>
           )}
         </div>
       ) : (
-        <Button
-          variant="bordered"
-          fullWidth
-          className="h-auto p-8 rounded-lg border-2 border-dashed flex flex-col items-center justify-center"
-          onPress={() => fileInputRef.current?.click()}
-        >
-          <Upload className="w-8 h-8 text-muted-foreground mb-2" />
-          <p className="text-sm font-medium text-foreground">{uploadText}</p>
-          <p className="text-xs text-muted-foreground">{uploadDescription}</p>
-        </Button>
+        <div className="flex flex-row gap-3">
+          {isTouchDevice && (
+            <Button
+              variant="bordered"
+              fullWidth
+              className="h-auto py-6 px-3 rounded-lg border-2 border-dashed flex flex-col items-center justify-center"
+              onPress={() => cameraInputRef.current?.click()}
+            >
+              <Camera className="w-8 h-8 text-muted-foreground mb-2" />
+              <p className="text-sm font-medium text-foreground">{imageUploaderTranslations("takePhoto")}</p>
+            </Button>
+          )}
+          <Button
+            variant="bordered"
+            fullWidth
+            className="h-auto py-6 px-3 rounded-lg border-2 border-dashed flex flex-col items-center justify-center"
+            onPress={() => galleryInputRef.current?.click()}
+          >
+            <Upload className="w-8 h-8 text-muted-foreground mb-2" />
+            <p className="text-sm font-medium text-foreground">{uploadText}</p>
+            {!isTouchDevice && <p className="text-xs text-muted-foreground text-center leading-tight">{uploadDescription}</p>}
+          </Button>
+        </div>
       )}
-      <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
+      <input ref={galleryInputRef} type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
+      <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handleImageChange} className="hidden" />
     </div>
   );
 }

--- a/client/src/components/shared/__tests__/ImageUploader.test.jsx
+++ b/client/src/components/shared/__tests__/ImageUploader.test.jsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { ImageUploader } from "../ImageUploader";
 
 jest.mock("lucide-react", () => ({
+  Camera: () => <span data-testid="camera-icon" />,
   Upload: () => <span data-testid="upload-icon" />,
   X: () => <span data-testid="x-icon" />,
 }));
@@ -17,6 +18,13 @@ jest.mock("@heroui/react", () => ({
   ),
   Image: ({ src, alt, className }) => <MockedImage src={src} alt={alt} className={className} />,
 }));
+
+const setTouchDevice = (isTouchDevice) => {
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    value: isTouchDevice ? 1 : 0,
+    configurable: true,
+  });
+};
 
 const defaultProps = {
   title: "Upload Logo",
@@ -31,6 +39,7 @@ function makeFile(name = "logo.png", type = "image/png") {
 }
 
 beforeEach(() => {
+  setTouchDevice(true);
   jest.clearAllMocks();
 
   global.FileReader = class {
@@ -50,7 +59,14 @@ describe("ImageUploader", () => {
       expect(screen.getByText("Upload Logo")).toBeInTheDocument();
     });
 
-    it("renders upload text and description", () => {
+    it("renders upload text on touch devices", () => {
+      render(<ImageUploader {...defaultProps} />);
+      expect(screen.getByText("Click to upload")).toBeInTheDocument();
+      expect(screen.queryByText("PNG, JPG up to 2MB")).not.toBeInTheDocument();
+    });
+
+    it("renders upload text and description on non-touch devices", () => {
+      setTouchDevice(false);
       render(<ImageUploader {...defaultProps} />);
       expect(screen.getByText("Click to upload")).toBeInTheDocument();
       expect(screen.getByText("PNG, JPG up to 2MB")).toBeInTheDocument();
@@ -61,25 +77,61 @@ describe("ImageUploader", () => {
       expect(screen.getByTestId("upload-icon")).toBeInTheDocument();
     });
 
-    it("renders a hidden file input", () => {
+    it("renders the camera icon on touch devices", () => {
       render(<ImageUploader {...defaultProps} />);
-      const input = document.querySelector("input[type='file']");
-      expect(input).toBeInTheDocument();
-      expect(input).toHaveClass("hidden");
-      expect(input).toHaveAttribute("accept", "image/*");
+      expect(screen.getByTestId("camera-icon")).toBeInTheDocument();
+    });
+
+    it("does not render the camera button on non-touch devices", async () => {
+      setTouchDevice(false);
+      render(<ImageUploader {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.queryByTestId("camera-icon")).not.toBeInTheDocument();
+      });
+    });
+
+    it("renders a hidden gallery input without capture", () => {
+      render(<ImageUploader {...defaultProps} />);
+      const inputs = document.querySelectorAll("input[type='file']");
+      const galleryInput = Array.from(inputs).find((input) => !input.hasAttribute("capture"));
+      expect(galleryInput).toBeInTheDocument();
+      expect(galleryInput).toHaveClass("hidden");
+      expect(galleryInput).toHaveAttribute("accept", "image/*");
+    });
+
+    it("renders a hidden camera input with capture=environment", () => {
+      render(<ImageUploader {...defaultProps} />);
+      const cameraInput = document.querySelector("input[capture='environment']");
+      expect(cameraInput).toBeInTheDocument();
+      expect(cameraInput).toHaveClass("hidden");
+      expect(cameraInput).toHaveAttribute("accept", "image/*");
     });
   });
 
   describe("file selection", () => {
-    it("calls onChange with the selected file", async () => {
+    it("calls onChange with the selected file from gallery input", async () => {
       const onChange = jest.fn();
       render(<ImageUploader {...defaultProps} onChange={onChange} />);
 
-      const input = document.querySelector("input[type='file']");
+      const galleryInput = document.querySelector("input[type='file']:not([capture])");
       const file = makeFile();
 
       await act(async () => {
-        fireEvent.change(input, { target: { files: [file] } });
+        fireEvent.change(galleryInput, { target: { files: [file] } });
+      });
+
+      expect(onChange).toHaveBeenCalledWith(file);
+    });
+
+    it("calls onChange with the selected file from camera input", async () => {
+      const onChange = jest.fn();
+      render(<ImageUploader {...defaultProps} onChange={onChange} />);
+
+      const cameraInput = document.querySelector("input[capture='environment']");
+      const file = makeFile("photo.jpg", "image/jpeg");
+
+      await act(async () => {
+        fireEvent.change(cameraInput, { target: { files: [file] } });
       });
 
       expect(onChange).toHaveBeenCalledWith(file);
@@ -89,10 +141,10 @@ describe("ImageUploader", () => {
       const onChange = jest.fn();
       render(<ImageUploader {...defaultProps} onChange={onChange} />);
 
-      const input = document.querySelector("input[type='file']");
+      const galleryInput = document.querySelector("input[type='file']:not([capture])");
 
       await act(async () => {
-        fireEvent.change(input, { target: { files: [] } });
+        fireEvent.change(galleryInput, { target: { files: [] } });
       });
 
       expect(onChange).not.toHaveBeenCalled();
@@ -101,14 +153,14 @@ describe("ImageUploader", () => {
 
   describe("preview", () => {
     it("shows preview image when value is a string URL", () => {
-      render(<ImageUploader {...defaultProps} value="https://example.com/logo.png" />);
+      render(<ImageUploader {...defaultProps} image="https://example.com/logo.png" />);
       expect(screen.getByAltText("Image preview")).toBeInTheDocument();
     });
 
     it("shows preview after selecting a file", async () => {
       render(<ImageUploader {...defaultProps} />);
 
-      const input = document.querySelector("input[type='file']");
+      const input = document.querySelector("input[type='file']:not([capture])");
       const file = makeFile();
 
       await act(async () => {
@@ -124,19 +176,19 @@ describe("ImageUploader", () => {
       const file = makeFile("my-logo.png");
 
       await act(async () => {
-        render(<ImageUploader {...defaultProps} value={file} />);
+        render(<ImageUploader {...defaultProps} image={file} />);
       });
 
       expect(screen.getByText("my-logo.png")).toBeInTheDocument();
     });
 
     it("does not show filename when value is a string URL", () => {
-      render(<ImageUploader {...defaultProps} value="https://example.com/logo.png" />);
+      render(<ImageUploader {...defaultProps} image="https://example.com/logo.png" />);
       expect(screen.queryByText("logo.png")).not.toBeInTheDocument();
     });
 
     it("shows the remove button when preview is visible", () => {
-      render(<ImageUploader {...defaultProps} value="https://example.com/logo.png" />);
+      render(<ImageUploader {...defaultProps} image="https://example.com/logo.png" />);
       expect(screen.getByTestId("remove-image-button")).toBeInTheDocument();
     });
   });
@@ -144,7 +196,7 @@ describe("ImageUploader", () => {
   describe("remove image", () => {
     it("calls onChange with null when remove is clicked", () => {
       const onChange = jest.fn();
-      render(<ImageUploader {...defaultProps} onChange={onChange} value="https://example.com/logo.png" />);
+      render(<ImageUploader {...defaultProps} onChange={onChange} image="https://example.com/logo.png" />);
 
       fireEvent.click(screen.getByTestId("remove-image-button"));
 
@@ -154,12 +206,12 @@ describe("ImageUploader", () => {
     it("hides preview after remove is clicked", async () => {
       const onChange = jest.fn();
       const { rerender } = render(
-        <ImageUploader {...defaultProps} onChange={onChange} value="https://example.com/logo.png" />,
+        <ImageUploader {...defaultProps} onChange={onChange} image="https://example.com/logo.png" />,
       );
 
       fireEvent.click(screen.getByTestId("remove-image-button"));
 
-      rerender(<ImageUploader {...defaultProps} onChange={onChange} value={null} />);
+      rerender(<ImageUploader {...defaultProps} onChange={onChange} image={null} />);
 
       await waitFor(() => {
         expect(screen.queryByAltText("Image preview")).not.toBeInTheDocument();


### PR DESCRIPTION
## Changes:
- Add camera capture support to `ImageUploader` on touch devices (Android/iOS): shows a "Take a photo" button that opens the device camera directly via `capture="environment"`, alongside the existing gallery upload button
- Hide the camera button on non-touch devices (desktop) where `capture="environment"` falls back to the file picker, avoiding two buttons with identical behavior
- Hide the upload description text on touch devices to prevent overflow in the side-by-side button layout
- Rename `ImageUploader` prop `value` → `image` and local `reader` → `fileReader` for clarity; update all callers (`AddProductsModal`, `EditProductsModal`, `EditStoreInfoModal`, `AddBusinessData`)
- Add `takePhoto` locale key in EN and ES
- Clean up `CashPaymentModal` test mock: exclude `maxValue` and `formatOptions` from the DOM spread to suppress React prop warnings

**Issues Related**: 
https://github.com/olympus-btc/ambrosia/issues/513

**Screenshots**:

<img width="440" height="670" alt="Screenshot 2026-05-22 at 2 16 53 p m" src="https://github.com/user-attachments/assets/ff21dfd3-103c-4fbd-879d-ef9573e540e6" />