### PR TITLE
Feat(sale): add description product with accordion

### DIFF
--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -36,42 +36,43 @@ export function ProductList({ products, onAddProduct, categories }) {
     <div className="grid grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4">
       {products.map((product) => {
         const status = stockStatus(product);
-        const imageUrl = storedAssetUrl(product.imageUrl);
+        const { id, description, priceCents, name, imageUrl, SKU, categoryIds, quantity } = product;
+        const productImageUrl = storedAssetUrl(imageUrl);
         return (
           <Card
             shadow="none"
             className="bg-white rounded-lg"
-            key={product.id}
+            key={id}
           >
             <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
-              {imageUrl ? (
+              {productImageUrl ? (
                 <Image
                   removeWrapper
-                  alt={product.name}
-                  src={imageUrl}
+                  alt={name}
+                  src={productImageUrl}
                   className="w-full h-full object-cover rounded-none"
                 />
               ) : (
-                <div data-testid={`product-image-placeholder-${product.id}`}>
+                <div data-testid={`product-image-placeholder-${id}`}>
                   <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
                 </div>
               )}
             </div>
             <CardHeader className="flex flex-col items-start pb-1">
-              <h2 className="text-sm md:text-lg font-medium">{product.name}</h2>
-              <p className="text-xs">{getCategoryNames(product.categoryIds)}</p>
+              <h2 className="text-sm md:text-lg font-medium">{name}</h2>
+              <p className="text-xs">{getCategoryNames(categoryIds)}</p>
             </CardHeader>
             <CardBody className="py-1">
               <h2 className="text-lg md:text-2xl font-bold text-green-800">
-                {formatAmount(product.priceCents)}
+                {formatAmount(priceCents)}
               </h2>
               <p className="hidden md:block text-xs">
-                SKU: <span className="text-gray-800">{product.SKU}</span>
+                SKU: <span className="text-gray-800">{SKU}</span>
               </p>
-              {product.description && (
+              {description && (
                 <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
                   <AccordionItem
-                    key={product.id}
+                    key={id}
                     indicator={<ChevronUp className="text-primary h-4 w-4" />}
                     classNames={{
                       trigger: "px-0 rounded-lg",
@@ -88,7 +89,7 @@ export function ProductList({ products, onAddProduct, categories }) {
                     title={cardProductTranslation("card.showProductDescription")}
                     className="text-gray-400 text-justify text-xs"
                   >
-                    {product.description}
+                    {description}
                   </AccordionItem>
                 </Accordion>
               )}
@@ -104,12 +105,12 @@ export function ProductList({ products, onAddProduct, categories }) {
                       : "bg-green-200 text-xs text-green-800 border border-green-300"
                 }
               >
-                {normalizeNumber(product.quantity)} {cardProductTranslation("card.stock")}
+                {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
               </Chip>
               <Button
                 color="primary"
                 size="sm"
-                isDisabled={product.quantity === 0}
+                isDisabled={quantity === 0}
                 onPress={() => onAddProduct(product)}
               >
                 {cardProductTranslation("card.add")}

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -123,7 +123,7 @@ export function ProductList({ products, onAddProduct, categories }) {
                 </Chip>
                 <div className="flex justify-between">
                   <div className="md:hidden">
-                    <ViewButton onPress={() => handleShowProductDetails(product)}>Ver Detalles</ViewButton>
+                    <ViewButton onPress={() => handleShowProductDetails(product)} />
                   </div>
 
                   <Button

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -7,6 +7,8 @@ import { useTranslations } from "next-intl";
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
+import { ViewButton } from "../../../shared/ViewButton";
+
 export function ProductList({ products, onAddProduct, categories }) {
   const cardProductTranslation = useTranslations("cart");
   const { formatAmount } = useCurrency();
@@ -94,7 +96,9 @@ export function ProductList({ products, onAddProduct, categories }) {
                 </Accordion>
               )}
             </CardBody>
-            <CardFooter className="flex flex-col items-stretch gap-5 sm:flex-row sm:items-center sm:justify-between">
+            <CardFooter
+              className="flex flex-col pt-0 items-stretch gap-2 md:gap-5 sm:flex-row sm:items-center sm:justify-between"
+            >
               <Chip
                 size="sm"
                 className={
@@ -107,14 +111,21 @@ export function ProductList({ products, onAddProduct, categories }) {
               >
                 {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
               </Chip>
-              <Button
-                color="primary"
-                size="sm"
-                isDisabled={quantity === 0}
-                onPress={() => onAddProduct(product)}
-              >
-                {cardProductTranslation("card.add")}
-              </Button>
+              <div className="flex justify-between">
+                <div className="md:hidden">
+                  <ViewButton>Ver Detalles</ViewButton>
+                </div>
+
+                <Button
+                  className="w-full ml-3"
+                  color="primary"
+                  size="sm"
+                  isDisabled={quantity === 0}
+                  onPress={() => onAddProduct(product)}
+                >
+                  {cardProductTranslation("card.add")}
+                </Button>
+              </div>
             </CardFooter>
           </Card>
         );

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button, Card, CardBody, CardFooter, CardHeader, Chip, Image } from "@heroui/react";
-import { ImageIcon } from "lucide-react";
+import { Accordion, AccordionItem, Button, Card, CardBody, CardFooter, CardHeader, Chip, Image } from "@heroui/react";
+import { ChevronUp, ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
@@ -68,6 +68,30 @@ export function ProductList({ products, onAddProduct, categories }) {
               <p className="hidden md:block text-xs">
                 SKU: <span className="text-gray-800">{product.SKU}</span>
               </p>
+              {product.description && (
+                <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
+                  <AccordionItem
+                    key={product.id}
+                    indicator={<ChevronUp className="text-primary h-4 w-4" />}
+                    classNames={{
+                      trigger: "px-0 rounded-lg",
+                      content: "px-0",
+                      indicator: [
+                        "rotate-0",
+                        "data-[open=true]:rotate-180",
+                        "transition-transform",
+                        "duration-200",
+                      ].join(" "),
+                      title: "text-xs",
+                    }}
+                    aria-label={`${cardProductTranslation("card.showProductDescription")} ${product.name}`}
+                    title={cardProductTranslation("card.showProductDescription")}
+                    className="text-gray-400 text-justify text-xs"
+                  >
+                    {product.description}
+                  </AccordionItem>
+                </Accordion>
+              )}
             </CardBody>
             <CardFooter className="flex flex-col items-stretch gap-5 sm:flex-row sm:items-center sm:justify-between">
               <Chip

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -1,18 +1,22 @@
 "use client";
 
+import { useState } from "react";
+
 import { Accordion, AccordionItem, Button, Card, CardBody, CardFooter, CardHeader, Chip, Image } from "@heroui/react";
 import { ChevronUp, ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
+import { ProductDetailsModal } from "@/components/shared/ProductDetailsModal";
+import { ViewButton } from "@/components/shared/ViewButton";
 import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
-
-import { ViewButton } from "../../../shared/ViewButton";
 
 export function ProductList({ products, onAddProduct, categories }) {
   const cardProductTranslation = useTranslations("cart");
   const { formatAmount } = useCurrency();
   const defaultMaxStock = 11;
+  const [showProductDetails, setShowProductDetails] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState(null);
 
   const getCategoryNames = (categoryIds) => {
     const ids = categoryIds ?? [];
@@ -34,102 +38,116 @@ export function ProductList({ products, onAddProduct, categories }) {
     return "ok";
   };
 
-  return (
-    <div className="grid grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4">
-      {products.map((product) => {
-        const status = stockStatus(product);
-        const { id, description, priceCents, name, imageUrl, SKU, categoryIds, quantity } = product;
-        const productImageUrl = storedAssetUrl(imageUrl);
-        return (
-          <Card
-            shadow="none"
-            className="bg-white rounded-lg"
-            key={id}
-          >
-            <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
-              {productImageUrl ? (
-                <Image
-                  removeWrapper
-                  alt={name}
-                  src={productImageUrl}
-                  className="w-full h-full object-cover rounded-none"
-                />
-              ) : (
-                <div data-testid={`product-image-placeholder-${id}`}>
-                  <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
-                </div>
-              )}
-            </div>
-            <CardHeader className="flex flex-col items-start pb-1">
-              <h2 className="text-sm md:text-lg font-medium">{name}</h2>
-              <p className="text-xs">{getCategoryNames(categoryIds)}</p>
-            </CardHeader>
-            <CardBody className="py-1">
-              <h2 className="text-lg md:text-2xl font-bold text-green-800">
-                {formatAmount(priceCents)}
-              </h2>
-              <p className="hidden md:block text-xs">
-                SKU: <span className="text-gray-800">{SKU}</span>
-              </p>
-              {description && (
-                <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
-                  <AccordionItem
-                    key={id}
-                    indicator={<ChevronUp className="text-primary h-4 w-4" />}
-                    classNames={{
-                      trigger: "px-0 rounded-lg",
-                      content: "px-0",
-                      indicator: [
-                        "rotate-0",
-                        "data-[open=true]:rotate-180",
-                        "transition-transform",
-                        "duration-200",
-                      ].join(" "),
-                      title: "text-xs",
-                    }}
-                    aria-label={`${cardProductTranslation("card.showProductDescription")} ${product.name}`}
-                    title={cardProductTranslation("card.showProductDescription")}
-                    className="text-gray-400 text-justify text-xs"
-                  >
-                    {description}
-                  </AccordionItem>
-                </Accordion>
-              )}
-            </CardBody>
-            <CardFooter
-              className="flex flex-col pt-0 items-stretch gap-2 md:gap-5 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <Chip
-                size="sm"
-                className={
-                  status === "out"
-                    ? "bg-rose-100 text-rose-800 border border-rose-200 text-xs"
-                    : status === "low"
-                      ? "bg-amber-100 text-amber-800 border border-amber-200 text-xs"
-                      : "bg-green-200 text-xs text-green-800 border border-green-300"
-                }
-              >
-                {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
-              </Chip>
-              <div className="flex justify-between">
-                <div className="md:hidden">
-                  <ViewButton>Ver Detalles</ViewButton>
-                </div>
+  const handleShowProductDetails = (product) => {
+    setShowProductDetails(true);
+    setSelectedProduct(product);
+  };
 
-                <Button
-                  className="w-full ml-3"
-                  color="primary"
-                  size="sm"
-                  isDisabled={quantity === 0}
-                  onPress={() => onAddProduct(product)}
-                >
-                  {cardProductTranslation("card.add")}
-                </Button>
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4">
+        {products.map((product) => {
+          const status = stockStatus(product);
+          const { id, description, priceCents, name, imageUrl, SKU, categoryIds, quantity } = product;
+          const productImageUrl = storedAssetUrl(imageUrl);
+          return (
+            <Card
+              shadow="none"
+              className="bg-white rounded-lg"
+              key={id}
+            >
+              <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
+                {productImageUrl ? (
+                  <Image
+                    removeWrapper
+                    alt={name}
+                    src={productImageUrl}
+                    className="w-full h-full object-cover rounded-none"
+                  />
+                ) : (
+                  <div data-testid={`product-image-placeholder-${id}`}>
+                    <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
+                  </div>
+                )}
               </div>
-            </CardFooter>
-          </Card>
-        );
-      })}
-    </div>
+              <CardHeader className="flex flex-col items-start pb-1">
+                <h2 className="text-sm md:text-lg font-medium">{name}</h2>
+                <p className="text-xs">{getCategoryNames(categoryIds)}</p>
+              </CardHeader>
+              <CardBody className="py-1">
+                <h2 className="text-lg md:text-2xl font-bold text-green-800">
+                  {formatAmount(priceCents)}
+                </h2>
+                <p className="hidden md:block text-xs">
+                  SKU: <span className="text-gray-800">{SKU}</span>
+                </p>
+                {description && (
+                  <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
+                    <AccordionItem
+                      key={id}
+                      indicator={<ChevronUp className="text-primary h-4 w-4" />}
+                      classNames={{
+                        trigger: "px-0 rounded-lg",
+                        content: "px-0",
+                        indicator: [
+                          "rotate-0",
+                          "data-[open=true]:rotate-180",
+                          "transition-transform",
+                          "duration-200",
+                        ].join(" "),
+                        title: "text-xs",
+                      }}
+                      aria-label={`${cardProductTranslation("card.showProductDescription")} ${product.name}`}
+                      title={cardProductTranslation("card.showProductDescription")}
+                      className="text-gray-400 text-justify text-xs"
+                    >
+                      {description}
+                    </AccordionItem>
+                  </Accordion>
+                )}
+              </CardBody>
+              <CardFooter
+                className="flex flex-col pt-0 items-stretch gap-2 md:gap-5 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <Chip
+                  size="sm"
+                  className={
+                    status === "out"
+                      ? "bg-rose-100 text-rose-800 border border-rose-200 text-xs"
+                      : status === "low"
+                        ? "bg-amber-100 text-amber-800 border border-amber-200 text-xs"
+                        : "bg-green-200 text-xs text-green-800 border border-green-300"
+                  }
+                >
+                  {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
+                </Chip>
+                <div className="flex justify-between">
+                  <div className="md:hidden">
+                    <ViewButton onPress={() => handleShowProductDetails(product)}>Ver Detalles</ViewButton>
+                  </div>
+
+                  <Button
+                    className="w-full ml-3"
+                    color="primary"
+                    size="sm"
+                    isDisabled={quantity === 0}
+                    onPress={() => onAddProduct(product)}
+                  >
+                    {cardProductTranslation("card.add")}
+                  </Button>
+                </div>
+              </CardFooter>
+            </Card>
+          );
+        })}
+      </div>
+      <ProductDetailsModal
+        isOpen={showProductDetails}
+        onClose={() => setShowProductDetails(false)}
+        showAddButton={false}
+        product={selectedProduct}
+        categories={categories}
+      />
+    </>
   );
 }

--- a/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
@@ -21,6 +21,22 @@ jest.mock("@heroui/react", () => ({
   ),
 }));
 
+jest.mock("@/components/shared/ViewButton", () => ({
+  ViewButton: ({ onPress, children }) => (
+    <button data-testid="view-button" onClick={onPress}>{children}</button>
+  ),
+}));
+
+jest.mock("@/components/shared/ProductDetailsModal", () => ({
+  ProductDetailsModal: ({ isOpen, onClose, product, showAddButton }) => (isOpen ? (
+    <div data-testid="product-details-modal">
+      <span data-testid="modal-product-name">{product?.name}</span>
+      {showAddButton && <button>modal-add</button>}
+      <button onClick={onClose}>close-modal</button>
+    </div>
+  ) : null),
+}));
+
 const products = [
   {
     id: 1,
@@ -128,5 +144,71 @@ describe("ProductList", () => {
     );
 
     expect(screen.queryByText("card.showProductDescription")).not.toBeInTheDocument();
+  });
+
+  it("does not show ProductDetailsModal initially", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={[productWithDescription]}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByTestId("product-details-modal")).not.toBeInTheDocument();
+  });
+
+  it("opens ProductDetailsModal with the correct product when ViewButton is clicked", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={[productWithDescription]}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("view-button"));
+
+    expect(screen.getByTestId("product-details-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("modal-product-name")).toHaveTextContent("M5 StickPlus");
+  });
+
+  it("opens ProductDetailsModal with showAddButton=false", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={[productWithDescription]}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("view-button"));
+
+    expect(screen.queryByText("modal-add")).not.toBeInTheDocument();
+  });
+
+  it("closes ProductDetailsModal when onClose is called", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={[productWithDescription]}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("view-button"));
+    expect(screen.getByTestId("product-details-modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("close-modal"));
+
+    expect(screen.queryByTestId("product-details-modal")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/ProductList.test.jsx
@@ -10,6 +10,17 @@ jest.mock("@/components/hooks/useCurrency", () => ({
   }),
 }));
 
+jest.mock("@heroui/react", () => ({
+  ...jest.requireActual("@heroui/react"),
+  Accordion: ({ children }) => <div>{children}</div>,
+  AccordionItem: ({ children, title, "aria-label": ariaLabel }) => (
+    <div>
+      <button aria-label={ariaLabel}>{title}</button>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
 const products = [
   {
     id: 1,
@@ -29,6 +40,16 @@ const products = [
     quantity: 1,
   },
 ];
+
+const productWithDescription = {
+  id: 3,
+  name: "M5 StickPlus",
+  SKU: "m5-stickplus",
+  categoryIds: ["cat-1"],
+  priceCents: 900,
+  quantity: 5,
+  description: "A compact IoT device with built-in display.",
+};
 
 const categories = [
   { id: "cat-1", name: "Hardware" },
@@ -78,5 +99,34 @@ describe("ProductList", () => {
     const addButtons = screen.getAllByText("card.add");
     fireEvent.click(addButtons[0]);
     expect(onAddProduct).toHaveBeenCalledWith(products[0]);
+  });
+
+  it("renders description accordion title and content for a product with description", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={[productWithDescription]}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("card.showProductDescription")).toBeInTheDocument();
+    expect(screen.getByText("A compact IoT device with built-in display.")).toBeInTheDocument();
+  });
+
+  it("does not render description accordion for products without description", () => {
+    render(
+      <I18nProvider>
+        <ProductList
+          products={products}
+          categories={categories}
+          onAddProduct={jest.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByText("card.showProductDescription")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -11,6 +11,7 @@ const cartEn = {
       add: "Add",
       stock: "in stock",
       showProductDetails: "Show Details",
+      showProductDescription: "Description",
       errors: {
         unknownCategory: "Unknown category",
       },

--- a/client/src/components/pages/Store/Cart/locales/es.js
+++ b/client/src/components/pages/Store/Cart/locales/es.js
@@ -11,6 +11,7 @@ const cartEs = {
       add: "Agregar",
       stock: "en almacén",
       showProductDetails: "Ver detalles",
+      showProductDescription: "Descripcion",
       errors: {
         unknownCategory: "Categoría desconocida",
       },

--- a/client/src/components/shared/ProductDetailsModal.jsx
+++ b/client/src/components/shared/ProductDetailsModal.jsx
@@ -82,10 +82,10 @@ export function ProductDetailsModal({ isOpen, onClose, onAddProduct, showAddButt
 
           {product.description && (
             <div>
-              <p className="text-xs tracking-wide text-gray-500 mb-1">
+              <p className="text-xs tracking-wide text-primary mb-1">
                 {t("description")}
               </p>
-              <p className="text-sm text-gray-600">{product.description}</p>
+              <p className="text-xs text-gray-400">{product.description}</p>
             </div>
           )}
         </ModalBody>

--- a/client/src/components/shared/__tests__/ProductDetailsModal.test.jsx
+++ b/client/src/components/shared/__tests__/ProductDetailsModal.test.jsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ProductDetailsModal } from "../ProductDetailsModal";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: () => ({
+    formatAmount: (value) => `fmt-${value}`,
+  }),
+}));
+
+jest.mock("@heroui/react", () => ({
+  Modal: ({ isOpen, children }) => (isOpen ? <div data-testid="modal">{children}</div> : null),
+  ModalContent: ({ children }) => (
+    <div>{typeof children === "function" ? children() : children}</div>
+  ),
+  ModalHeader: ({ children }) => <div data-testid="modal-header">{children}</div>,
+  ModalBody: ({ children }) => <div data-testid="modal-body">{children}</div>,
+  ModalFooter: ({ children }) => <div data-testid="modal-footer">{children}</div>,
+  Button: ({ children, onPress, isDisabled }) => (
+    <button onClick={onPress} disabled={isDisabled}>
+      {children}
+    </button>
+  ),
+  Chip: ({ children }) => <span>{children}</span>,
+  Image: ({ alt, src }) => <img alt={alt} src={src} />,
+}));
+
+const baseProduct = {
+  id: 1,
+  name: "Jade Wallet",
+  SKU: "jade-wallet",
+  categoryIds: ["cat-1"],
+  imageUrl: "/uploads/jade-wallet.png",
+  priceCents: 1600,
+  quantity: 5,
+  description: "A premium hardware wallet.",
+};
+
+const categories = [{ id: "cat-1", name: "Hardware" }];
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onAddProduct: jest.fn(),
+  showAddButton: true,
+  product: baseProduct,
+  categories,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProductDetailsModal", () => {
+  it("returns null when no product is provided", () => {
+    const { container } = render(
+      <ProductDetailsModal {...defaultProps} product={null} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when isOpen is false", () => {
+    render(<ProductDetailsModal {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
+  it("renders product name, price, SKU and category", () => {
+    render(<ProductDetailsModal {...defaultProps} />);
+
+    expect(screen.getByText("Jade Wallet")).toBeInTheDocument();
+    expect(screen.getByText("fmt-1600")).toBeInTheDocument();
+    expect(screen.getByText("jade-wallet")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+  });
+
+  it("renders description label with text-primary class", () => {
+    render(<ProductDetailsModal {...defaultProps} />);
+
+    expect(screen.getByText("description")).toHaveClass("text-primary");
+  });
+
+  it("renders description text with text-xs and text-gray-400 classes", () => {
+    render(<ProductDetailsModal {...defaultProps} />);
+
+    expect(screen.getByText("A premium hardware wallet.")).toHaveClass("text-xs", "text-gray-400");
+  });
+
+  it("does not render description section when product has no description", () => {
+    render(
+      <ProductDetailsModal {...defaultProps} product={{ ...baseProduct, description: undefined }} />,
+    );
+
+    expect(screen.queryByText("description")).not.toBeInTheDocument();
+    expect(screen.queryByText("A premium hardware wallet.")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is pressed", () => {
+    const onClose = jest.fn();
+    render(<ProductDetailsModal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByText("close"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onAddProduct with the product and onClose when add button is pressed", () => {
+    const onAddProduct = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <ProductDetailsModal {...defaultProps} onAddProduct={onAddProduct} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByText("add"));
+
+    expect(onAddProduct).toHaveBeenCalledWith(baseProduct);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides add button when showAddButton is false", () => {
+    render(<ProductDetailsModal {...defaultProps} showAddButton={false} />);
+
+    expect(screen.queryByText("add")).not.toBeInTheDocument();
+    expect(screen.getByText("close")).toBeInTheDocument();
+  });
+
+  it("disables add button when product is out of stock", () => {
+    render(
+      <ProductDetailsModal {...defaultProps} product={{ ...baseProduct, quantity: 0 }} />,
+    );
+
+    expect(screen.getByText("add")).toBeDisabled();
+  });
+});

--- a/client/src/components/shared/__tests__/ProductDetailsModal.test.jsx
+++ b/client/src/components/shared/__tests__/ProductDetailsModal.test.jsx
@@ -26,7 +26,7 @@ jest.mock("@heroui/react", () => ({
     </button>
   ),
   Chip: ({ children }) => <span>{children}</span>,
-  Image: ({ alt, src }) => <img alt={alt} src={src} />,
+  Image: () => null,
 }));
 
 const baseProduct = {


### PR DESCRIPTION
## Summary

  - Adds a collapsible **description accordion** to each product card in the Store Cart (desktop only), letting merchants preview a product's description without leaving the grid
  - Updates description styles in `ProductDetailsModal`: label color changed from `text-gray-500` to `text-primary`, body text from `text-sm text-gray-600` to `text-xs text-gray-400`
  - Adds `card.showProductDescription` translation key to `en.js` and `es.js`
  - Adds a **"Ver Detalles" ViewButton** on mobile product cards that opens the `ProductDetailsModal` for the selected product

  ## Desktop Screenshots
  <img width="710" height="356" alt="image" src="https://github.com/user-attachments/assets/0c94ba27-6eb7-4d32-8f28-a918c5866893" />
  <img width="381" height="675" alt="image" src="https://github.com/user-attachments/assets/26d15438-86b6-42c3-9562-2f290b07a5fd" />
  <img width="455" height="518" alt="image" src="https://github.com/user-attachments/assets/c35306f6-a991-4d3d-ac7a-3d9f567e60dc" />

  ## Mobile Screenshots

  <img width="168" height="287" alt="image" src="https://github.com/user-attachments/assets/8958d9b4-47cb-414f-8e04-91d2a0f22354" />
  <img width="187" height="332" alt="image" src="https://github.com/user-attachments/assets/42f89bc4-527e-4ea5-b544-9738ee897407" />

  ## What changed

  | File | Change |
  |---|---|
  | `ProductList.jsx` | Added `Accordion` / `AccordionItem` that renders when `product.description` exists; hidden on mobile via `hidden md:block` |
  | `ProductList.jsx` | Added `ViewButton` on mobile (hidden on `md+`) that opens `ProductDetailsModal` with the tapped product; `showAddButton={false}` |
  | `ProductDetailsModal.jsx` | Description label: `text-gray-500` → `text-primary`; description text: `text-sm text-gray-600` → `text-xs text-gray-400` |
  | `locales/en.js` / `locales/es.js` | Added `card.showProductDescription` key |

  ## Test plan

  - [x] On desktop, open Store → Cart and confirm the Description accordion appears only on products that have a description
  - [x] Expand the accordion — description text renders correctly and the chevron rotates
  - [x] Products without description show no accordion at all
  - [x] Open the product details modal — description label renders in primary color and description text is `text-xs text-gray-400`
  - [x] On mobile, tap "Ver Detalles" — `ProductDetailsModal` opens with the correct product and no add button
  - [x] Close the modal — modal dismisses and state resets correctly
  - [x] `npx jest --no-coverage` passes with no failures