### PR TITLE
Feature/cart item delete gesture

### DIFF
--- a/client/__tests__/__mocks__/framer-motion.js
+++ b/client/__tests__/__mocks__/framer-motion.js
@@ -12,6 +12,13 @@ const cleanMotionProps = (props) => {
     "whileHover",
     "onAnimationComplete",
     "onAnimationStart",
+    "drag",
+    "dragConstraints",
+    "dragElastic",
+    "dragTransition",
+    "dragDirectionLock",
+    "whileDrag",
+    "onDragEnd",
   ].forEach((key) => delete sanitized[key]);
   return sanitized;
 };
@@ -20,6 +27,15 @@ const Mock = React.forwardRef(({ children, ...props }, ref) => (
   <div ref={ref} {...cleanMotionProps(props)}>{children}</div>
 ));
 Mock.displayName = "FramerMotionMock";
+
+export const useMotionValue = (initial) => ({
+  get: () => initial,
+  set: jest.fn(),
+});
+
+export const useTransform = () => ({ get: () => 0 });
+
+export const animate = jest.fn(() => Promise.resolve());
 
 export const AnimatePresence = ({ children }) => children;
 export const LazyMotion = ({ children }) => children;

--- a/client/src/components/pages/Store/Cart/Summary/CartItemCard.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartItemCard.jsx
@@ -7,7 +7,7 @@ import { DeleteButton } from "@/components/shared/DeleteButton";
 import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
 export function CartItemCard({ item, onRemove, onUpdateQuantity }) {
-  const t = useTranslations("cart");
+  const translateCart = useTranslations("cart");
   const { formatAmount } = useCurrency();
   const imageUrl = storedAssetUrl(item.imageUrl);
 
@@ -33,7 +33,7 @@ export function CartItemCard({ item, onRemove, onUpdateQuantity }) {
             <div className="flex min-w-0 flex-col">
               <h3 className="text-sm font-medium text-green-900">{item.name}</h3>
               <div className="text-xs text-gray-700">
-                {formatAmount(item.price)} {t("summary.each")}
+                {formatAmount(item.price)} {translateCart("summary.each")}
               </div>
             </div>
           </div>
@@ -44,7 +44,7 @@ export function CartItemCard({ item, onRemove, onUpdateQuantity }) {
         <div className="flex items-center justify-between">
           <NumberInput
             className="w-1/2"
-            label={t("summary.quantity")}
+            label={translateCart("summary.quantity")}
             minValue={1}
             size="sm"
             placeholder="Enter the amount"

--- a/client/src/components/pages/Store/Cart/Summary/CartItemCard.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartItemCard.jsx
@@ -1,0 +1,61 @@
+import { Card, CardBody, CardHeader, Image, NumberInput } from "@heroui/react";
+import { ImageIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { useCurrency } from "@/components/hooks/useCurrency";
+import { DeleteButton } from "@/components/shared/DeleteButton";
+import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
+
+export function CartItemCard({ item, onRemove, onUpdateQuantity }) {
+  const t = useTranslations("cart");
+  const { formatAmount } = useCurrency();
+  const imageUrl = storedAssetUrl(item.imageUrl);
+
+  return (
+    <Card className="shadow-none border-1 border-green-600">
+      <CardHeader>
+        <div className="flex w-full items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
+              {imageUrl ? (
+                <Image
+                  removeWrapper
+                  alt={item.name}
+                  src={imageUrl}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div data-testid={`summary-image-placeholder-${item.id}`}>
+                  <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
+                </div>
+              )}
+            </div>
+            <div className="flex min-w-0 flex-col">
+              <h3 className="text-sm font-medium text-green-900">{item.name}</h3>
+              <div className="text-xs text-gray-700">
+                {formatAmount(item.price)} {t("summary.each")}
+              </div>
+            </div>
+          </div>
+          <DeleteButton onPress={onRemove} />
+        </div>
+      </CardHeader>
+      <CardBody>
+        <div className="flex items-center justify-between">
+          <NumberInput
+            className="w-1/2"
+            label={t("summary.quantity")}
+            minValue={1}
+            size="sm"
+            placeholder="Enter the amount"
+            value={item.quantity}
+            onChange={(value) => onUpdateQuantity(item.id, Number(value))}
+          />
+          <div className="text-sm font-semibold text-green-900">
+            {formatAmount(item.subtotal)}
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Cart/Summary/CartPaymentSection.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartPaymentSection.jsx
@@ -12,7 +12,7 @@ export function CartPaymentSection({
   onClearPaymentError,
   onPay,
 }) {
-  const t = useTranslations("cart");
+  const translateCart = useTranslations("cart");
   const { paymentMethods } = usePaymentMethods();
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("");
 
@@ -28,10 +28,10 @@ export function CartPaymentSection({
         <p className="text-sm text-red-600">{paymentError}</p>
       )}
       <Select
-        label={t("summary.paymentMethodLabel")}
-        placeholder={t("summary.paymentMethodSelectPlaceholder")}
+        label={translateCart("summary.paymentMethodLabel")}
+        placeholder={translateCart("summary.paymentMethodSelectPlaceholder")}
         isRequired
-        errorMessage={t("summary.errorMsgSelectEmpty")}
+        errorMessage={translateCart("summary.errorMsgSelectEmpty")}
         selectedKeys={effectivePaymentMethod ? [effectivePaymentMethod] : []}
         onSelectionChange={(keys) => {
           const value = Array.from(keys)[0];
@@ -55,7 +55,7 @@ export function CartPaymentSection({
         isDisabled={isDisabled}
         onPress={() => onPay(effectivePaymentMethod)}
       >
-        {t("summary.pay")}
+        {translateCart("summary.pay")}
       </Button>
     </div>
   );

--- a/client/src/components/pages/Store/Cart/Summary/CartPaymentSection.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartPaymentSection.jsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from "react";
+
+import { Button, Select, SelectItem } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { usePaymentMethods } from "../hooks/usePaymentMethod";
+
+export function CartPaymentSection({
+  isPaying,
+  isDisabled,
+  paymentError,
+  onClearPaymentError,
+  onPay,
+}) {
+  const t = useTranslations("cart");
+  const { paymentMethods } = usePaymentMethods();
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("");
+
+  const effectivePaymentMethod = useMemo(() => {
+    if (selectedPaymentMethod) return selectedPaymentMethod;
+    const bitcoinLightningMethod = paymentMethods.find((method) => method.name === "BTC");
+    return bitcoinLightningMethod ? String(bitcoinLightningMethod.id) : "";
+  }, [selectedPaymentMethod, paymentMethods]);
+
+  return (
+    <div className="space-y-2">
+      {paymentError && (
+        <p className="text-sm text-red-600">{paymentError}</p>
+      )}
+      <Select
+        label={t("summary.paymentMethodLabel")}
+        placeholder={t("summary.paymentMethodSelectPlaceholder")}
+        isRequired
+        errorMessage={t("summary.errorMsgSelectEmpty")}
+        selectedKeys={effectivePaymentMethod ? [effectivePaymentMethod] : []}
+        onSelectionChange={(keys) => {
+          const value = Array.from(keys)[0];
+          if (!value) return;
+          setSelectedPaymentMethod(value);
+          onClearPaymentError?.();
+        }}
+        isDisabled={isPaying}
+      >
+        {paymentMethods.map((method) => (
+          <SelectItem key={method.id} value={method.id}>
+            {method.name === "BTC" ? `${method.name} (Lightning)` : method.name}
+          </SelectItem>
+        ))}
+      </Select>
+      <Button
+        color="primary"
+        className="w-full"
+        size="lg"
+        isLoading={isPaying}
+        isDisabled={isDisabled}
+        onPress={() => onPay(effectivePaymentMethod)}
+      >
+        {t("summary.pay")}
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/pages/Store/Cart/Summary/CartTotals.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartTotals.jsx
@@ -1,0 +1,27 @@
+import { Divider } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { useCurrency } from "@/components/hooks/useCurrency";
+
+export function CartTotals({ subtotal, discountAmount, total }) {
+  const t = useTranslations("cart");
+  const { formatAmount } = useCurrency();
+
+  return (
+    <div className="space-y-2 text-sm text-gray-800">
+      <div className="flex justify-between">
+        <span>{t("summary.subtotal")}</span>
+        <span>{formatAmount(subtotal)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>{t("summary.discount")}</span>
+        <span>{formatAmount(discountAmount)}</span>
+      </div>
+      <Divider className="bg-green-600" />
+      <div className="flex justify-between items-center font-semibold text-green-900">
+        <span>{t("summary.total")}:</span>
+        <span className="text-lg">{formatAmount(total)}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/pages/Store/Cart/Summary/CartTotals.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/CartTotals.jsx
@@ -4,22 +4,22 @@ import { useTranslations } from "next-intl";
 import { useCurrency } from "@/components/hooks/useCurrency";
 
 export function CartTotals({ subtotal, discountAmount, total }) {
-  const t = useTranslations("cart");
+  const translateCart = useTranslations("cart");
   const { formatAmount } = useCurrency();
 
   return (
     <div className="space-y-2 text-sm text-gray-800">
       <div className="flex justify-between">
-        <span>{t("summary.subtotal")}</span>
+        <span>{translateCart("summary.subtotal")}</span>
         <span>{formatAmount(subtotal)}</span>
       </div>
       <div className="flex justify-between">
-        <span>{t("summary.discount")}</span>
+        <span>{translateCart("summary.discount")}</span>
         <span>{formatAmount(discountAmount)}</span>
       </div>
       <Divider className="bg-green-600" />
       <div className="flex justify-between items-center font-semibold text-green-900">
-        <span>{t("summary.total")}:</span>
+        <span>{translateCart("summary.total")}:</span>
         <span className="text-lg">{formatAmount(total)}</span>
       </div>
     </div>

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 
-import { Button, Card, CardBody, CardHeader, Divider, Image, NumberInput, Select, SelectItem } from "@heroui/react";
+import { addToast, Button, Card, CardBody, CardHeader, Divider, Image, NumberInput, Select, SelectItem } from "@heroui/react";
 import { ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -13,6 +13,7 @@ import { CardPaymentModal } from "../CardPaymentModal";
 import { CashPaymentModal } from "../CashPaymentModal";
 import { usePaymentMethods } from "../hooks/usePaymentMethod";
 
+import { usePendingRemoval } from "./hooks/usePendingRemoval";
 import { SwipeableCartItem } from "./SwipeableCartItem";
 
 export function SummaryContent({
@@ -31,11 +32,31 @@ export function SummaryContent({
   const t = useTranslations("cart");
   const { formatAmount } = useCurrency();
   const { paymentMethods } = usePaymentMethods();
+  const { pendingRemovals, startRemoval, cancelRemoval } = usePendingRemoval();
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("");
   const [isTouchDevice] = useState(
     () => typeof window !== "undefined" && navigator.maxTouchPoints > 0,
   );
   const items = cartItems || [];
+  const visibleItems = items.filter((item) => !pendingRemovals.has(item.id));
+
+  const handleStartRemoval = (item) => {
+    startRemoval(item.id, () => onRemoveProduct(item.id));
+    addToast({
+      description: item.name,
+      timeout: 5000,
+      endContent: (
+        <Button
+          size="sm"
+          color="primary"
+          className="bg-green-800"
+          onPress={() => cancelRemoval(item.id)}
+        >
+          {t("summary.undoToast.undo")}
+        </Button>
+      ),
+    });
+  };
 
   const effectivePaymentMethod = useMemo(() => {
     if (selectedPaymentMethod) return selectedPaymentMethod;
@@ -72,12 +93,12 @@ export function SummaryContent({
   return (
     <>
       <div className="space-y-4">
-        {items.map((item) => {
+        {visibleItems.map((item) => {
           const imageUrl = storedAssetUrl(item.imageUrl);
           return (
             <SwipeableCartItem
               key={item.id}
-              onRemove={() => onRemoveProduct(item.id)}
+              onRemove={() => handleStartRemoval(item)}
               isTouchDevice={isTouchDevice}
             >
               <Card className="shadow-none border-1 border-green-600">
@@ -107,7 +128,7 @@ export function SummaryContent({
                         </div>
                       </div>
                     </div>
-                    {!isTouchDevice && <DeleteButton onPress={() => onRemoveProduct(item.id)} />}
+                    <DeleteButton onPress={() => handleStartRemoval(item)} />
                   </div>
                 </CardHeader>
                 <CardBody>
@@ -178,7 +199,7 @@ export function SummaryContent({
             className="w-full"
             size="lg"
             isLoading={isPaying}
-            isDisabled={!items.length}
+            isDisabled={!visibleItems.length}
             onPress={handlePay}
           >
             {t("summary.pay")}
@@ -214,6 +235,7 @@ export function SummaryContent({
         onClose={cardPayment?.onClose}
         onComplete={cardPayment?.onComplete}
       />
+
     </>
   );
 }

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -26,7 +26,7 @@ export function SummaryContent({
   cashPayment,
   cardPayment,
 }) {
-  const t = useTranslations("cart");
+  const translateCart = useTranslations("cart");
   const { pendingRemovals, startRemoval, cancelRemoval } = usePendingRemoval();
   const [isTouchDevice] = useState(
     () => typeof window !== "undefined" && navigator.maxTouchPoints > 0,
@@ -50,7 +50,7 @@ export function SummaryContent({
           className="bg-green-800"
           onPress={() => cancelRemoval(item.id)}
         >
-          {t("summary.undoToast.undo")}
+          {translateCart("summary.undoToast.undo")}
         </Button>
       ),
     });

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -1,18 +1,16 @@
 import { useMemo, useState } from "react";
 
-import { addToast, Button, Card, CardBody, CardHeader, Divider, Image, NumberInput, Select, SelectItem } from "@heroui/react";
-import { ImageIcon } from "lucide-react";
+import { addToast, Button, Divider, Select, SelectItem } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
-import { DeleteButton } from "@/components/shared/DeleteButton";
-import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
 import { BitcoinPaymentModal } from "../BitcoinPaymentModal";
 import { CardPaymentModal } from "../CardPaymentModal";
 import { CashPaymentModal } from "../CashPaymentModal";
 import { usePaymentMethods } from "../hooks/usePaymentMethod";
 
+import { CartItemCard } from "./CartItemCard";
 import { usePendingRemoval } from "./hooks/usePendingRemoval";
 import { SwipeableCartItem } from "./SwipeableCartItem";
 
@@ -93,64 +91,19 @@ export function SummaryContent({
   return (
     <>
       <div className="space-y-4">
-        {visibleItems.map((item) => {
-          const imageUrl = storedAssetUrl(item.imageUrl);
-          return (
-            <SwipeableCartItem
-              key={item.id}
+        {visibleItems.map((item) => (
+          <SwipeableCartItem
+            key={item.id}
+            onRemove={() => handleStartRemoval(item)}
+            isTouchDevice={isTouchDevice}
+          >
+            <CartItemCard
+              item={item}
               onRemove={() => handleStartRemoval(item)}
-              isTouchDevice={isTouchDevice}
-            >
-              <Card className="shadow-none border-1 border-green-600">
-                <CardHeader>
-                  <div className="flex w-full items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
-                        {imageUrl ? (
-                          <Image
-                            removeWrapper
-                            alt={item.name}
-                            src={imageUrl}
-                            className="h-full w-full object-cover"
-                          />
-                        ) : (
-                          <div data-testid={`summary-image-placeholder-${item.id}`}>
-                            <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex min-w-0 flex-col">
-                        <h3 className="text-sm font-medium text-green-900">
-                          {item.name}
-                        </h3>
-                        <div className="text-xs text-gray-700">
-                          {formatAmount(item.price)} {t("summary.each")}
-                        </div>
-                      </div>
-                    </div>
-                    <DeleteButton onPress={() => handleStartRemoval(item)} />
-                  </div>
-                </CardHeader>
-                <CardBody>
-                  <div className="flex items-center justify-between">
-                    <NumberInput
-                      className="w-1/2"
-                      label={t("summary.quantity")}
-                      minValue={1}
-                      size="sm"
-                      placeholder="Enter the amount"
-                      value={item.quantity}
-                      onChange={(value) => onUpdateQuantity(item.id, Number(value))}
-                    />
-                    <div className="text-sm font-semibold text-green-900">
-                      {formatAmount(item.subtotal)}
-                    </div>
-                  </div>
-                </CardBody>
-              </Card>
-            </SwipeableCartItem>
-          );
-        })}
+              onUpdateQuantity={onUpdateQuantity}
+            />
+          </SwipeableCartItem>
+        ))}
 
         <div className="space-y-2 text-sm text-gray-800">
           <div className="flex justify-between">

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -1,16 +1,15 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
-import { addToast, Button, Divider, Select, SelectItem } from "@heroui/react";
+import { addToast, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
-
-import { useCurrency } from "@/components/hooks/useCurrency";
 
 import { BitcoinPaymentModal } from "../BitcoinPaymentModal";
 import { CardPaymentModal } from "../CardPaymentModal";
 import { CashPaymentModal } from "../CashPaymentModal";
-import { usePaymentMethods } from "../hooks/usePaymentMethod";
 
 import { CartItemCard } from "./CartItemCard";
+import { CartPaymentSection } from "./CartPaymentSection";
+import { CartTotals } from "./CartTotals";
 import { usePendingRemoval } from "./hooks/usePendingRemoval";
 import { SwipeableCartItem } from "./SwipeableCartItem";
 
@@ -28,15 +27,16 @@ export function SummaryContent({
   cardPayment,
 }) {
   const t = useTranslations("cart");
-  const { formatAmount } = useCurrency();
-  const { paymentMethods } = usePaymentMethods();
   const { pendingRemovals, startRemoval, cancelRemoval } = usePendingRemoval();
-  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("");
   const [isTouchDevice] = useState(
     () => typeof window !== "undefined" && navigator.maxTouchPoints > 0,
   );
   const items = cartItems || [];
   const visibleItems = items.filter((item) => !pendingRemovals.has(item.id));
+
+  const subtotal = items.reduce((sum, item) => sum + item.subtotal, 0);
+  const discountAmount = (subtotal * (Number(discount) || 0)) / 100;
+  const total = subtotal - discountAmount;
 
   const handleStartRemoval = (item) => {
     startRemoval(item.id, () => onRemoveProduct(item.id));
@@ -53,38 +53,6 @@ export function SummaryContent({
           {t("summary.undoToast.undo")}
         </Button>
       ),
-    });
-  };
-
-  const effectivePaymentMethod = useMemo(() => {
-    if (selectedPaymentMethod) return selectedPaymentMethod;
-    const bitcoinLightningMethod = paymentMethods.find((method) => method.name === "BTC");
-    return bitcoinLightningMethod ? String(bitcoinLightningMethod.id) : "";
-  }, [selectedPaymentMethod, paymentMethods]);
-
-  const { subtotal, discountAmount, total } = useMemo(() => {
-    const itemsToProcess = cartItems || [];
-    const subtotalValue = itemsToProcess.reduce((sum, item) => sum + item.subtotal, 0);
-    const discountValue = Number(discount) || 0;
-    const discountTotal = (subtotalValue * discountValue) / 100;
-    const totalValue = subtotalValue - discountTotal;
-
-    return {
-      subtotal: subtotalValue,
-      discountAmount: discountTotal,
-      total: totalValue,
-    };
-  }, [cartItems, discount]);
-
-  const handlePay = () => {
-    onClearPaymentError?.();
-    onPay?.({
-      items,
-      subtotal,
-      discount,
-      discountAmount,
-      total,
-      selectedPaymentMethod: effectivePaymentMethod,
     });
   };
 
@@ -105,59 +73,18 @@ export function SummaryContent({
           </SwipeableCartItem>
         ))}
 
-        <div className="space-y-2 text-sm text-gray-800">
-          <div className="flex justify-between">
-            <span>{t("summary.subtotal")}</span>
-            <span>{formatAmount(subtotal)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>{t("summary.discount")}</span>
-            <span>{formatAmount(discountAmount)}</span>
-          </div>
-          <Divider className="bg-green-600" />
-          <div className="flex justify-between items-center font-semibold text-green-900">
-            <span>{t("summary.total")}:</span>
-            <span className="text-lg">{formatAmount(total)}</span>
-          </div>
-        </div>
+        <CartTotals subtotal={subtotal} discountAmount={discountAmount} total={total} />
 
-        {paymentError && (
-          <p className="text-sm text-red-600">{paymentError}</p>
-        )}
-
-        <div className="space-y-2">
-          <Select
-            label={t("summary.paymentMethodLabel")}
-            placeholder={t("summary.paymentMethodSelectPlaceholder")}
-            isRequired
-            errorMessage={t("summary.errorMsgSelectEmpty")}
-            selectedKeys={effectivePaymentMethod ? [effectivePaymentMethod] : []}
-            onSelectionChange={(keys) => {
-              const value = Array.from(keys)[0];
-              if (!value) return;
-              setSelectedPaymentMethod(value);
-              onClearPaymentError?.();
-            }}
-            isDisabled={isPaying}
-          >
-            {paymentMethods.map((method) => (
-              <SelectItem key={method.id} value={method.id}>
-                {method.name === "BTC" ? `${method.name} (Lightning)` : method.name}
-              </SelectItem>
-            ))}
-          </Select>
-
-          <Button
-            color="primary"
-            className="w-full"
-            size="lg"
-            isLoading={isPaying}
-            isDisabled={!visibleItems.length}
-            onPress={handlePay}
-          >
-            {t("summary.pay")}
-          </Button>
-        </div>
+        <CartPaymentSection
+          isPaying={isPaying}
+          isDisabled={!visibleItems.length}
+          paymentError={paymentError}
+          onClearPaymentError={onClearPaymentError}
+          onPay={(selectedPaymentMethod) => {
+            onClearPaymentError?.();
+            onPay?.({ items, subtotal, discount, discountAmount, total, selectedPaymentMethod });
+          }}
+        />
       </div>
 
       <BitcoinPaymentModal

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -13,6 +13,8 @@ import { CardPaymentModal } from "../CardPaymentModal";
 import { CashPaymentModal } from "../CashPaymentModal";
 import { usePaymentMethods } from "../hooks/usePaymentMethod";
 
+import { SwipeableCartItem } from "./SwipeableCartItem";
+
 export function SummaryContent({
   cartItems,
   discount,
@@ -30,6 +32,9 @@ export function SummaryContent({
   const { formatAmount } = useCurrency();
   const { paymentMethods } = usePaymentMethods();
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("");
+  const [isTouchDevice] = useState(
+    () => typeof window !== "undefined" && navigator.maxTouchPoints > 0,
+  );
   const items = cartItems || [];
 
   const effectivePaymentMethod = useMemo(() => {
@@ -70,53 +75,59 @@ export function SummaryContent({
         {items.map((item) => {
           const imageUrl = storedAssetUrl(item.imageUrl);
           return (
-            <Card key={item.id} className="shadow-none border-1 border-green-600">
-              <CardHeader>
-                <div className="flex w-full items-start justify-between gap-3">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
-                      {imageUrl ? (
-                        <Image
-                          removeWrapper
-                          alt={item.name}
-                          src={imageUrl}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <div data-testid={`summary-image-placeholder-${item.id}`}>
-                          <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
+            <SwipeableCartItem
+              key={item.id}
+              onRemove={() => onRemoveProduct(item.id)}
+              isTouchDevice={isTouchDevice}
+            >
+              <Card className="shadow-none border-1 border-green-600">
+                <CardHeader>
+                  <div className="flex w-full items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden bg-gray-100">
+                        {imageUrl ? (
+                          <Image
+                            removeWrapper
+                            alt={item.name}
+                            src={imageUrl}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <div data-testid={`summary-image-placeholder-${item.id}`}>
+                            <ImageIcon aria-hidden="true" className="h-5 w-5 text-gray-400" />
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex min-w-0 flex-col">
+                        <h3 className="text-sm font-medium text-green-900">
+                          {item.name}
+                        </h3>
+                        <div className="text-xs text-gray-700">
+                          {formatAmount(item.price)} {t("summary.each")}
                         </div>
-                      )}
-                    </div>
-                    <div className="flex min-w-0 flex-col">
-                      <h3 className="text-sm font-medium text-green-900">
-                        {item.name}
-                      </h3>
-                      <div className="text-xs text-gray-700">
-                        {formatAmount(item.price)} {t("summary.each")}
                       </div>
                     </div>
+                    {!isTouchDevice && <DeleteButton onPress={() => onRemoveProduct(item.id)} />}
                   </div>
-                  <DeleteButton onPress={() => onRemoveProduct(item.id)} />
-                </div>
-              </CardHeader>
-              <CardBody>
-                <div className="flex items-center justify-between">
-                  <NumberInput
-                    className="w-1/2"
-                    label={t("summary.quantity")}
-                    minValue={1}
-                    size="sm"
-                    placeholder="Enter the amount"
-                    value={item.quantity}
-                    onChange={(value) => onUpdateQuantity(item.id, Number(value))}
-                  />
-                  <div className="text-sm font-semibold text-green-900">
-                    {formatAmount(item.subtotal)}
+                </CardHeader>
+                <CardBody>
+                  <div className="flex items-center justify-between">
+                    <NumberInput
+                      className="w-1/2"
+                      label={t("summary.quantity")}
+                      minValue={1}
+                      size="sm"
+                      placeholder="Enter the amount"
+                      value={item.quantity}
+                      onChange={(value) => onUpdateQuantity(item.id, Number(value))}
+                    />
+                    <div className="text-sm font-semibold text-green-900">
+                      {formatAmount(item.subtotal)}
+                    </div>
                   </div>
-                </div>
-              </CardBody>
-            </Card>
+                </CardBody>
+              </Card>
+            </SwipeableCartItem>
           );
         })}
 

--- a/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
@@ -1,9 +1,10 @@
 import { motion, useMotionValue, useTransform, animate } from "framer-motion";
-import { Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 const DELETE_THRESHOLD = 100;
 
 export function SwipeableCartItem({ onRemove, isTouchDevice, children }) {
+  const t = useTranslations("cart");
   const dragX = useMotionValue(0);
   const deleteBackgroundOpacity = useTransform(dragX, [-DELETE_THRESHOLD, 0], [1, 0]);
 
@@ -17,7 +18,7 @@ export function SwipeableCartItem({ onRemove, isTouchDevice, children }) {
         className="absolute inset-0 bg-red-500 flex items-center justify-end px-5 rounded-lg"
         style={{ opacity: deleteBackgroundOpacity }}
       >
-        <Trash2 className="text-white w-6 h-6" />
+        <span className="text-white font-semibold text-sm">{t("summary.swipeDelete")}</span>
       </motion.div>
       <motion.div
         style={{ x: dragX }}

--- a/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 const DELETE_THRESHOLD = 100;
 
 export function SwipeableCartItem({ onRemove, isTouchDevice, children }) {
-  const t = useTranslations("cart");
+  const translateCart = useTranslations("cart");
   const dragX = useMotionValue(0);
   const deleteBackgroundOpacity = useTransform(dragX, [-DELETE_THRESHOLD, 0], [1, 0]);
 
@@ -18,7 +18,7 @@ export function SwipeableCartItem({ onRemove, isTouchDevice, children }) {
         className="absolute inset-0 bg-red-500 flex items-center justify-end px-5 rounded-lg"
         style={{ opacity: deleteBackgroundOpacity }}
       >
-        <span className="text-white font-semibold text-sm">{t("summary.swipeDelete")}</span>
+        <span className="text-white font-semibold text-sm">{translateCart("summary.swipeDelete")}</span>
       </motion.div>
       <motion.div
         style={{ x: dragX }}

--- a/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SwipeableCartItem.jsx
@@ -1,0 +1,39 @@
+import { motion, useMotionValue, useTransform, animate } from "framer-motion";
+import { Trash2 } from "lucide-react";
+
+const DELETE_THRESHOLD = 100;
+
+export function SwipeableCartItem({ onRemove, isTouchDevice, children }) {
+  const dragX = useMotionValue(0);
+  const deleteBackgroundOpacity = useTransform(dragX, [-DELETE_THRESHOLD, 0], [1, 0]);
+
+  if (!isTouchDevice) {
+    return children;
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-lg">
+      <motion.div
+        className="absolute inset-0 bg-red-500 flex items-center justify-end px-5 rounded-lg"
+        style={{ opacity: deleteBackgroundOpacity }}
+      >
+        <Trash2 className="text-white w-6 h-6" />
+      </motion.div>
+      <motion.div
+        style={{ x: dragX }}
+        drag="x"
+        dragConstraints={{ left: -DELETE_THRESHOLD, right: 0 }}
+        dragElastic={0.2}
+        onDragEnd={(_, info) => {
+          if (info.offset.x < -DELETE_THRESHOLD) {
+            animate(dragX, -500, { duration: 0.2 }).then(() => onRemove());
+          } else {
+            animate(dragX, 0, { type: "spring", stiffness: 500, damping: 40 });
+          }
+        }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/CartItemCard.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/CartItemCard.test.jsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { CartItemCard } from "../CartItemCard";
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: () => ({ formatAmount: (value) => `fmt-${value}` }),
+}));
+
+jest.mock("@/components/shared/DeleteButton", () => ({
+  DeleteButton: ({ onPress }) => (
+    <button aria-label="Remove Product" onClick={onPress} />
+  ),
+}));
+
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return {
+    ...actual,
+    NumberInput: ({ label, value, onChange }) => (
+      <input aria-label={label} value={value} onChange={(e) => onChange?.(e.target.value)} />
+    ),
+  };
+});
+
+jest.mock("lucide-react", () => ({
+  ImageIcon: () => <span data-testid="image-icon" />,
+}));
+
+const defaultItem = {
+  id: 1,
+  name: "Jade Wallet",
+  price: 1000,
+  quantity: 2,
+  subtotal: 2000,
+  imageUrl: "/uploads/jade-wallet.png",
+};
+
+describe("CartItemCard", () => {
+  it("renders item name", () => {
+    render(<CartItemCard item={defaultItem} onRemove={jest.fn()} onUpdateQuantity={jest.fn()} />);
+    expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
+  });
+
+  it("renders formatted price and subtotal", () => {
+    render(<CartItemCard item={defaultItem} onRemove={jest.fn()} onUpdateQuantity={jest.fn()} />);
+    expect(screen.getByText(/fmt-1000/)).toBeInTheDocument();
+    expect(screen.getByText("fmt-2000")).toBeInTheDocument();
+  });
+
+  it("renders the product image when imageUrl is present", () => {
+    render(<CartItemCard item={defaultItem} onRemove={jest.fn()} onUpdateQuantity={jest.fn()} />);
+    expect(screen.getByRole("img", { name: "Jade Wallet" })).toHaveAttribute(
+      "src",
+      "/uploads/jade-wallet.png",
+    );
+  });
+
+  it("renders a placeholder when imageUrl is missing", () => {
+    render(
+      <CartItemCard
+        item={{ ...defaultItem, imageUrl: undefined }}
+        onRemove={jest.fn()}
+        onUpdateQuantity={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("summary-image-placeholder-1")).toBeInTheDocument();
+  });
+
+  it("calls onRemove when delete button is pressed", () => {
+    const onRemove = jest.fn();
+    render(<CartItemCard item={defaultItem} onRemove={onRemove} onUpdateQuantity={jest.fn()} />);
+    fireEvent.click(screen.getByLabelText("Remove Product"));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it("calls onUpdateQuantity with item id and new value when quantity changes", () => {
+    const onUpdateQuantity = jest.fn();
+    render(<CartItemCard item={defaultItem} onRemove={jest.fn()} onUpdateQuantity={onUpdateQuantity} />);
+    fireEvent.change(screen.getByLabelText("summary.quantity"), { target: { value: "5" } });
+    expect(onUpdateQuantity).toHaveBeenCalledWith(1, 5);
+  });
+});

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/CartPaymentSection.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/CartPaymentSection.test.jsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { CartPaymentSection } from "../CartPaymentSection";
+
+jest.mock("../../hooks/usePaymentMethod", () => ({
+  usePaymentMethods: () => ({
+    paymentMethods: [
+      { id: "cash", name: "Cash" },
+      { id: "btc", name: "BTC" },
+    ],
+  }),
+}));
+
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return {
+    ...actual,
+    Select: ({ label, selectedKeys, onSelectionChange, children, isDisabled }) => (
+      <select
+        aria-label={label}
+        disabled={isDisabled}
+        value={selectedKeys?.[0] || ""}
+        onChange={(e) => onSelectionChange?.(new Set([e.target.value]))}
+      >
+        <option value="">placeholder</option>
+        {children}
+      </select>
+    ),
+    SelectItem: ({ value, children }) => <option value={value}>{children}</option>,
+  };
+});
+
+const defaultProps = {
+  isPaying: false,
+  isDisabled: false,
+  paymentError: "",
+  onClearPaymentError: jest.fn(),
+  onPay: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("CartPaymentSection", () => {
+  it("selects BTC as default payment method", () => {
+    render(<CartPaymentSection {...defaultProps} />);
+    expect(screen.getByLabelText("summary.paymentMethodLabel")).toHaveValue("btc");
+  });
+
+  it("calls onPay with the selected payment method when Pay is pressed", () => {
+    const onPay = jest.fn();
+    render(<CartPaymentSection {...defaultProps} onPay={onPay} />);
+    fireEvent.click(screen.getByText("summary.pay"));
+    expect(onPay).toHaveBeenCalledWith("btc");
+  });
+
+  it("shows payment error when provided", () => {
+    render(<CartPaymentSection {...defaultProps} paymentError="payment.error" />);
+    expect(screen.getByText("payment.error")).toBeInTheDocument();
+  });
+
+  it("calls onClearPaymentError when payment method changes", () => {
+    const onClearPaymentError = jest.fn();
+    render(<CartPaymentSection {...defaultProps} onClearPaymentError={onClearPaymentError} />);
+    fireEvent.change(screen.getByLabelText("summary.paymentMethodLabel"), { target: { value: "cash" } });
+    expect(onClearPaymentError).toHaveBeenCalled();
+  });
+
+  it("disables Pay button when isDisabled is true", () => {
+    render(<CartPaymentSection {...defaultProps} isDisabled />);
+    expect(screen.getByText("summary.pay")).toBeDisabled();
+  });
+});

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/CartTotals.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/CartTotals.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import { CartTotals } from "../CartTotals";
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: () => ({ formatAmount: (value) => `fmt-${value}` }),
+}));
+
+describe("CartTotals", () => {
+  it("renders the subtotal", () => {
+    render(<CartTotals subtotal={1000} discountAmount={100} total={900} />);
+    expect(screen.getByText("fmt-1000")).toBeInTheDocument();
+  });
+
+  it("renders the discount amount", () => {
+    render(<CartTotals subtotal={1000} discountAmount={100} total={900} />);
+    expect(screen.getByText("fmt-100")).toBeInTheDocument();
+  });
+
+  it("renders the total", () => {
+    render(<CartTotals subtotal={1000} discountAmount={100} total={900} />);
+    expect(screen.getByText("fmt-900")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -2,6 +2,19 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { SummaryContent } from "../SummaryContent";
 
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return { ...actual, addToast: jest.fn() };
+});
+
+jest.mock("../hooks/usePendingRemoval", () => ({
+  usePendingRemoval: () => ({
+    pendingRemovals: new Set(),
+    startRemoval: jest.fn((itemId, onConfirm) => onConfirm()),
+    cancelRemoval: jest.fn(),
+  }),
+}));
+
 jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({ formatAmount: (value) => `fmt-${value}` }),
 }));

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -7,6 +7,16 @@ jest.mock("@heroui/react", () => {
   return { ...actual, addToast: jest.fn() };
 });
 
+jest.mock("../CartItemCard", () => ({
+  CartItemCard: ({ item, onRemove }) => (
+    <div data-testid={`cart-item-${item.id}`}>
+      <span>{item.name}</span>
+      <button aria-label="Remove Product" onClick={onRemove} />
+      <span data-testid={`summary-image-placeholder-${item.id}`} />
+    </div>
+  ),
+}));
+
 jest.mock("../hooks/usePendingRemoval", () => ({
   usePendingRemoval: () => ({
     pendingRemovals: new Set(),
@@ -86,24 +96,11 @@ beforeEach(() => {
 });
 
 describe("SummaryContent", () => {
-  it("renders item name, price and subtotal", () => {
+  it("renders a CartItemCard for each cart item", () => {
     render(<SummaryContent {...defaultProps} />);
 
+    expect(screen.getByTestId("cart-item-1")).toBeInTheDocument();
     expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Jade Wallet" })).toHaveAttribute("src", "/uploads/jade-wallet.png");
-    expect(screen.getByText(/fmt-1000/)).toBeInTheDocument();
-    expect(screen.getAllByText("fmt-2000")).toHaveLength(2);
-  });
-
-  it("renders a placeholder when an item image is missing", () => {
-    render(
-      <SummaryContent
-        {...defaultProps}
-        cartItems={[{ id: 2, name: "M5 Stick", price: 500, quantity: 1, subtotal: 500 }]}
-      />,
-    );
-
-    expect(screen.getByTestId("summary-image-placeholder-2")).toBeInTheDocument();
   });
 
   it("renders computed totals with discount", () => {
@@ -119,14 +116,6 @@ describe("SummaryContent", () => {
 
     fireEvent.click(screen.getByLabelText("Remove Product"));
     expect(onRemoveProduct).toHaveBeenCalledWith(1);
-  });
-
-  it("calls onUpdateQuantity when quantity changes", () => {
-    const onUpdateQuantity = jest.fn();
-    render(<SummaryContent {...defaultProps} onUpdateQuantity={onUpdateQuantity} />);
-
-    fireEvent.change(screen.getByLabelText("summary.quantity"), { target: { value: "3" } });
-    expect(onUpdateQuantity).toHaveBeenCalledWith(1, 3);
   });
 
   it("selects BTC as default payment method", () => {

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -2,10 +2,26 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { SummaryContent } from "../SummaryContent";
 
-jest.mock("@heroui/react", () => {
-  const actual = jest.requireActual("@heroui/react");
-  return { ...actual, addToast: jest.fn() };
-});
+jest.mock("../CartTotals", () => ({
+  CartTotals: ({ subtotal, discountAmount, total }) => (
+    <div>
+      <span>{`fmt-${subtotal}`}</span>
+      <span>{`fmt-${discountAmount}`}</span>
+      <span>{`fmt-${total}`}</span>
+    </div>
+  ),
+}));
+
+jest.mock("../CartPaymentSection", () => ({
+  CartPaymentSection: ({ onPay, isDisabled, paymentError }) => (
+    <div>
+      {paymentError && <p>{paymentError}</p>}
+      <button disabled={isDisabled} onClick={() => onPay("btc")}>
+        summary.pay
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock("../CartItemCard", () => ({
   CartItemCard: ({ item, onRemove }) => (
@@ -103,7 +119,7 @@ describe("SummaryContent", () => {
     expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
   });
 
-  it("renders computed totals with discount", () => {
+  it("passes computed totals to CartTotals", () => {
     render(<SummaryContent {...defaultProps} />);
 
     expect(screen.getByText("fmt-200")).toBeInTheDocument();
@@ -116,12 +132,6 @@ describe("SummaryContent", () => {
 
     fireEvent.click(screen.getByLabelText("Remove Product"));
     expect(onRemoveProduct).toHaveBeenCalledWith(1);
-  });
-
-  it("selects BTC as default payment method", () => {
-    render(<SummaryContent {...defaultProps} />);
-
-    expect(screen.getByLabelText("summary.paymentMethodLabel")).toHaveValue("btc");
   });
 
   it("calls onPay with correct data when Pay is pressed", () => {
@@ -145,12 +155,6 @@ describe("SummaryContent", () => {
     expect(screen.getByText("summary.pay")).toBeDisabled();
   });
 
-  it("shows payment error message", () => {
-    render(<SummaryContent {...defaultProps} paymentError="payment.error" />);
-
-    expect(screen.getByText("payment.error")).toBeInTheDocument();
-  });
-
   it("handles undefined cartItems gracefully", () => {
     render(<SummaryContent {...defaultProps} cartItems={undefined} />);
 
@@ -170,13 +174,5 @@ describe("SummaryContent", () => {
     expect(screen.getByText("btc-modal")).toBeInTheDocument();
     expect(screen.getByText("cash-modal")).toBeInTheDocument();
     expect(screen.getByText("card-modal")).toBeInTheDocument();
-  });
-
-  it("clears payment error when payment method changes", () => {
-    const onClearPaymentError = jest.fn();
-    render(<SummaryContent {...defaultProps} paymentError="error" onClearPaymentError={onClearPaymentError} />);
-
-    fireEvent.change(screen.getByLabelText("summary.paymentMethodLabel"), { target: { value: "cash" } });
-    expect(onClearPaymentError).toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SwipeableCartItem.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SwipeableCartItem.test.jsx
@@ -16,10 +16,6 @@ jest.mock("framer-motion", () => {
   };
 });
 
-jest.mock("lucide-react", () => ({
-  Trash2: () => <span data-testid="trash-icon" />,
-}));
-
 afterEach(() => {
   global.__swipeableOnDragEnd = null;
   jest.clearAllMocks();
@@ -50,14 +46,14 @@ describe("SwipeableCartItem", () => {
       expect(screen.getByTestId("child-content")).toBeInTheDocument();
     });
 
-    it("renders the delete background with trash icon", () => {
+    it("renders the delete label in the swipe background", () => {
       render(
         <SwipeableCartItem onRemove={jest.fn()} isTouchDevice>
           <div />
         </SwipeableCartItem>,
       );
 
-      expect(screen.getByTestId("trash-icon")).toBeInTheDocument();
+      expect(screen.getByText("summary.swipeDelete")).toBeInTheDocument();
     });
 
     it("calls onRemove when drag exceeds the delete threshold", async () => {

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SwipeableCartItem.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SwipeableCartItem.test.jsx
@@ -1,0 +1,93 @@
+import { render, screen, act } from "@testing-library/react";
+
+import { SwipeableCartItem } from "../SwipeableCartItem";
+
+jest.mock("framer-motion", () => {
+  const React = require("react");
+  const MockMotionDiv = ({ children, onDragEnd, style, drag, dragConstraints, dragElastic, ...rest }) => {
+    if (onDragEnd) global.__swipeableOnDragEnd = onDragEnd;
+    return React.createElement("div", rest, children);
+  };
+  return {
+    motion: { div: MockMotionDiv },
+    useMotionValue: (initial) => ({ get: () => initial, set: jest.fn() }),
+    useTransform: () => ({ get: () => 0 }),
+    animate: jest.fn(() => Promise.resolve()),
+  };
+});
+
+jest.mock("lucide-react", () => ({
+  Trash2: () => <span data-testid="trash-icon" />,
+}));
+
+afterEach(() => {
+  global.__swipeableOnDragEnd = null;
+  jest.clearAllMocks();
+});
+
+describe("SwipeableCartItem", () => {
+  describe("non-touch device", () => {
+    it("renders children directly without a wrapper", () => {
+      render(
+        <SwipeableCartItem onRemove={jest.fn()} isTouchDevice={false}>
+          <div data-testid="child-content" />
+        </SwipeableCartItem>,
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.queryByTestId("trash-icon")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("touch device", () => {
+    it("renders children inside the swipeable wrapper", () => {
+      render(
+        <SwipeableCartItem onRemove={jest.fn()} isTouchDevice>
+          <div data-testid="child-content" />
+        </SwipeableCartItem>,
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+    });
+
+    it("renders the delete background with trash icon", () => {
+      render(
+        <SwipeableCartItem onRemove={jest.fn()} isTouchDevice>
+          <div />
+        </SwipeableCartItem>,
+      );
+
+      expect(screen.getByTestId("trash-icon")).toBeInTheDocument();
+    });
+
+    it("calls onRemove when drag exceeds the delete threshold", async () => {
+      const onRemove = jest.fn();
+      render(
+        <SwipeableCartItem onRemove={onRemove} isTouchDevice>
+          <div />
+        </SwipeableCartItem>,
+      );
+
+      await act(async () => {
+        await global.__swipeableOnDragEnd({}, { offset: { x: -150, y: 0 } });
+      });
+
+      expect(onRemove).toHaveBeenCalled();
+    });
+
+    it("does not call onRemove when drag is within the threshold", async () => {
+      const onRemove = jest.fn();
+      render(
+        <SwipeableCartItem onRemove={onRemove} isTouchDevice>
+          <div />
+        </SwipeableCartItem>,
+      );
+
+      await act(async () => {
+        await global.__swipeableOnDragEnd({}, { offset: { x: -50, y: 0 } });
+      });
+
+      expect(onRemove).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/pages/Store/Cart/Summary/hooks/__tests__/usePendingRemoval.test.js
+++ b/client/src/components/pages/Store/Cart/Summary/hooks/__tests__/usePendingRemoval.test.js
@@ -1,0 +1,108 @@
+import { renderHook, act } from "@testing-library/react";
+
+import { usePendingRemoval } from "../usePendingRemoval";
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("usePendingRemoval", () => {
+  it("starts with an empty set", () => {
+    const { result } = renderHook(() => usePendingRemoval());
+    expect(result.current.pendingRemovals.size).toBe(0);
+  });
+
+  it("adds the item id to pendingRemovals when startRemoval is called", () => {
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, jest.fn());
+    });
+
+    expect(result.current.pendingRemovals.has(42)).toBe(true);
+  });
+
+  it("calls onConfirm and removes the id after 5 seconds", () => {
+    const onConfirm = jest.fn();
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, onConfirm);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onConfirm).toHaveBeenCalled();
+    expect(result.current.pendingRemovals.has(42)).toBe(false);
+  });
+
+  it("does not call onConfirm before 5 seconds", () => {
+    const onConfirm = jest.fn();
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, onConfirm);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(4999);
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("cancels the timer and removes the id when cancelRemoval is called", () => {
+    const onConfirm = jest.fn();
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, onConfirm);
+    });
+
+    act(() => {
+      result.current.cancelRemoval(42);
+    });
+
+    expect(result.current.pendingRemovals.has(42)).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple independent removals simultaneously", () => {
+    const onConfirm1 = jest.fn();
+    const onConfirm2 = jest.fn();
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(1, onConfirm1);
+      result.current.startRemoval(2, onConfirm2);
+    });
+
+    expect(result.current.pendingRemovals.has(1)).toBe(true);
+    expect(result.current.pendingRemovals.has(2)).toBe(true);
+
+    act(() => {
+      result.current.cancelRemoval(1);
+    });
+
+    expect(result.current.pendingRemovals.has(1)).toBe(false);
+    expect(result.current.pendingRemovals.has(2)).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onConfirm1).not.toHaveBeenCalled();
+    expect(onConfirm2).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/pages/Store/Cart/Summary/hooks/usePendingRemoval.js
+++ b/client/src/components/pages/Store/Cart/Summary/hooks/usePendingRemoval.js
@@ -1,0 +1,31 @@
+import { useState, useRef } from "react";
+
+export function usePendingRemoval() {
+  const [pendingRemovals, setPendingRemovals] = useState(new Set());
+  const timers = useRef({});
+
+  const startRemoval = (itemId, onConfirm) => {
+    setPendingRemovals((prev) => new Set([...prev, itemId]));
+    timers.current[itemId] = setTimeout(() => {
+      onConfirm();
+      setPendingRemovals((prev) => {
+        const next = new Set(prev);
+        next.delete(itemId);
+        return next;
+      });
+      delete timers.current[itemId];
+    }, 5000);
+  };
+
+  const cancelRemoval = (itemId) => {
+    clearTimeout(timers.current[itemId]);
+    delete timers.current[itemId];
+    setPendingRemovals((prev) => {
+      const next = new Set(prev);
+      next.delete(itemId);
+      return next;
+    });
+  };
+
+  return { pendingRemovals, startRemoval, cancelRemoval };
+}

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -28,6 +28,10 @@ const cartEn = {
       pay: "Pay",
       each: "each",
       viewCart: "Checkout",
+      swipeDelete: "Remove",
+      undoToast: {
+        undo: "Undo",
+      },
     },
     payment: {
       errors: {

--- a/client/src/components/pages/Store/Cart/locales/es.js
+++ b/client/src/components/pages/Store/Cart/locales/es.js
@@ -28,6 +28,10 @@ const cartEs = {
       pay: "Pagar",
       each: "c/u",
       viewCart: "Cobrar",
+      swipeDelete: "Remover",
+      undoToast: {
+        undo: "Deshacer",
+      },
     },
     payment: {
       errors: {


### PR DESCRIPTION
## Changes:
- Add `SwipeableCartItem` component with Framer Motion drag gesture: swipe left past 100px threshold triggers removal with slide-out animation; snaps back if released within threshold
- Add `usePendingRemoval` hook with 5-second deferred deletion and independent per-item timer cancellation
- Integrate undo toast via HeroUI `addToast` with an Undo button that cancels the pending removal; locale keys added for `swipeDelete` and `undoToast.undo` (EN/ES)
- Refactor `SummaryContent` by extracting `CartItemCard`, `CartTotals`, and `CartPaymentSection` as focused, independently-tested components
- Update Framer Motion mock to support `useMotionValue`, `useTransform`, `animate`, and drag-related props; add `SwipeableCartItem` tests using `global.__swipeableOnDragEnd` pattern

**Screnshots**:
<img width="488" height="674" alt="Screenshot 2026-05-23 at 6 48 10 p m" src="https://github.com/user-attachments/assets/02295db5-fd77-42ea-8274-505d877e54da" />
<img width="488" height="405" alt="Screenshot 2026-05-23 at 6 48 33 p m" src="https://github.com/user-attachments/assets/e63c4aae-6194-44cd-84dc-61ebd0c62141" />

**Related Issues**:
https://github.com/olympus-btc/ambrosia/issues/514