### PR TITLE
fix(store):  Cart persistent state

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -22,10 +22,30 @@ export function Cart() {
     cart,
     setCart,
     discount,
+    hydrated,
     resetCartState,
   } = usePersistentCart();
   const { products, refetch: refetchProducts } = useProducts();
   const { categories } = useCategories();
+
+  useEffect(() => {
+    if (!hydrated || products.length === 0) return;
+    setCart((currentCart) => {
+      let changed = false;
+      const reconciled = currentCart.reduce((acc, item) => {
+        const product = products.find((p) => p.id === item.id);
+        if (!product) { changed = true; return acc; }
+        if (product.priceCents !== item.price) {
+          changed = true;
+          acc.push({ ...item, price: product.priceCents, subtotal: item.quantity * product.priceCents });
+        } else {
+          acc.push(item);
+        }
+        return acc;
+      }, []);
+      return changed ? reconciled : currentCart;
+    });
+  }, [products, hydrated, setCart]);
 
   const {
     handlePay,
@@ -196,6 +216,7 @@ export function Cart() {
           <Summary
             cartItems={cart}
             discount={discount}
+            hydrated={hydrated}
             onRemoveProduct={removeProduct}
             onClearCart={clearCart}
             onUpdateQuantity={updateQuantity}
@@ -221,6 +242,7 @@ export function Cart() {
         onClose={() => setShowMobileSummary(false)}
         cartItems={cart}
         discount={discount}
+        hydrated={hydrated}
         onRemoveProduct={removeProduct}
         onClearCart={clearCart}
         onUpdateQuantity={updateQuantity}

--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -14,6 +14,21 @@ import { usePersistentCart } from "./hooks/usePersistentCart";
 import { SearchProducts } from "./SearchProducts";
 import { MobileSummaryBar, Summary, SummaryModal } from "./Summary";
 
+function reconcileCartWithProducts(cart, products) {
+  const reconciledItems = cart.reduce((reconciledItems, item) => {
+    const catalogProduct = products.find((product) => product.id === item.id);
+    if (!catalogProduct) return reconciledItems;
+    if (catalogProduct.priceCents === item.price) return [...reconciledItems, item];
+    return [...reconciledItems, { ...item, price: catalogProduct.priceCents, subtotal: item.quantity * catalogProduct.priceCents }];
+  }, []);
+
+  const hasChanges =
+    reconciledItems.length !== cart.length ||
+    reconciledItems.some((item, index) => item !== cart[index]);
+
+  return hasChanges ? reconciledItems : cart;
+}
+
 export function Cart() {
   const t = useTranslations("cart");
   const outOfStockTimeoutRef = useRef(null);
@@ -30,21 +45,7 @@ export function Cart() {
 
   useEffect(() => {
     if (!hydrated || products.length === 0) return;
-    setCart((currentCart) => {
-      let changed = false;
-      const reconciled = currentCart.reduce((acc, item) => {
-        const product = products.find((p) => p.id === item.id);
-        if (!product) { changed = true; return acc; }
-        if (product.priceCents !== item.price) {
-          changed = true;
-          acc.push({ ...item, price: product.priceCents, subtotal: item.quantity * product.priceCents });
-        } else {
-          acc.push(item);
-        }
-        return acc;
-      }, []);
-      return changed ? reconciled : currentCart;
-    });
+    setCart((currentCart) => reconcileCartWithProducts(currentCart, products));
   }, [products, hydrated, setCart]);
 
   const {
@@ -92,9 +93,9 @@ export function Cart() {
   }, [cart.length]);
 
   const cartTotal = useMemo(() => {
-    const sub = cart.reduce((sum, item) => sum + item.subtotal, 0);
-    const disc = Number(discount) || 0;
-    return sub - (sub * disc) / 100;
+    const subtotal = cart.reduce((sum, item) => sum + item.subtotal, 0);
+    const discountRate = Number(discount) || 0;
+    return subtotal - (subtotal * discountRate) / 100;
   }, [cart, discount]);
 
   const getAvailableQuantity = (productId) => {

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -16,6 +16,7 @@ import { usePaymentMethods } from "../hooks/usePaymentMethod";
 export function SummaryContent({
   cartItems,
   discount,
+  hydrated,
   onRemoveProduct,
   onUpdateQuantity,
   onPay,
@@ -167,7 +168,7 @@ export function SummaryContent({
             className="w-full"
             size="lg"
             isLoading={isPaying}
-            isDisabled={!items.length}
+            isDisabled={!hydrated || !items.length}
             onPress={handlePay}
           >
             {t("summary.pay")}

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -60,6 +60,7 @@ const cartItems = [{ id: 1, imageUrl: "/uploads/jade-wallet.png", name: "Jade Wa
 const defaultProps = {
   cartItems,
   discount: 10,
+  hydrated: true,
   onRemoveProduct: jest.fn(),
   onUpdateQuantity: jest.fn(),
   onPay: jest.fn(),
@@ -139,6 +140,12 @@ describe("SummaryContent", () => {
 
   it("disables Pay button when cart is empty", () => {
     render(<SummaryContent {...defaultProps} cartItems={[]} />);
+
+    expect(screen.getByText("summary.pay")).toBeDisabled();
+  });
+
+  it("disables Pay button when not yet hydrated even if cart has items", () => {
+    render(<SummaryContent {...defaultProps} hydrated={false} />);
 
     expect(screen.getByText("summary.pay")).toBeDisabled();
   });

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -49,6 +49,7 @@ jest.mock("../hooks/usePersistentCart", () => ({
     setCart: mockSetCart,
     discount: 0,
     setDiscount: mockSetDiscount,
+    hydrated: true,
     resetCartState: mockResetCartState,
   }),
 }));
@@ -56,8 +57,8 @@ jest.mock("../hooks/usePersistentCart", () => ({
 jest.mock("../../hooks/useProducts", () => ({
   useProducts: () => ({
     products: [
-      { id: 1, quantity: 5 },
-      { id: 2, quantity: 5 },
+      { id: 1, quantity: 5, priceCents: 100 },
+      { id: 2, quantity: 5, priceCents: 200 },
     ],
     refetch: jest.fn(),
   }),
@@ -183,6 +184,21 @@ describe("Cart page", () => {
       { id: 1, name: "Jade Wallet", price: 100, quantity: 1, subtotal: 100 },
       { id: 2, imageUrl: "/uploads/m5.png", name: "M5 Stick", price: 200, quantity: 1, subtotal: 200 },
     ]);
+  });
+
+  it("reconciles stale cart prices when products load", async () => {
+    await act(async () => {
+      renderCart();
+    });
+
+    const setCartCalls = mockSetCart.mock.calls;
+    const reconcileCall = setCartCalls.find(([arg]) => typeof arg === "function");
+    expect(reconcileCall).toBeDefined();
+
+    const updater = reconcileCall[0];
+    const staleCart = [{ id: 1, name: "Jade Wallet", price: 50, quantity: 2, subtotal: 100 }];
+    const result = updater(staleCart);
+    expect(result).toEqual([{ id: 1, name: "Jade Wallet", price: 100, quantity: 2, subtotal: 200 }]);
   });
 
   it("updates quantity, removes product when quantity is zero, and forwards pay", async () => {

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/usePersistentCart.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/usePersistentCart.test.jsx
@@ -7,7 +7,7 @@ import { usePersistentCart, CART_STORAGE_KEY } from "../usePersistentCart";
 const handlers = {};
 
 function TestComponent() {
-  const { cart, discount, setCart, setDiscount, resetCartState } = usePersistentCart();
+  const { cart, discount, hydrated, setCart, setDiscount, resetCartState } = usePersistentCart();
   useEffect(() => {
     handlers.setCart = setCart;
     handlers.setDiscount = setDiscount;
@@ -17,6 +17,7 @@ function TestComponent() {
     <div>
       <span data-testid="count">{cart.length}</span>
       <span data-testid="discount">{discount}</span>
+      <span data-testid="hydrated">{String(hydrated)}</span>
     </div>
   );
 }
@@ -121,6 +122,14 @@ describe("usePersistentCart", () => {
     });
 
     localStorage.setItem = originalSetItem;
+  });
+
+  it("exposes hydrated=false before effect and hydrated=true after", async () => {
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hydrated")).toHaveTextContent("true");
+    });
   });
 
   it("handles storage clear errors gracefully", async () => {

--- a/client/src/components/pages/Store/Cart/hooks/usePersistentCart.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/usePersistentCart.jsx
@@ -59,6 +59,7 @@ export function usePersistentCart() {
     setCart,
     discount,
     setDiscount,
+    hydrated,
     resetCartState,
   };
 }


### PR DESCRIPTION
## Summary

- Exposes a `hydrated` flag from `usePersistentCart` to signal when the cart has finished rehydrating from `localStorage`
- Disables the Pay button until `hydrated === true` to prevent payments before the cart state is ready
- Adds a reconciliation effect in `Cart` that, once hydrated and products are loaded, updates stale prices from `localStorage` and removes products that no longer exist

## Test plan

- [x] Add a product to the cart, reload the page — cart should persist and Pay should remain disabled until hydration completes
- [x] Change the price of a product in the backend while a cart is saved in `localStorage`, reload — the cart should update to the new price automatically
- [x] Add a product, delete it from the backend, reload — the product should be removed from the cart on load
- [x] All 17 Cart test suites pass (`npx jest --testPathPatterns="Cart|usePersistentCart|SummaryContent"`)
- [x] Lint passes (`npm run lint`)
