### PR TITLE
Feature/price historical current

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9365,9 +9365,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -17474,9 +17474,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/client/src/components/hooks/__tests__/useBitcoinPrice.test.js
+++ b/client/src/components/hooks/__tests__/useBitcoinPrice.test.js
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { useBitcoinPrice } from "../useBitcoinPrice";
+
+let mockGetBitcoinPrice;
+
+jest.mock("@/services/bitcoinPriceService", () => jest.fn().mockImplementation(() => ({
+  getBitcoinPrice: (...args) => mockGetBitcoinPrice(...args),
+})),
+);
+
+describe("useBitcoinPrice", () => {
+  beforeEach(() => {
+    mockGetBitcoinPrice = jest.fn();
+  });
+
+  it("returns null currentRate and false isLoading initially without currencyAcronym", () => {
+    const { result } = renderHook(() => useBitcoinPrice());
+    expect(result.current.currentRate).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("fetches and returns currentRate when currencyAcronym is provided", async () => {
+    mockGetBitcoinPrice.mockResolvedValue(50000);
+    const { result } = renderHook(() => useBitcoinPrice({ currencyAcronym: "USD" }));
+
+    await waitFor(() => expect(result.current.currentRate).toBe(50000));
+    expect(mockGetBitcoinPrice).toHaveBeenCalledWith("usd");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("sets isLoading true while fetching", async () => {
+    let resolve;
+    mockGetBitcoinPrice.mockReturnValue(new Promise((res) => { resolve = res; }));
+
+    const { result } = renderHook(() => useBitcoinPrice({ currencyAcronym: "USD" }));
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => { resolve(50000); });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("resets isLoading on fetch error without throwing", async () => {
+    mockGetBitcoinPrice.mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useBitcoinPrice({ currencyAcronym: "USD" }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.currentRate).toBeNull();
+  });
+
+  it("convertSatoshisToFiat returns correct fiat value", async () => {
+    mockGetBitcoinPrice.mockResolvedValue(100000);
+    const { result } = renderHook(() => useBitcoinPrice({ currencyAcronym: "USD" }));
+
+    await waitFor(() => expect(result.current.currentRate).toBe(100000));
+    expect(result.current.convertSatoshisToFiat(100_000_000)).toBeCloseTo(100000);
+    expect(result.current.convertSatoshisToFiat(1_000_000)).toBeCloseTo(1000);
+  });
+
+  it("convertSatoshisToFiat returns null when currentRate is not loaded", () => {
+    const { result } = renderHook(() => useBitcoinPrice());
+    expect(result.current.convertSatoshisToFiat(50000)).toBeNull();
+  });
+});

--- a/client/src/components/hooks/useBitcoinPrice.js
+++ b/client/src/components/hooks/useBitcoinPrice.js
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import BitcoinPriceService from "@/services/bitcoinPriceService";
+
+const bitcoinService = new BitcoinPriceService();
+
+export function useBitcoinPrice({ currencyAcronym } = {}) {
+  const currency = currencyAcronym?.toLowerCase() ?? null;
+  const [currentRate, setCurrentRate] = useState(null);
+  const [fetchedFor, setFetchedFor] = useState(null);
+
+  useEffect(() => {
+    if (!currency) return;
+    let cancelled = false;
+    bitcoinService
+      .getBitcoinPrice(currency)
+      .then((rate) => {
+        if (!cancelled) {
+          setCurrentRate(rate);
+          setFetchedFor(currency);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setFetchedFor(currency);
+      });
+    return () => { cancelled = true; };
+  }, [currency]);
+
+  const isLoading = Boolean(currency) && fetchedFor !== currency;
+
+  const convertSatoshisToFiat = useCallback(
+    (satoshis) => {
+      if (!currentRate || satoshis == null) return null;
+      return (satoshis / 100_000_000) * currentRate;
+    },
+    [currentRate],
+  );
+
+  return { currentRate, isLoading, convertSatoshisToFiat };
+}

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -83,6 +83,11 @@ const componentsEn = {
     other: "Other",
     loadError: "Error loading shift data",
   },
+  amountDisplay: {
+    satsLabel: "sats",
+    showCurrentRate: "Show current rate",
+    showHistoricalRate: "Show rate at time of sale",
+  },
 };
 
 export default componentsEn;

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -87,6 +87,8 @@ const componentsEn = {
     satsLabel: "sats",
     showCurrentRate: "Show current rate",
     showHistoricalRate: "Show rate at time of sale",
+    amountAtTimeOfPayment: "Amount at time of sale",
+    amountAtCurrentRate: "Amount at current rate",
   },
 };
 

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -83,6 +83,11 @@ const componentsEs = {
     other: "Otro",
     loadError: "Error al cargar datos del turno",
   },
+  amountDisplay: {
+    satsLabel: "sats",
+    showCurrentRate: "Ver tipo de cambio actual",
+    showHistoricalRate: "Ver tipo de cambio al momento de la venta",
+  },
 };
 
 export default componentsEs;

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -87,6 +87,8 @@ const componentsEs = {
     satsLabel: "sats",
     showCurrentRate: "Ver tipo de cambio actual",
     showHistoricalRate: "Ver tipo de cambio al momento de la venta",
+    amountAtTimeOfPayment: "Monto al momento del cobro",
+    amountAtCurrentRate: "Monto con tasa actual",
   },
 };
 

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/paymentHandlers.test.js
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/paymentHandlers.test.js
@@ -251,12 +251,18 @@ describe("paymentHandlers", () => {
     expect(dispatch).toHaveBeenCalledWith({ type: "stop" });
   });
 
-  it("updates BTC invoice config on invoice ready", () => {
-    const setBtcPaymentConfig = jest.fn((fn) => fn({ existing: true }));
+  it("stores exchangeRate in btcPaymentConfig on invoice ready", () => {
+    let captured = { existing: true };
+    const setBtcPaymentConfig = jest.fn((fn) => {
+      captured = fn(captured);
+    });
     const handle = buildHandleBtcInvoiceReady({ setBtcPaymentConfig });
 
-    handle({ invoice: "inv" });
-    expect(setBtcPaymentConfig).toHaveBeenCalled();
+    handle({ invoice: { serialized: "ln", paymentHash: "hash-1" }, satoshis: 20000, paymentId: "pay-1", exchangeRate: 50000 });
+
+    expect(captured.invoiceData).toEqual(
+      expect.objectContaining({ exchangeRate: 50000, satoshis: 20000 }),
+    );
   });
 
   it("returns early when BTC config is missing", async () => {
@@ -300,6 +306,7 @@ describe("paymentHandlers", () => {
         discount: 0,
         discountAmount: 0,
         total: 1,
+        invoiceData: { exchangeRate: 50000, satoshis: 20000 },
       },
       dispatch,
       onPay,
@@ -311,10 +318,15 @@ describe("paymentHandlers", () => {
       printCustomerReceipt: jest.fn(() => Promise.resolve()),
     });
 
-    await handler({ invoice: { serialized: "ln" } });
+    await handler({ invoice: { serialized: "ln", paymentHash: "hash-1" }, satoshis: 20000 });
 
     expect(processCheckout).toHaveBeenCalledWith(
-      expect.objectContaining({ transactionId: "ln" }),
+      expect.objectContaining({
+        transactionId: "ln",
+        satoshiAmount: 20000,
+        exchangeRateAtPayment: 50000,
+        paymentHash: "hash-1",
+      }),
     );
     expect(onPay).toHaveBeenCalledWith(
       expect.objectContaining({ orderId: "order-1" }),
@@ -342,6 +354,7 @@ describe("paymentHandlers", () => {
         discount: 0,
         discountAmount: 0,
         total: 1,
+        invoiceData: { exchangeRate: 50000, satoshis: 20000 },
       },
       dispatch: jest.fn(),
       onPay: jest.fn(),
@@ -353,7 +366,7 @@ describe("paymentHandlers", () => {
       printCustomerReceipt: jest.fn(),
     });
 
-    await handler({ invoice: { serialized: "ln" } });
+    await handler({ invoice: { serialized: "ln", paymentHash: "hash-1" }, satoshis: 20000 });
 
     expect(notifyError).toHaveBeenCalledWith("errors.checkout");
     expect(setBtcPaymentConfig).toHaveBeenCalled();

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useBitcoinInvoice.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useBitcoinInvoice.test.jsx
@@ -4,11 +4,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 import { useBitcoinInvoice } from "../useBitcoinInvoice";
 
-let mockFiatToSatoshis;
+let mockGetBitcoinPrice;
 let mockCreateInvoice;
 
 jest.mock("@/services/bitcoinPriceService", () => jest.fn().mockImplementation(() => ({
-  fiatToSatoshis: (...args) => mockFiatToSatoshis(...args),
+  getBitcoinPrice: (...args) => mockGetBitcoinPrice(...args),
 })),
 );
 
@@ -35,25 +35,50 @@ function TestComponent(props) {
 
 describe("useBitcoinInvoice", () => {
   beforeEach(() => {
-    mockFiatToSatoshis = jest.fn();
+    mockGetBitcoinPrice = jest.fn();
     mockCreateInvoice = jest.fn();
     latestState = {};
   });
 
   it("auto-generates invoice when amount is provided", async () => {
-    mockFiatToSatoshis.mockResolvedValue(500);
+    mockGetBitcoinPrice.mockResolvedValue(50000);
     mockCreateInvoice.mockResolvedValue({ serialized: "ln", paymentHash: "hash-1" });
 
     render(<TestComponent amountFiat={10} currencyAcronym="mxn" paymentId="pay-1" />);
 
     await waitFor(() => expect(screen.getByTestId("invoice")).toHaveTextContent("yes"));
-    expect(mockFiatToSatoshis).toHaveBeenCalledWith(10, "mxn");
-    expect(mockCreateInvoice).toHaveBeenCalledWith(500, "pay-1");
-    expect(screen.getByTestId("sats")).toHaveTextContent("500");
+    expect(mockGetBitcoinPrice).toHaveBeenCalledWith("mxn");
+    expect(mockCreateInvoice).toHaveBeenCalledWith(20000, "pay-1");
+    expect(screen.getByTestId("sats")).toHaveTextContent("20000");
+  });
+
+  it("calls onInvoiceReady with satoshis and exchangeRate", async () => {
+    const onInvoiceReady = jest.fn();
+    mockGetBitcoinPrice.mockResolvedValue(50000);
+    mockCreateInvoice.mockResolvedValue({ serialized: "ln", paymentHash: "hash-1" });
+
+    render(
+      <TestComponent
+        amountFiat={10}
+        currencyAcronym="mxn"
+        paymentId="pay-1"
+        onInvoiceReady={onInvoiceReady}
+      />,
+    );
+
+    await waitFor(() => expect(onInvoiceReady).toHaveBeenCalled());
+    expect(onInvoiceReady).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: { serialized: "ln", paymentHash: "hash-1" },
+        satoshis: 20000,
+        paymentId: "pay-1",
+        exchangeRate: 50000,
+      }),
+    );
   });
 
   it("captures errors when invoice creation fails", async () => {
-    mockFiatToSatoshis.mockResolvedValue(500);
+    mockGetBitcoinPrice.mockResolvedValue(50000);
     mockCreateInvoice.mockRejectedValue(new Error("invoice-error"));
 
     render(<TestComponent amountFiat={10} currencyAcronym="mxn" paymentId="pay-1" />);
@@ -69,7 +94,7 @@ describe("useBitcoinInvoice", () => {
       expect(result).toBeNull();
     });
 
-    expect(mockFiatToSatoshis).not.toHaveBeenCalled();
+    expect(mockGetBitcoinPrice).not.toHaveBeenCalled();
     expect(mockCreateInvoice).not.toHaveBeenCalled();
   });
 
@@ -84,11 +109,11 @@ describe("useBitcoinInvoice", () => {
     );
 
     await waitFor(() => expect(screen.getByTestId("invoice")).toHaveTextContent("no"));
-    expect(mockFiatToSatoshis).not.toHaveBeenCalled();
+    expect(mockGetBitcoinPrice).not.toHaveBeenCalled();
   });
 
   it("resets invoice state", async () => {
-    mockFiatToSatoshis.mockResolvedValue(500);
+    mockGetBitcoinPrice.mockResolvedValue(50000);
     mockCreateInvoice.mockResolvedValue({ serialized: "ln", paymentHash: "hash-1" });
 
     render(<TestComponent amountFiat={10} currencyAcronym="mxn" paymentId="pay-1" />);

--- a/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
@@ -8,6 +8,9 @@ export async function processCheckout({
   currencyId,
   user,
   transactionId = "",
+  satoshiAmount = null,
+  exchangeRateAtPayment = null,
+  paymentHash = null,
   t,
 }) {
   const checkoutHttpResponse = await httpClient("/store/orders/checkout", {
@@ -24,6 +27,9 @@ export async function processCheckout({
       currencyId,
       amount: paymentAmounts.amountFiat,
       transactionId: transactionId || "",
+      satoshiAmount,
+      exchangeRateAtPayment,
+      paymentHash,
     }),
   });
 

--- a/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
@@ -11,6 +11,8 @@ export async function processCheckout({
   satoshiAmount = null,
   exchangeRateAtPayment = null,
   paymentHash = null,
+  exchangeRateCurrency = null,
+  fiatAmountAtPayment = null,
   t,
 }) {
   const checkoutHttpResponse = await httpClient("/store/orders/checkout", {
@@ -30,6 +32,8 @@ export async function processCheckout({
       satoshiAmount,
       exchangeRateAtPayment,
       paymentHash,
+      exchangeRateCurrency,
+      fiatAmountAtPayment,
     }),
   });
 

--- a/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
@@ -189,6 +189,8 @@ export function buildHandleBtcComplete({
         satoshiAmount: data?.satoshis ?? null,
         exchangeRateAtPayment: btcPaymentConfig.invoiceData?.exchangeRate ?? null,
         paymentHash: data?.invoice?.paymentHash ?? null,
+        exchangeRateCurrency: btcPaymentConfig.currencyAcronym ?? null,
+        fiatAmountAtPayment: btcPaymentConfig.amountFiat ?? null,
         t,
       });
 

--- a/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
@@ -186,6 +186,9 @@ export function buildHandleBtcComplete({
         currencyId: btcPaymentConfig.currencyId,
         user,
         transactionId: data?.invoice?.serialized || "",
+        satoshiAmount: data?.satoshis ?? null,
+        exchangeRateAtPayment: btcPaymentConfig.invoiceData?.exchangeRate ?? null,
+        paymentHash: data?.invoice?.paymentHash ?? null,
         t,
       });
 

--- a/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useBitcoinInvoice.jsx
@@ -32,10 +32,8 @@ export function useBitcoinInvoice({
     setError("");
 
     try {
-      const sats = await priceService.fiatToSatoshis(
-        amountFiat,
-        currencyAcronym.toLowerCase(),
-      );
+      const btcPrice = await priceService.getBitcoinPrice(currencyAcronym.toLowerCase());
+      const sats = Math.round((amountFiat / btcPrice) * 100_000_000);
       const fallbackDescription = paymentId || `btc-${Date.now()}`;
       const createdInvoice = await createInvoiceForCart(
         sats,
@@ -44,7 +42,7 @@ export function useBitcoinInvoice({
 
       setInvoice(createdInvoice);
       setSatsAmount(sats);
-      onInvoiceReady?.({ invoice: createdInvoice, satoshis: sats, paymentId });
+      onInvoiceReady?.({ invoice: createdInvoice, satoshis: sats, paymentId, exchangeRate: btcPrice });
 
       return createdInvoice;
     } catch (caughtError) {

--- a/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
+++ b/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
@@ -9,7 +9,7 @@ import formatDate from "@lib/formatDate";
 import { StatusChip } from "./OrdersList/StatusChip";
 
 export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, currentRate }) {
-  const t = useTranslations("orders");
+  const ordersTranslations = useTranslations("orders");
   const {
     id,
     userName,
@@ -37,21 +37,21 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, curren
       }}
     >
       <ModalContent>
-        <ModalHeader>{t("details.title")}</ModalHeader>
+        <ModalHeader>{ordersTranslations("details.title")}</ModalHeader>
         <ModalBody>
           <div className="space-y-3 text-sm text-deep">
-            <DetailRow label={t("details.id")} value={id} />
-            <DetailRow label={t("details.user")} value={userName ?? t("details.unassigned")} />
+            <DetailRow label={ordersTranslations("details.id")} value={id} />
+            <DetailRow label={ordersTranslations("details.user")} value={userName ?? ordersTranslations("details.unassigned")} />
             <DetailRow
-              label={t("details.status")}
-              value={status ? <StatusChip status={status} /> : t("details.unassigned")}
+              label={ordersTranslations("details.status")}
+              value={status ? <StatusChip status={status} /> : ordersTranslations("details.unassigned")}
             />
             <DetailRow
-              label={t("details.paymentMethod")}
-              value={paymentMethod || t("details.noPayment")}
+              label={ordersTranslations("details.paymentMethod")}
+              value={paymentMethod || ordersTranslations("details.noPayment")}
             />
             <DetailRow
-              label={t("details.total")}
+              label={ordersTranslations("details.total")}
               value={
                 satoshiAmount != null
                   ? (
@@ -67,8 +67,8 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, curren
               }
             />
             <DetailRow
-              label={t("details.createdAt")}
-              value={createdAt ? formatDate(createdAt) : t("details.unassigned")}
+              label={ordersTranslations("details.createdAt")}
+              value={createdAt ? formatDate(createdAt) : ordersTranslations("details.unassigned")}
             />
           </div>
         </ModalBody>
@@ -78,7 +78,7 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, curren
             variant="bordered"
             onPress={onClose}
           >
-            {t("details.close")}
+            {ordersTranslations("details.close")}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
+++ b/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
@@ -3,13 +3,25 @@
 import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { AmountDisplay } from "@/components/shared/AmountDisplay";
 import formatDate from "@lib/formatDate";
 
 import { StatusChip } from "./OrdersList/StatusChip";
 
-export function OrderDetailsModal({ order, isOpen, onClose, formatAmount }) {
+export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, currentRate }) {
   const t = useTranslations("orders");
-  const userLabel = order?.userName ?? t("details.unassigned");
+  const {
+    id,
+    userName,
+    status,
+    paymentMethod,
+    total,
+    createdAt,
+    satoshiAmount,
+    exchangeRateAtPayment,
+    exchangeRateCurrency,
+    fiatAmountAtPayment,
+  } = order ?? {};
 
   return (
     <Modal
@@ -28,23 +40,35 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount }) {
         <ModalHeader>{t("details.title")}</ModalHeader>
         <ModalBody>
           <div className="space-y-3 text-sm text-deep">
-            <DetailRow label={t("details.id")} value={order?.id} />
-            <DetailRow label={t("details.user")} value={userLabel} />
+            <DetailRow label={t("details.id")} value={id} />
+            <DetailRow label={t("details.user")} value={userName ?? t("details.unassigned")} />
             <DetailRow
               label={t("details.status")}
-              value={order ? <StatusChip status={order.status} /> : t("details.unassigned")}
+              value={status ? <StatusChip status={status} /> : t("details.unassigned")}
             />
             <DetailRow
               label={t("details.paymentMethod")}
-              value={order?.paymentMethod || t("details.noPayment")}
+              value={paymentMethod || t("details.noPayment")}
             />
             <DetailRow
               label={t("details.total")}
-              value={order ? formatAmount(order.total * 100 ?? 0) : t("details.unassigned")}
+              value={
+                satoshiAmount != null
+                  ? (
+                    <AmountDisplay
+                      satoshis={satoshiAmount}
+                      exchangeRateAtSale={exchangeRateAtPayment}
+                      exchangeRateCurrency={exchangeRateCurrency}
+                      fiatAmountAtPayment={fiatAmountAtPayment}
+                      currentRate={currentRate}
+                    /> ?? formatAmount(total * 100)
+                    )
+                  : formatAmount(total * 100 ?? 0)
+              }
             />
             <DetailRow
               label={t("details.createdAt")}
-              value={order?.createdAt ? formatDate(order.createdAt) : t("details.unassigned")}
+              value={createdAt ? formatDate(createdAt) : t("details.unassigned")}
             />
           </div>
         </ModalBody>

--- a/client/src/components/pages/Store/Orders/StoreOrders.jsx
+++ b/client/src/components/pages/Store/Orders/StoreOrders.jsx
@@ -12,6 +12,7 @@ import {
 } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { useBitcoinPrice } from "@/components/hooks/useBitcoinPrice";
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { usePaymentMethods } from "@/components/pages/Store/Cart/hooks/usePaymentMethod";
 
@@ -45,7 +46,8 @@ export default function StoreOrders() {
   const [filters, setFilters] = useState(DEFAULT_FILTERS);
   const { orders, fetchOrders, fetchOrdersFiltered } = useOrders();
   const { paymentMethods } = usePaymentMethods();
-  const { formatAmount } = useCurrency();
+  const { formatAmount, currency } = useCurrency();
+  const { currentRate } = useBitcoinPrice({ currencyAcronym: currency?.acronym });
 
   const handleOrderClick = (order) => {
     setSelectedOrder(order);
@@ -163,6 +165,7 @@ export default function StoreOrders() {
         onClose={() => setShowDetails(false)}
         onEdit={handleEditOrder}
         formatAmount={formatAmount}
+        currentRate={currentRate}
       />
     </div>
   );

--- a/client/src/components/pages/Store/Orders/__tests__/OrderDetailsModal.test.jsx
+++ b/client/src/components/pages/Store/Orders/__tests__/OrderDetailsModal.test.jsx
@@ -2,6 +2,14 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { OrderDetailsModal } from "../OrderDetailsModal";
 
+jest.mock("@/components/shared/AmountDisplay", () => ({
+  AmountDisplay: ({ satoshis }) => <span>{`amount-display-${satoshis}`}</span>,
+}));
+
+jest.mock("../OrdersList/StatusChip", () => ({
+  StatusChip: ({ status }) => <span>{`status-${status}`}</span>,
+}));
+
 jest.mock("@/lib/formatDate", () => ({
   __esModule: true,
   default: jest.fn(() => "formatted-date"),
@@ -66,6 +74,62 @@ describe("OrderDetailsModal", () => {
 
     fireEvent.click(screen.getByText("details.close"));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders AmountDisplay for BTC orders with satoshiAmount", () => {
+    const formatAmount = jest.fn((value) => `fmt-${value}`);
+    const btcOrder = {
+      id: "order-btc",
+      userName: "Ana",
+      status: "paid",
+      paymentMethod: "BTC",
+      total: 1.0,
+      createdAt: "2024-01-01T10:00:00Z",
+      satoshiAmount: 100000,
+      exchangeRateAtPayment: 95000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+    };
+
+    render(
+      <OrderDetailsModal
+        order={btcOrder}
+        isOpen
+        onClose={jest.fn()}
+        onEdit={jest.fn()}
+        formatAmount={formatAmount}
+        currentRate={95000}
+      />,
+    );
+
+    expect(screen.getByText("amount-display-100000")).toBeInTheDocument();
+    expect(formatAmount).not.toHaveBeenCalledWith(100);
+  });
+
+  it("uses formatAmount for non-BTC orders", () => {
+    const formatAmount = jest.fn((value) => `fmt-${value}`);
+    const cashOrder = {
+      id: "order-cash",
+      userName: "Luis",
+      status: "paid",
+      paymentMethod: "Cash",
+      total: 25,
+      createdAt: "2024-01-01T10:00:00Z",
+    };
+
+    render(
+      <OrderDetailsModal
+        order={cashOrder}
+        isOpen
+        onClose={jest.fn()}
+        onEdit={jest.fn()}
+        formatAmount={formatAmount}
+        currentRate={95000}
+      />,
+    );
+
+    expect(formatAmount).toHaveBeenCalledWith(2500);
+    expect(screen.queryByText(/amount-display/)).not.toBeInTheDocument();
   });
 
   it("renders fallbacks when order is missing", () => {

--- a/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
@@ -5,9 +5,10 @@ import {
 } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { AmountDisplay } from "@/components/shared/AmountDisplay";
 import formatDate from "@lib/formatDate";
 
-export function OrderDetailModal({ order, formatCurrency, onClose }) {
+export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }) {
   const reportsTranslations = useTranslations("reports");
 
   return (
@@ -72,7 +73,19 @@ export function OrderDetailModal({ order, formatCurrency, onClose }) {
 
               <div className="border-t border-gray-200 pt-3 flex justify-between items-center">
                 <span className="font-semibold text-sm">{reportsTranslations("orders.total")}</span>
-                <span className="font-bold text-green-700">{formatCurrency(order.total)}</span>
+                <div className="font-bold text-green-700">
+                  {order.satoshiAmount != null
+                    ? (
+                      <AmountDisplay
+                        satoshis={order.satoshiAmount}
+                        exchangeRateAtSale={order.exchangeRateAtPayment}
+                        exchangeRateCurrency={order.exchangeRateCurrency}
+                        fiatAmountAtPayment={order.fiatAmountAtPayment}
+                        currentRate={currentRate}
+                      />
+                      )
+                    : formatCurrency(order.total)}
+                </div>
               </div>
             </div>
           )}

--- a/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
@@ -10,6 +10,18 @@ import formatDate from "@lib/formatDate";
 
 export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }) {
   const reportsTranslations = useTranslations("reports");
+  const {
+    shortId,
+    date,
+    userName,
+    paymentMethod,
+    items,
+    total,
+    satoshiAmount,
+    exchangeRateAtPayment,
+    exchangeRateCurrency,
+    fiatAmountAtPayment,
+  } = order ?? {};
 
   return (
     <Modal
@@ -26,7 +38,7 @@ export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }
       <ModalContent>
         <ModalHeader className="flex flex-col gap-0.5 pb-2">
           <span>{reportsTranslations("orders.detailTitle")}</span>
-          {order && <span className="font-mono text-sm font-normal text-gray-400">#{order.shortId}</span>}
+          {order && <span className="font-mono text-sm font-normal text-gray-400">#{shortId}</span>}
         </ModalHeader>
         <ModalBody className="pb-6">
           {order && (
@@ -34,15 +46,15 @@ export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }
               <div className="grid grid-cols-2 gap-3 text-sm">
                 <div>
                   <p className="text-xs text-gray-400">{reportsTranslations("sales.date")}</p>
-                  <p className="font-medium">{formatDate(order.date)}</p>
+                  <p className="font-medium">{formatDate(date)}</p>
                 </div>
                 <div>
                   <p className="text-xs text-gray-400">{reportsTranslations("sales.user")}</p>
-                  <p className="font-medium">{order.userName ?? "—"}</p>
+                  <p className="font-medium">{userName ?? "—"}</p>
                 </div>
                 <div>
                   <p className="text-xs text-gray-400">{reportsTranslations("sales.paymentMethod")}</p>
-                  <p className="font-medium">{order.paymentMethod || reportsTranslations("payment.unknown")}</p>
+                  <p className="font-medium">{paymentMethod || reportsTranslations("payment.unknown")}</p>
                 </div>
               </div>
 
@@ -59,7 +71,7 @@ export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }
                     <TableColumn align="end">{reportsTranslations("orders.subtotal")}</TableColumn>
                   </TableHeader>
                   <TableBody>
-                    {order.items.map((item, itemIndex) => (
+                    {items?.map((item, itemIndex) => (
                       <TableRow key={itemIndex}>
                         <TableCell className="py-2 text-gray-700">{item.productName}</TableCell>
                         <TableCell className="py-2 text-center text-gray-500">×{item.quantity}</TableCell>
@@ -74,17 +86,17 @@ export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }
               <div className="border-t border-gray-200 pt-3 flex justify-between items-center">
                 <span className="font-semibold text-sm">{reportsTranslations("orders.total")}</span>
                 <div className="font-bold text-green-700">
-                  {order.satoshiAmount != null
+                  {satoshiAmount != null
                     ? (
                       <AmountDisplay
-                        satoshis={order.satoshiAmount}
-                        exchangeRateAtSale={order.exchangeRateAtPayment}
-                        exchangeRateCurrency={order.exchangeRateCurrency}
-                        fiatAmountAtPayment={order.fiatAmountAtPayment}
+                        satoshis={satoshiAmount}
+                        exchangeRateAtSale={exchangeRateAtPayment}
+                        exchangeRateCurrency={exchangeRateCurrency}
+                        fiatAmountAtPayment={fiatAmountAtPayment}
                         currentRate={currentRate}
                       />
                       )
-                    : formatCurrency(order.total)}
+                    : formatCurrency(total)}
                 </div>
               </div>
             </div>

--- a/client/src/components/pages/Store/Reports/Orders/OrdersCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersCard.jsx
@@ -1,6 +1,6 @@
 "use client";
 import { Card, CardBody } from "@heroui/react";
-import { ShoppingCart, Users } from "lucide-react";
+import { Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { ViewButton } from "@/components/shared/ViewButton";
@@ -12,9 +12,6 @@ export function OrdersCard({ order, formatCurrency, onClick }) {
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-row items-center gap-3 p-3">
-        <div className="bg-forest/10 rounded-lg p-2 shrink-0">
-          <ShoppingCart aria-hidden="true" className="w-4 h-4 text-forest" />
-        </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-mono text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded">

--- a/client/src/components/pages/Store/Reports/Orders/OrdersCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersCard.jsx
@@ -8,6 +8,7 @@ import formatDate from "@lib/formatDate";
 
 export function OrdersCard({ order, formatCurrency, onClick }) {
   const reportsTranslations = useTranslations("reports");
+  const { shortId, userName, paymentMethod, date, itemCount, total } = order;
 
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
@@ -15,21 +16,21 @@ export function OrdersCard({ order, formatCurrency, onClick }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-mono text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded">
-              #{order.shortId}
+              #{shortId}
             </span>
           </div>
           <div className="flex items-center gap-1 text-sm text-forest mt-0.5">
             <Users aria-hidden="true" className="w-3 h-3 shrink-0" />
-            <span className="truncate">{order.userName ?? "—"}</span>
+            <span className="truncate">{userName ?? "—"}</span>
           </div>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
-            <span className="text-xs text-gray-500">{order.paymentMethod}</span>
-            <span className="text-xs text-gray-400">{order.date ? formatDate(order.date) : "—"}</span>
+            <span className="text-xs text-gray-500">{paymentMethod}</span>
+            <span className="text-xs text-gray-400">{date ? formatDate(date) : "—"}</span>
           </div>
         </div>
         <div className="shrink-0 text-right">
-          <p className="text-xs text-gray-500">×{order.itemCount} {reportsTranslations("sales.quantity").toLowerCase()}</p>
-          <p className="text-sm font-bold text-green-700 mb-1">{formatCurrency(order.total)}</p>
+          <p className="text-xs text-gray-500">×{itemCount} {reportsTranslations("sales.quantity").toLowerCase()}</p>
+          <p className="text-sm font-bold text-green-700 mb-1">{formatCurrency(total)}</p>
           <ViewButton onPress={onClick}>{reportsTranslations("orders.view")}</ViewButton>
         </div>
       </CardBody>

--- a/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
@@ -13,7 +13,7 @@ import { ReportsOrdersList } from "./OrdersList";
 
 const ROWS_PER_PAGE_OPTIONS = [5, 10, 20, 50];
 
-export function OrdersDetailCard({ orders, formatCurrency, disabled }) {
+export function OrdersDetailCard({ orders, formatCurrency, disabled, currentRate }) {
   const reportsTranslations = useTranslations("reports");
   const [search, setSearch] = useState("");
   const [paymentMethod, setPaymentMethod] = useState("");
@@ -69,7 +69,7 @@ export function OrdersDetailCard({ orders, formatCurrency, disabled }) {
           orders={orders}
         />
 
-        <ReportsOrdersList orders={paginatedOrders} formatCurrency={formatCurrency} />
+        <ReportsOrdersList orders={paginatedOrders} formatCurrency={formatCurrency} currentRate={currentRate} />
 
         <div className="flex flex-col items-center sm:flex-row sm:items-center sm:justify-between gap-3 pt-4 border-t border-default-100">
           <div className="flex items-center gap-2 text-sm text-default-500">

--- a/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
@@ -20,15 +20,15 @@ export function OrdersDetailCard({ orders, formatCurrency, disabled, currentRate
 
   const filteredOrders = useMemo(() => {
     const term = search.toLowerCase();
-    return orders.filter((order) => {
+    return orders.filter(({ shortId, userName, paymentMethod: orderPaymentMethod, total, items }) => {
       const searchMatch = !search || (
-        order.shortId?.toLowerCase().includes(term) ||
-        order.userName?.toLowerCase().includes(term) ||
-        order.paymentMethod?.toLowerCase().includes(term) ||
-        String(order.total).includes(term) ||
-        order.items.some((item) => item.productName?.toLowerCase().includes(term))
+        shortId?.toLowerCase().includes(term) ||
+        userName?.toLowerCase().includes(term) ||
+        orderPaymentMethod?.toLowerCase().includes(term) ||
+        String(total).includes(term) ||
+        items.some(({ productName }) => productName?.toLowerCase().includes(term))
       );
-      const methodMatch = !paymentMethod || order.paymentMethod === paymentMethod;
+      const methodMatch = !paymentMethod || orderPaymentMethod === paymentMethod;
       return searchMatch && methodMatch;
     });
   }, [orders, search, paymentMethod]);

--- a/client/src/components/pages/Store/Reports/Orders/OrdersFilters.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersFilters.jsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 export function OrdersFilters({ search, onSearchChange, paymentMethod, onPaymentMethodChange, disabled, orders = [] }) {
   const reportsTranslations = useTranslations("reports");
 
-  const paymentMethods = ["all", ...new Set(orders.map((order) => order.paymentMethod).filter(Boolean))];
+  const paymentMethods = ["all", ...new Set(orders.map(({ paymentMethod }) => paymentMethod).filter(Boolean))];
 
   return (
     <div className="flex flex-col sm:flex-row gap-3">

--- a/client/src/components/pages/Store/Reports/Orders/OrdersList.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersList.jsx
@@ -36,17 +36,17 @@ export function ReportsOrdersList({ orders, formatCurrency, currentRate }) {
     {
       key: "id",
       label: reportsTranslations("orders.shortId"),
-      render: (order) => (
+      render: ({ shortId }) => (
         <span className="font-mono text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded">
-          #{order.shortId}
+          #{shortId}
         </span>
       ),
     },
     {
       key: "date",
       label: reportsTranslations("sales.date"),
-      render: (order) => {
-        const { date, time } = formatDateParts(order.date);
+      render: ({ date: orderDate }) => {
+        const { date, time } = formatDateParts(orderDate);
         return (
           <div className="text-xs">
             <span className="text-gray-700">{date}</span>
@@ -58,32 +58,32 @@ export function ReportsOrdersList({ orders, formatCurrency, currentRate }) {
     {
       key: "user",
       label: reportsTranslations("sales.user"),
-      render: (order) => <span className="text-sm text-gray-700">{order.userName ?? "—"}</span>,
+      render: ({ userName }) => <span className="text-sm text-gray-700">{userName ?? "—"}</span>,
     },
     {
       key: "products",
       label: reportsTranslations("orders.products"),
-      render: (order) => (
-        <span className="text-sm text-deep">{buildProductSummary(order.items, reportsTranslations("orders.more"))}</span>
+      render: ({ items }) => (
+        <span className="text-sm text-deep">{buildProductSummary(items, reportsTranslations("orders.more"))}</span>
       ),
     },
     {
       key: "items",
       label: reportsTranslations("sales.quantity"),
-      render: (order) => <span className="font-bold">×{order.itemCount}</span>,
+      render: ({ itemCount }) => <span className="font-bold">×{itemCount}</span>,
     },
     {
       key: "total",
       label: reportsTranslations("orders.total"),
-      render: (order) => (
-        <span className="whitespace-nowrap font-bold text-green-700">{formatCurrency(order.total)}</span>
+      render: ({ total }) => (
+        <span className="whitespace-nowrap font-bold text-green-700">{formatCurrency(total)}</span>
       ),
     },
     {
       key: "payment",
       label: reportsTranslations("sales.paymentMethod"),
-      render: (order) => (
-        <span className="text-sm text-gray-700">{order.paymentMethod || reportsTranslations("payment.unknown")}</span>
+      render: ({ paymentMethod }) => (
+        <span className="text-sm text-gray-700">{paymentMethod || reportsTranslations("payment.unknown")}</span>
       ),
     },
     {

--- a/client/src/components/pages/Store/Reports/Orders/OrdersList.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersList.jsx
@@ -19,7 +19,7 @@ const buildProductSummary = (items, overflowLabel) => {
   return names.join(", ");
 };
 
-export function ReportsOrdersList({ orders, formatCurrency }) {
+export function ReportsOrdersList({ orders, formatCurrency, currentRate }) {
   const reportsTranslations = useTranslations("reports");
   const [selectedOrder, setSelectedOrder] = useState(null);
 
@@ -122,6 +122,7 @@ export function ReportsOrdersList({ orders, formatCurrency }) {
       <OrderDetailModal
         order={selectedOrder}
         formatCurrency={formatCurrency}
+        currentRate={currentRate}
         onClose={() => setSelectedOrder(null)}
       />
     </section>

--- a/client/src/components/pages/Store/Reports/Orders/__tests__/OrderDetailModal.test.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/__tests__/OrderDetailModal.test.jsx
@@ -21,6 +21,10 @@ jest.mock("next-intl", () => ({
 
 jest.mock("@lib/formatDate", () => jest.fn((date) => `formatted:${date}`));
 
+jest.mock("@/components/shared/AmountDisplay", () => ({
+  AmountDisplay: ({ satoshis }) => <span>{`amount-display-${satoshis}`}</span>,
+}));
+
 const ORDER_FIXTURE = {
   shortId: "ABC123",
   date: "2024-01-15",
@@ -98,5 +102,24 @@ describe("OrderDetailModal", () => {
     const order = { ...ORDER_FIXTURE, paymentMethod: "" };
     render(<OrderDetailModal order={order} formatCurrency={formatCurrency} onClose={jest.fn()} />);
     expect(screen.getByText("payment.unknown")).toBeInTheDocument();
+  });
+
+  it("renders AmountDisplay for BTC orders with satoshiAmount", () => {
+    const btcOrder = {
+      ...ORDER_FIXTURE,
+      paymentMethod: "BTC",
+      satoshiAmount: 100000,
+      exchangeRateAtPayment: 95000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+    };
+    render(<OrderDetailModal order={btcOrder} formatCurrency={formatCurrency} currentRate={95000} onClose={jest.fn()} />);
+    expect(screen.getByText("amount-display-100000")).toBeInTheDocument();
+  });
+
+  it("uses formatCurrency for total when order has no satoshiAmount", () => {
+    render(<OrderDetailModal order={ORDER_FIXTURE} formatCurrency={formatCurrency} currentRate={95000} onClose={jest.fn()} />);
+    expect(screen.getByText("$5000")).toBeInTheDocument();
+    expect(screen.queryByText(/amount-display/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Reports/Reports.jsx
+++ b/client/src/components/pages/Store/Reports/Reports.jsx
@@ -5,6 +5,7 @@ import { Card, CardBody, Tab, Tabs } from "@heroui/react";
 import { AlertCircle, Loader2, Package, ShoppingCart } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { useBitcoinPrice } from "@/components/hooks/useBitcoinPrice";
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { PageHeader } from "@components/shared/PageHeader";
 
@@ -23,7 +24,8 @@ export default function Reports() {
   const reportsTranslations = useTranslations("reports");
   const { fetchReport, reportData, error, loading: reportsLoading } = useReports();
   const { filters, handleFilters } = useFiltersState(fetchReport);
-  const { formatAmount, loading: currencyLoading } = useCurrency();
+  const { formatAmount, loading: currencyLoading, currency } = useCurrency();
+  const { currentRate } = useBitcoinPrice({ currencyAcronym: currency?.acronym });
   const formatCurrency = useCallback((cents) => formatAmount(cents), [formatAmount]);
   const [activeTab, setActiveTab] = useState("orders");
   const [pendingTab, setPendingTab] = useState(null);
@@ -42,12 +44,23 @@ export default function Reports() {
     { label: reportsTranslations("summary.avgItemsPerOrder"), value: avgItemsPerOrder },
   ], [reportsTranslations, ordersRevenue, orderCount, averageTicket, avgItemsPerOrder, formatCurrency]);
 
-  const productStats = useMemo(() => [
-    { label: reportsTranslations("summary.revenue"), value: formatCurrency(productsRevenue) },
-    { label: reportsTranslations("summary.items"), value: totalItems },
-    { label: reportsTranslations("summary.productLines"), value: productLines },
-    { label: reportsTranslations("summary.uniqueProducts"), value: uniqueProducts },
-  ], [reportsTranslations, productsRevenue, totalItems, productLines, uniqueProducts, formatCurrency]);
+  const totalBtcSatoshis = reportData?.totalBtcSatoshis ?? 0;
+
+  const productStats = useMemo(() => {
+    const stats = [
+      { label: reportsTranslations("summary.revenue"), value: formatCurrency(productsRevenue) },
+      { label: reportsTranslations("summary.items"), value: totalItems },
+      { label: reportsTranslations("summary.productLines"), value: productLines },
+      { label: reportsTranslations("summary.uniqueProducts"), value: uniqueProducts },
+    ];
+    if (totalBtcSatoshis > 0) {
+      stats.push({
+        label: reportsTranslations("summary.totalBtcSatoshis"),
+        value: `${totalBtcSatoshis.toLocaleString()} sats`,
+      });
+    }
+    return stats;
+  }, [reportsTranslations, productsRevenue, totalItems, productLines, uniqueProducts, formatCurrency, totalBtcSatoshis]);
 
   if ((reportsLoading || currencyLoading) && !reportData) return <ReportSkeleton />;
 
@@ -127,6 +140,7 @@ export default function Reports() {
                 orders={orders}
                 formatCurrency={formatCurrency}
                 disabled={currencyLoading}
+                currentRate={currentRate}
               />
             </div>
           )}
@@ -140,6 +154,7 @@ export default function Reports() {
                 sales={sales}
                 formatCurrency={formatCurrency}
                 disabled={currencyLoading}
+                currentRate={currentRate}
               />
             </div>
           )}

--- a/client/src/components/pages/Store/Reports/Sales/SalesCard.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesCard.jsx
@@ -1,37 +1,43 @@
 "use client";
 
 import { Card, CardBody } from "@heroui/react";
-import { Package, Users } from "lucide-react";
+import { Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { AmountDisplay } from "@/components/shared/AmountDisplay";
 import formatDate from "@lib/formatDate";
 
-export function SalesCard({ sale, formatCurrency }) {
+export function SalesCard({ sale, formatCurrency, currentRate }) {
   const reportsTranslations = useTranslations("reports");
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
-      <CardBody className="flex flex-row items-center gap-3 p-3">
-        <div className="bg-forest/10 rounded-lg p-2 shrink-0">
-          <Package aria-hidden="true" className="w-4 h-4 text-forest" />
+      <CardBody>
+        <p className="font-bold text-deep">{sale.productName}</p>
+        <div className="flex items-center gap-1 text-sm text-forest mt-0.5">
+          <Users aria-hidden="true" className="w-3 h-3 shrink-0" />
+          <span className="truncate">{sale.userName}</span>
         </div>
-        <div className="flex-1 min-w-0">
-          <p className="font-bold text-deep truncate">{sale.productName}</p>
-          <div className="flex items-center gap-1 text-sm text-forest mt-0.5">
-            <Users aria-hidden="true" className="w-3 h-3 shrink-0" />
-            <span className="truncate">{sale.userName}</span>
-          </div>
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
-            <span className="text-sm text-gray-700">{sale.paymentMethod}</span>
-            <span className="text-xs text-gray-400">
-              {sale.saleDate ? formatDate(sale.saleDate) : "-"}
-            </span>
-          </div>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
+          <span className="text-sm text-gray-700">{sale.paymentMethod}</span>
+          <span className="text-xs text-gray-400">
+            {sale.saleDate ? formatDate(sale.saleDate) : "-"}
+          </span>
         </div>
-        <div className="shrink-0 text-right">
+        <div className="mt-1">
           <p className="text-xs text-gray-500">{reportsTranslations("sales.quantity")} ×{sale.quantity}</p>
-          <p className="text-sm font-bold text-green-700">
-            {formatCurrency(sale.priceAtOrder * sale.quantity)}
-          </p>
+          <div className="text-sm font-bold text-green-700 mt-1">
+            {sale.satoshiAmount != null
+              ? (
+                <AmountDisplay
+                  satoshis={sale.satoshiAmount}
+                  exchangeRateAtSale={sale.exchangeRateAtPayment}
+                  exchangeRateCurrency={sale.exchangeRateCurrency}
+                  fiatAmountAtPayment={sale.fiatAmountAtPayment}
+                  currentRate={currentRate}
+                />
+                )
+              : formatCurrency(sale.priceAtOrder * sale.quantity)}
+          </div>
         </div>
       </CardBody>
     </Card>

--- a/client/src/components/pages/Store/Reports/Sales/SalesCard.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesCard.jsx
@@ -9,34 +9,47 @@ import formatDate from "@lib/formatDate";
 
 export function SalesCard({ sale, formatCurrency, currentRate }) {
   const reportsTranslations = useTranslations("reports");
+  const {
+    productName,
+    userName,
+    paymentMethod,
+    saleDate,
+    quantity,
+    priceAtOrder,
+    satoshiAmount,
+    exchangeRateAtPayment,
+    exchangeRateCurrency,
+    fiatAmountAtPayment,
+  } = sale;
+
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody>
-        <p className="font-bold text-deep">{sale.productName}</p>
+        <p className="font-bold text-deep">{productName}</p>
         <div className="flex items-center gap-1 text-sm text-forest mt-0.5">
           <Users aria-hidden="true" className="w-3 h-3 shrink-0" />
-          <span className="truncate">{sale.userName}</span>
+          <span className="truncate">{userName}</span>
         </div>
         <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
-          <span className="text-sm text-gray-700">{sale.paymentMethod}</span>
+          <span className="text-sm text-gray-700">{paymentMethod}</span>
           <span className="text-xs text-gray-400">
-            {sale.saleDate ? formatDate(sale.saleDate) : "-"}
+            {saleDate ? formatDate(saleDate) : "-"}
           </span>
         </div>
         <div className="mt-1">
-          <p className="text-xs text-gray-500">{reportsTranslations("sales.quantity")} ×{sale.quantity}</p>
+          <p className="text-xs text-gray-500">{reportsTranslations("sales.quantity")} ×{quantity}</p>
           <div className="text-sm font-bold text-green-700 mt-1">
-            {sale.satoshiAmount != null
+            {satoshiAmount != null
               ? (
                 <AmountDisplay
-                  satoshis={sale.satoshiAmount}
-                  exchangeRateAtSale={sale.exchangeRateAtPayment}
-                  exchangeRateCurrency={sale.exchangeRateCurrency}
-                  fiatAmountAtPayment={sale.fiatAmountAtPayment}
+                  satoshis={satoshiAmount}
+                  exchangeRateAtSale={exchangeRateAtPayment}
+                  exchangeRateCurrency={exchangeRateCurrency}
+                  fiatAmountAtPayment={fiatAmountAtPayment}
                   currentRate={currentRate}
                 />
                 )
-              : formatCurrency(sale.priceAtOrder * sale.quantity)}
+              : formatCurrency(priceAtOrder * quantity)}
           </div>
         </div>
       </CardBody>

--- a/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
@@ -13,7 +13,7 @@ import { SalesList } from "./SalesList";
 
 const ROWS_PER_PAGE_OPTIONS = [5, 10, 20, 50];
 
-export function SalesDetailCard({ sales, formatCurrency, disabled }) {
+export function SalesDetailCard({ sales, formatCurrency, disabled, currentRate }) {
   const reportsTranslations = useTranslations("reports");
   const [search, setSearch] = useState("");
   const [paymentMethod, setPaymentMethod] = useState("");
@@ -68,7 +68,7 @@ export function SalesDetailCard({ sales, formatCurrency, disabled }) {
           sales={sales}
         />
 
-        <SalesList sales={paginatedSales} formatCurrency={formatCurrency} />
+        <SalesList sales={paginatedSales} formatCurrency={formatCurrency} currentRate={currentRate} />
 
         <div className="flex flex-col items-center sm:flex-row sm:items-center sm:justify-between gap-3 pt-4 border-t border-default-100">
           <div className="flex items-center gap-2 text-sm text-default-500">

--- a/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
@@ -20,14 +20,14 @@ export function SalesDetailCard({ sales, formatCurrency, disabled, currentRate }
 
   const filteredSales = useMemo(() => {
     const term = search.toLowerCase();
-    return sales.filter((sale) => {
+    return sales.filter(({ productName, userName, paymentMethod: salePaymentMethod, priceAtOrder, quantity }) => {
       const searchMatch = !search || (
-        sale.productName?.toLowerCase().includes(term) ||
-        sale.userName?.toLowerCase().includes(term) ||
-        sale.paymentMethod?.toLowerCase().includes(term) ||
-        String(sale.priceAtOrder * sale.quantity).includes(term)
+        productName?.toLowerCase().includes(term) ||
+        userName?.toLowerCase().includes(term) ||
+        salePaymentMethod?.toLowerCase().includes(term) ||
+        String(priceAtOrder * quantity).includes(term)
       );
-      const methodMatch = !paymentMethod || sale.paymentMethod === paymentMethod;
+      const methodMatch = !paymentMethod || salePaymentMethod === paymentMethod;
       return searchMatch && methodMatch;
     });
   }, [sales, search, paymentMethod]);

--- a/client/src/components/pages/Store/Reports/Sales/SalesFilters.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesFilters.jsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 export function SalesFilters({ search, onSearchChange, paymentMethod, onPaymentMethodChange, disabled, sales = [] }) {
   const reportsTranslations = useTranslations("reports");
 
-  const paymentMethods = ["all", ...new Set(sales.map((sale) => sale.paymentMethod).filter(Boolean))];
+  const paymentMethods = ["all", ...new Set(sales.map(({ paymentMethod }) => paymentMethod).filter(Boolean))];
 
   return (
     <div className="flex flex-col sm:flex-row gap-3">

--- a/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
@@ -25,35 +25,35 @@ export function SalesList({ sales, formatCurrency, currentRate }) {
     {
       key: "product",
       label: reportsTranslations("sales.product"),
-      render: (sale) => <span className="font-medium text-deep">{sale.productName}</span>,
+      render: ({ productName }) => <span className="font-medium text-deep">{productName}</span>,
     },
     {
       key: "user",
       label: reportsTranslations("sales.user"),
-      render: (sale) => <span className="text-sm text-gray-700">{sale.userName ?? "—"}</span>,
+      render: ({ userName }) => <span className="text-sm text-gray-700">{userName ?? "—"}</span>,
     },
     {
       key: "qty",
       label: reportsTranslations("sales.quantity"),
-      render: (sale) => <span className="font-bold">×{sale.quantity}</span>,
+      render: ({ quantity }) => <span className="font-bold">×{quantity}</span>,
     },
     {
       key: "price",
       label: reportsTranslations("sales.price"),
-      render: (sale) => <span className="whitespace-nowrap">{formatCurrency(sale.priceAtOrder)}</span>,
+      render: ({ priceAtOrder }) => <span className="whitespace-nowrap">{formatCurrency(priceAtOrder)}</span>,
     },
     {
       key: "total",
       label: reportsTranslations("sales.total"),
-      render: (sale) => {
-        if (sale.satoshiAmount != null) {
+      render: ({ satoshiAmount, exchangeRateAtPayment, exchangeRateCurrency, fiatAmountAtPayment, priceAtOrder, quantity }) => {
+        if (satoshiAmount != null) {
           return (
             <div className="font-bold text-green-700">
               <AmountDisplay
-                satoshis={sale.satoshiAmount}
-                exchangeRateAtSale={sale.exchangeRateAtPayment}
-                exchangeRateCurrency={sale.exchangeRateCurrency}
-                fiatAmountAtPayment={sale.fiatAmountAtPayment}
+                satoshis={satoshiAmount}
+                exchangeRateAtSale={exchangeRateAtPayment}
+                exchangeRateCurrency={exchangeRateCurrency}
+                fiatAmountAtPayment={fiatAmountAtPayment}
                 currentRate={currentRate}
               />
             </div>
@@ -61,7 +61,7 @@ export function SalesList({ sales, formatCurrency, currentRate }) {
         }
         return (
           <span className="whitespace-nowrap font-bold text-green-700">
-            {formatCurrency(sale.priceAtOrder * sale.quantity)}
+            {formatCurrency(priceAtOrder * quantity)}
           </span>
         );
       },
@@ -69,20 +69,20 @@ export function SalesList({ sales, formatCurrency, currentRate }) {
     {
       key: "payment",
       label: reportsTranslations("sales.paymentMethod"),
-      render: (sale) => <span className="text-sm text-gray-700">{sale.paymentMethod || reportsTranslations("payment.unknown")}</span>,
+      render: ({ paymentMethod }) => <span className="text-sm text-gray-700">{paymentMethod || reportsTranslations("payment.unknown")}</span>,
     },
     {
       key: "date",
       label: reportsTranslations("sales.date"),
-      render: (sale) => (
-        <span className="text-xs text-gray-400">{formatDateParts(sale.saleDate).date}</span>
+      render: ({ saleDate }) => (
+        <span className="text-xs text-gray-400">{formatDateParts(saleDate).date}</span>
       ),
     },
     {
       key: "time",
       label: reportsTranslations("sales.time"),
-      render: (sale) => (
-        <span className="text-xs text-gray-400">{formatDateParts(sale.saleDate).time}</span>
+      render: ({ saleDate }) => (
+        <span className="text-xs text-gray-400">{formatDateParts(saleDate).time}</span>
       ),
     },
   ];

--- a/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
@@ -3,12 +3,13 @@
 import { ShoppingBag } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { AmountDisplay } from "@/components/shared/AmountDisplay";
 import { DataTable } from "@/components/shared/DataTable";
 import { formatDateParts } from "@lib/formatDate";
 
 import { SalesCard } from "./SalesCard";
 
-export function SalesList({ sales, formatCurrency }) {
+export function SalesList({ sales, formatCurrency, currentRate }) {
   const reportsTranslations = useTranslations("reports");
 
   if (!sales?.length) {
@@ -44,11 +45,26 @@ export function SalesList({ sales, formatCurrency }) {
     {
       key: "total",
       label: reportsTranslations("sales.total"),
-      render: (sale) => (
-        <span className="whitespace-nowrap font-bold text-green-700">
-          {formatCurrency(sale.priceAtOrder * sale.quantity)}
-        </span>
-      ),
+      render: (sale) => {
+        if (sale.satoshiAmount != null) {
+          return (
+            <div className="font-bold text-green-700">
+              <AmountDisplay
+                satoshis={sale.satoshiAmount}
+                exchangeRateAtSale={sale.exchangeRateAtPayment}
+                exchangeRateCurrency={sale.exchangeRateCurrency}
+                fiatAmountAtPayment={sale.fiatAmountAtPayment}
+                currentRate={currentRate}
+              />
+            </div>
+          );
+        }
+        return (
+          <span className="whitespace-nowrap font-bold text-green-700">
+            {formatCurrency(sale.priceAtOrder * sale.quantity)}
+          </span>
+        );
+      },
     },
     {
       key: "payment",
@@ -75,7 +91,7 @@ export function SalesList({ sales, formatCurrency }) {
     <section aria-label={reportsTranslations("sales.tableAriaLabel")} className="w-full">
       <div className="md:hidden space-y-3">
         {sales.map((sale, saleIndex) => (
-          <SalesCard key={saleIndex} sale={sale} formatCurrency={formatCurrency} />
+          <SalesCard key={saleIndex} sale={sale} formatCurrency={formatCurrency} currentRate={currentRate} />
         ))}
       </div>
       <div className="hidden md:block overflow-x-auto">

--- a/client/src/components/pages/Store/Reports/Sales/__tests__/SalesCard.test.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/__tests__/SalesCard.test.jsx
@@ -9,6 +9,10 @@ jest.mock("@heroui/react", () => {
   return { ...actual, Card, CardBody };
 });
 
+jest.mock("@/components/shared/AmountDisplay", () => ({
+  AmountDisplay: ({ satoshis }) => <span>{`amount-display-${satoshis}`}</span>,
+}));
+
 const baseSale = {
   productName: "Widget A",
   userName: "alice",
@@ -49,5 +53,25 @@ describe("SalesCard", () => {
   it("shows '-' when saleDate is null", () => {
     render(<SalesCard sale={{ ...baseSale, saleDate: null }} formatCurrency={formatCurrency} />);
     expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("renders AmountDisplay for BTC sales with satoshiAmount", () => {
+    const btcSale = {
+      ...baseSale,
+      paymentMethod: "BTC",
+      satoshiAmount: 100000,
+      exchangeRateAtPayment: 95000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+    };
+    render(<SalesCard sale={btcSale} formatCurrency={formatCurrency} currentRate={95000} />);
+    expect(screen.getByText("amount-display-100000")).toBeInTheDocument();
+    expect(formatCurrency).not.toHaveBeenCalledWith(3000);
+  });
+
+  it("uses formatCurrency when sale has no satoshiAmount", () => {
+    render(<SalesCard sale={baseSale} formatCurrency={formatCurrency} currentRate={95000} />);
+    expect(formatCurrency).toHaveBeenCalledWith(3000);
+    expect(screen.queryByText(/amount-display/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Reports/Sales/__tests__/SalesList.test.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/__tests__/SalesList.test.jsx
@@ -6,6 +6,10 @@ jest.mock("../SalesCard", () => ({
   SalesCard: ({ sale }) => <div data-testid="sales-card">{`card-${sale.productName}`}</div>,
 }));
 
+jest.mock("@/components/shared/AmountDisplay", () => ({
+  AmountDisplay: ({ satoshis }) => <span>{`amount-display-${satoshis}`}</span>,
+}));
+
 jest.mock("@/components/shared/DataTable", () => ({
   DataTable: ({ columns, items }) => (
     <table>
@@ -179,5 +183,45 @@ describe("SalesList", () => {
     render(<SalesList sales={sales} formatCurrency={mockFormatCurrency} />);
 
     expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("renders AmountDisplay in total column for BTC sale with satoshiAmount", () => {
+    const sales = [
+      {
+        productName: "Sticker",
+        quantity: 2,
+        priceAtOrder: 500,
+        userName: "ivan",
+        paymentMethod: "BTC",
+        saleDate: "2024-01-01 00:00:00",
+        satoshiAmount: 100000,
+        exchangeRateAtPayment: 95000,
+        exchangeRateCurrency: "usd",
+        fiatAmountAtPayment: 1.0,
+      },
+    ];
+
+    render(<SalesList sales={sales} formatCurrency={mockFormatCurrency} currentRate={95000} />);
+
+    expect(screen.getByText("amount-display-100000")).toBeInTheDocument();
+    expect(mockFormatCurrency).not.toHaveBeenCalledWith(1000);
+  });
+
+  it("uses formatCurrency in total column for non-BTC sale", () => {
+    const sales = [
+      {
+        productName: "Widget",
+        quantity: 3,
+        priceAtOrder: 1500,
+        userName: "carlos",
+        paymentMethod: "Cash",
+        saleDate: "2024-01-01 00:00:00",
+      },
+    ];
+
+    render(<SalesList sales={sales} formatCurrency={mockFormatCurrency} currentRate={95000} />);
+
+    expect(mockFormatCurrency).toHaveBeenCalledWith(4500);
+    expect(screen.queryByText(/amount-display/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersData.test.js
@@ -5,7 +5,7 @@ import { useOrdersData } from "../useOrdersData";
 const SALES_FIXTURE = [
   { orderId: "order-aaa-00000001", productName: "Widget A", quantity: 2, priceAtOrder: 1000, userName: "alice", paymentMethod: "Cash", saleDate: "2024-01-02T10:00:00" },
   { orderId: "order-aaa-00000001", productName: "Widget B", quantity: 1, priceAtOrder: 500, userName: "alice", paymentMethod: "Cash", saleDate: "2024-01-02T10:00:00" },
-  { orderId: "order-bbb-00000002", productName: "Widget C", quantity: 3, priceAtOrder: 2000, userName: "bob", paymentMethod: "BTC", saleDate: "2024-01-01T08:00:00" },
+  { orderId: "order-bbb-00000002", productName: "Widget C", quantity: 3, priceAtOrder: 2000, userName: "bob", paymentMethod: "BTC", saleDate: "2024-01-01T08:00:00", satoshiAmount: 100000, exchangeRateAtPayment: 95000, exchangeRateCurrency: "usd", fiatAmountAtPayment: 1.0 },
 ];
 
 describe("useOrdersData", () => {
@@ -64,5 +64,23 @@ describe("useOrdersData", () => {
     const orderB = result.current.find((order) => order.orderId === "order-bbb-00000002");
     expect(orderB.items).toHaveLength(1);
     expect(orderB.total).toBe(3 * 2000);
+  });
+
+  it("copies bitcoin payment fields from the first sale of the order", () => {
+    const { result } = renderHook(() => useOrdersData(SALES_FIXTURE));
+    const btcOrder = result.current.find((order) => order.orderId === "order-bbb-00000002");
+    expect(btcOrder.satoshiAmount).toBe(100000);
+    expect(btcOrder.exchangeRateAtPayment).toBe(95000);
+    expect(btcOrder.exchangeRateCurrency).toBe("usd");
+    expect(btcOrder.fiatAmountAtPayment).toBe(1.0);
+  });
+
+  it("sets bitcoin fields to null when sale has no bitcoin payment data", () => {
+    const { result } = renderHook(() => useOrdersData(SALES_FIXTURE));
+    const cashOrder = result.current.find((order) => order.orderId === "order-aaa-00000001");
+    expect(cashOrder.satoshiAmount).toBeNull();
+    expect(cashOrder.exchangeRateAtPayment).toBeNull();
+    expect(cashOrder.exchangeRateCurrency).toBeNull();
+    expect(cashOrder.fiatAmountAtPayment).toBeNull();
   });
 });

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersData.js
@@ -4,26 +4,38 @@ import { useMemo } from "react";
 export function useOrdersData(sales) {
   return useMemo(() => {
     const byOrder = {};
-    for (const sale of sales) {
-      if (!byOrder[sale.orderId]) {
-        byOrder[sale.orderId] = {
-          orderId: sale.orderId,
-          shortId: sale.orderId.slice(-8),
-          date: sale.saleDate,
-          userName: sale.userName,
-          paymentMethod: sale.paymentMethod,
+    for (const {
+      orderId,
+      saleDate,
+      userName,
+      paymentMethod,
+      productName,
+      quantity,
+      priceAtOrder,
+      satoshiAmount,
+      exchangeRateAtPayment,
+      exchangeRateCurrency,
+      fiatAmountAtPayment,
+    } of sales) {
+      if (!byOrder[orderId]) {
+        byOrder[orderId] = {
+          orderId,
+          shortId: orderId.slice(-8),
+          date: saleDate,
+          userName,
+          paymentMethod,
           items: [],
           total: 0,
           itemCount: 0,
+          satoshiAmount: satoshiAmount ?? null,
+          exchangeRateAtPayment: exchangeRateAtPayment ?? null,
+          exchangeRateCurrency: exchangeRateCurrency ?? null,
+          fiatAmountAtPayment: fiatAmountAtPayment ?? null,
         };
       }
-      byOrder[sale.orderId].items.push({
-        productName: sale.productName,
-        quantity: sale.quantity,
-        priceAtOrder: sale.priceAtOrder,
-      });
-      byOrder[sale.orderId].total += sale.quantity * sale.priceAtOrder;
-      byOrder[sale.orderId].itemCount += sale.quantity;
+      byOrder[orderId].items.push({ productName, quantity, priceAtOrder });
+      byOrder[orderId].total += quantity * priceAtOrder;
+      byOrder[orderId].itemCount += quantity;
     }
     return Object.values(byOrder).sort((a, b) => b.date.localeCompare(a.date));
   }, [sales]);

--- a/client/src/components/pages/Store/Reports/locales/en.js
+++ b/client/src/components/pages/Store/Reports/locales/en.js
@@ -44,6 +44,7 @@ const reportsEn = {
       averageTicket: "Average Ticket",
       productLines: "Product Lines",
       uniqueProducts: "Unique Products",
+      totalBtcSatoshis: "Total Bitcoin",
       orderCount: "Orders",
       avgItemsPerOrder: "Average Items / Order",
     },

--- a/client/src/components/pages/Store/Reports/locales/es.js
+++ b/client/src/components/pages/Store/Reports/locales/es.js
@@ -44,6 +44,7 @@ const reportsEs = {
       averageTicket: "Ticket Promedio",
       productLines: "Líneas de Producto",
       uniqueProducts: "Productos Únicos",
+      totalBtcSatoshis: "Total Bitcoin",
       orderCount: "Órdenes",
       avgItemsPerOrder: "Items Promedio / Orden",
     },

--- a/client/src/components/pages/Store/Wallet/StoreWallet.jsx
+++ b/client/src/components/pages/Store/Wallet/StoreWallet.jsx
@@ -10,6 +10,8 @@ import {
 } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { useBitcoinPrice } from "@/components/hooks/useBitcoinPrice";
+import { useCurrency } from "@/components/hooks/useCurrency";
 import {
   getIncomingTransactions,
   getInfo,
@@ -23,6 +25,8 @@ import { InvoiceModal, Transactions } from "./Transactions";
 
 export function StoreWallet() {
   const t = useTranslations("wallet");
+  const { currency } = useCurrency();
+  const { currentRate } = useBitcoinPrice({ currencyAcronym: currency.acronym });
   const [info, setInfo] = useState(null);
   const [transactions, setTransactions] = useState([]);
   const [error, setError] = useState("");
@@ -146,6 +150,7 @@ export function StoreWallet() {
               invoiceActions={invoiceActions}
               fetchInfo={fetchInfo}
               fetchTransactions={fetchTransactions}
+              currentRate={currentRate}
             />
           </div>
 

--- a/client/src/components/pages/Store/Wallet/StoreWallet.jsx
+++ b/client/src/components/pages/Store/Wallet/StoreWallet.jsx
@@ -24,7 +24,7 @@ import { NodeError, NodeInfo } from "./NodeInfo";
 import { InvoiceModal, Transactions } from "./Transactions";
 
 export function StoreWallet() {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
   const { currency } = useCurrency();
   const { currentRate } = useBitcoinPrice({ currencyAcronym: currency.acronym });
   const [info, setInfo] = useState(null);
@@ -44,15 +44,15 @@ export function StoreWallet() {
       setError("");
     } catch (err) {
       console.error(err);
-      setError(t("nodeInfo.fetchInfoError"));
+      setError(walletTranslations("nodeInfo.fetchInfoError"));
       addToast({
-        title: t("errorTitle"),
-        description: t("nodeInfo.getInfoErrorDescription"),
+        title: walletTranslations("errorTitle"),
+        description: walletTranslations("nodeInfo.getInfoErrorDescription"),
         variant: "solid",
         color: "danger",
       });
     }
-  }, [t]);
+  }, [walletTranslations]);
 
   const fetchTransactions = useCallback(
     async () => {
@@ -75,15 +75,15 @@ export function StoreWallet() {
         setTransactions(allTx);
       } catch {
         addToast({
-          title: t("errorTitle"),
-          description: t("payments.history.getTransactionsErrorDescription"),
+          title: walletTranslations("errorTitle"),
+          description: walletTranslations("payments.history.getTransactionsErrorDescription"),
           variant: "solid",
           color: "danger",
         });
       } finally {
         setLoading(false);
       }
-    }, [filter, t]);
+    }, [filter, walletTranslations]);
 
   useEffect(() => {
     fetchInfo();
@@ -122,7 +122,7 @@ export function StoreWallet() {
         <CardBody className="flex flex-col items-center justify-center py-12">
           <Spinner size="lg" color="success" />
           <p className="text-lg font-semibold text-deep mt-4">
-            {t("loadingMessage")}
+            {walletTranslations("loadingMessage")}
           </p>
         </CardBody>
       </Card>
@@ -134,7 +134,7 @@ export function StoreWallet() {
   return (
     <div className="">
       {(error || !nodeAvailable) && (
-        <NodeError error={error || t("nodeInfo.nodeUnavailable")} />
+        <NodeError error={error || walletTranslations("nodeInfo.nodeUnavailable")} />
       )}
 
       {nodeAvailable && (

--- a/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
@@ -4,17 +4,19 @@ import { Button, Card, CardBody, Spinner } from "@heroui/react";
 import { ArrowDownLeft, ArrowUpRight, History } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 
+import { AmountDisplay } from "@/components/shared/AmountDisplay";
+
 import { formatSats } from "../utils/formatters";
 
-const getTransactionIcon = (type) => (
-  type === "outgoing_payment" ? (
+const getTransactionIcon = (transactionType) => (
+  transactionType === "outgoing_payment" ? (
     <ArrowUpRight className="w-4 h-4 text-red-600" />
   ) : (
     <ArrowDownLeft className="w-4 h-4 text-green-600" />
   )
 );
 
-export function HistoryTab({ transactions, loading, filter, setFilter }) {
+export function HistoryTab({ transactions, loading, filter, setFilter, currentRate }) {
   const t = useTranslations("wallet");
   const format = useFormatter();
 
@@ -65,37 +67,45 @@ export function HistoryTab({ transactions, loading, filter, setFilter }) {
           </div>
         ) : (
           <div className="space-y-3">
-            {transactions.map((tx, i) => (
-              <Card key={tx.paymentId || tx.txId || i} className="border" shadow="none">
+            {transactions.map((transaction, index) => (
+              <Card key={transaction.paymentId || transaction.txId || index} className="border" shadow="none">
                 <CardBody className="p-4">
                   <div className="flex items-center gap-3">
                     <div className="hidden sm:flex w-10 h-10 shrink-0 bg-gray-100 rounded-full items-center justify-center">
-                      {getTransactionIcon(tx.type)}
+                      {getTransactionIcon(transaction.type)}
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex justify-between items-baseline gap-2">
                         <span className="text-deep">
-                          {tx.type === "outgoing_payment"
+                          {transaction.type === "outgoing_payment"
                             ? t("payments.history.sent")
                             : t("payments.history.received")}
                         </span>
                         <span className="text-xs text-gray-400 shrink-0">
-                          {format.dateTime(new Date(tx.completedAt), { dateStyle: "short" })}
+                          {format.dateTime(new Date(transaction.completedAt), { dateStyle: "short" })}
                           {" "}
-                          {format.dateTime(new Date(tx.completedAt), { timeStyle: "short" })}
+                          {format.dateTime(new Date(transaction.completedAt), { timeStyle: "short" })}
                         </span>
                       </div>
-                      <p className={`text-lg font-bold ${tx.type === "outgoing_payment" ? "text-red-700" : "text-deep"}`}>
-                        {formatSats(
-                          tx.type === "outgoing_payment" ? tx.sent : tx.receivedSat,
-                        )}{" "}
-                        sats
+                      <p className={`text-lg font-bold ${transaction.type === "outgoing_payment" ? "text-red-700" : "text-deep"}`}>
+                        {transaction.type === "incoming_payment" && transaction.exchangeRateAtPayment ? (
+                          <AmountDisplay
+                            satoshis={transaction.receivedSat}
+                            exchangeRateAtSale={transaction.exchangeRateAtPayment}
+                            currentRate={currentRate}
+                          />
+                        ) : (
+                          <>
+                            {formatSats(transaction.type === "outgoing_payment" ? transaction.sent : transaction.receivedSat)}
+                            {" "}sats
+                          </>
+                        )}
                       </p>
                       <p className="text-sm text-deep">
-                        {t("payments.history.fee")} {formatSats(Number(tx.fees) / 1000)} sats
+                        {t("payments.history.fee")} {formatSats(Number(transaction.fees) / 1000)} sats
                       </p>
-                      {tx.description && (
-                        <p className="text-sm text-deep">{tx.description}</p>
+                      {transaction.description && (
+                        <p className="text-sm text-deep">{transaction.description}</p>
                       )}
                     </div>
                   </div>

--- a/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
@@ -87,7 +87,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                           {format.dateTime(new Date(transaction.completedAt), { timeStyle: "short" })}
                         </span>
                       </div>
-                      <p className={`text-lg font-bold ${transaction.type === "outgoing_payment" ? "text-red-700" : "text-deep"}`}>
+                      <div className={`text-lg font-bold ${transaction.type === "outgoing_payment" ? "text-red-700" : "text-deep"}`}>
                         {transaction.type === "incoming_payment" && transaction.exchangeRateAtPayment ? (
                           <AmountDisplay
                             satoshis={transaction.receivedSat}
@@ -100,7 +100,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                             {" "}sats
                           </>
                         )}
-                      </p>
+                      </div>
                       <p className="text-sm text-deep">
                         {t("payments.history.fee")} {formatSats(Number(transaction.fees) / 1000)} sats
                       </p>

--- a/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
@@ -17,7 +17,7 @@ const getTransactionIcon = (transactionType) => (
 );
 
 export function HistoryTab({ transactions, loading, filter, setFilter, currentRate }) {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
   const format = useFormatter();
 
   return (
@@ -30,7 +30,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
           className={filter !== "all" ? "border border-border text-foreground hover:bg-muted" : ""}
           onPress={() => setFilter("all")}
         >
-          {t("payments.history.all")}
+          {walletTranslations("payments.history.all")}
         </Button>
         <Button
           variant={filter === "incoming" ? "solid" : "bordered"}
@@ -39,7 +39,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
           className={filter !== "incoming" ? "border border-border text-foreground hover:bg-muted" : ""}
           onPress={() => setFilter("incoming")}
         >
-          {t("payments.history.received")}
+          {walletTranslations("payments.history.received")}
         </Button>
         <Button
           variant={filter === "outgoing" ? "solid" : "bordered"}
@@ -48,7 +48,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
           className={filter !== "outgoing" ? "border border-border text-foreground hover:bg-muted" : ""}
           onPress={() => setFilter("outgoing")}
         >
-          {t("payments.history.sent")}
+          {walletTranslations("payments.history.sent")}
         </Button>
       </div>
 
@@ -61,9 +61,9 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
           <div className="flex flex-col items-center justify-center h-full text-center">
             <History className="w-16 h-16 text-gray-300 mb-4" />
             <h3 className="text-xl font-semibold text-deep mb-2">
-              {t("payments.history.noTx")}
+              {walletTranslations("payments.history.noTx")}
             </h3>
-            <p className="text-gray-500">{t("payments.history.noTxMessage")}</p>
+            <p className="text-gray-500">{walletTranslations("payments.history.noTxMessage")}</p>
           </div>
         ) : (
           <div className="space-y-3">
@@ -78,8 +78,8 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                       <div className="flex justify-between items-baseline gap-2">
                         <span className="text-deep">
                           {transaction.type === "outgoing_payment"
-                            ? t("payments.history.sent")
-                            : t("payments.history.received")}
+                            ? walletTranslations("payments.history.sent")
+                            : walletTranslations("payments.history.received")}
                         </span>
                         <span className="text-xs text-gray-400 shrink-0">
                           {format.dateTime(new Date(transaction.completedAt), { dateStyle: "short" })}
@@ -104,7 +104,7 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                         )}
                       </div>
                       <p className="text-sm text-deep">
-                        {t("payments.history.fee")} {formatSats(Number(transaction.fees) / 1000)} sats
+                        {walletTranslations("payments.history.fee")} {formatSats(Number(transaction.fees) / 1000)} sats
                       </p>
                       {transaction.description && (
                         <p className="text-sm text-deep">{transaction.description}</p>

--- a/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
@@ -92,6 +92,8 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                           <AmountDisplay
                             satoshis={transaction.receivedSat}
                             exchangeRateAtSale={transaction.exchangeRateAtPayment}
+                            exchangeRateCurrency={transaction.exchangeRateCurrency}
+                            fiatAmountAtPayment={transaction.fiatAmountAtPayment}
                             currentRate={currentRate}
                           />
                         ) : (

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -23,6 +23,7 @@ export function Transactions({
   invoiceActions,
   fetchInfo,
   fetchTransactions,
+  currentRate,
 }) {
   const t = useTranslations("wallet");
   const tTour = useTranslations("walletTour");
@@ -135,6 +136,7 @@ export function Transactions({
               loading={loading}
               filter={filter}
               setFilter={setFilter}
+              currentRate={currentRate}
             />
           </Tab>
         </Tabs>

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -25,8 +25,8 @@ export function Transactions({
   fetchTransactions,
   currentRate,
 }) {
-  const t = useTranslations("wallet");
-  const tTour = useTranslations("walletTour");
+  const walletTranslations = useTranslations("wallet");
+  const walletTourTranslations = useTranslations("walletTour");
   const [activeTab, setActiveTab] = useState("receive");
 
   useTour({
@@ -40,8 +40,8 @@ export function Transactions({
         {
           element: "#wallet-receive-amount",
           popover: {
-            title: tTour("receiveAmountTitle"),
-            description: tTour.raw("receiveAmountDescription"),
+            title: walletTourTranslations("receiveAmountTitle"),
+            description: walletTourTranslations.raw("receiveAmountDescription"),
             side: "top",
             align: "center",
           },
@@ -49,8 +49,8 @@ export function Transactions({
         {
           element: "#wallet-receive-description",
           popover: {
-            title: tTour("receiveDescTitle"),
-            description: tTour.raw("receiveDescDescription"),
+            title: walletTourTranslations("receiveDescTitle"),
+            description: walletTourTranslations.raw("receiveDescDescription"),
             side: "top",
             align: "center",
           },
@@ -58,11 +58,11 @@ export function Transactions({
         {
           element: "#wallet-receive-button",
           popover: {
-            title: tTour("receiveButtonTitle"),
-            description: tTour.raw("receiveButtonDescription"),
+            title: walletTourTranslations("receiveButtonTitle"),
+            description: walletTourTranslations.raw("receiveButtonDescription"),
             side: "top",
             align: "center",
-            nextBtnText: tTour("receiveButton"),
+            nextBtnText: walletTourTranslations("receiveButton"),
           },
         },
       ],
@@ -79,12 +79,12 @@ export function Transactions({
     <Card className="rounded-lg mb-6 p-6">
       <CardBody className="p-0">
         <h2 className="text-xl font-bold text-deep px-6 pt-2 pb-4">
-          {t("payments.title")}
+          {walletTranslations("payments.title")}
         </h2>
         <Tabs
           selectedKey={activeTab}
           onSelectionChange={setActiveTab}
-          aria-label={t("payments.title")}
+          aria-label={walletTranslations("payments.title")}
           variant="underlined"
           classNames={{
             tabList: "gap-2 sm:gap-6 relative rounded-none px-4 sm:px-6 py-0 overflow-x-auto flex-nowrap w-full",
@@ -98,7 +98,7 @@ export function Transactions({
             title={(
               <div className="flex items-center space-x-2">
                 <ArrowDownLeft className="hidden sm:block w-4 h-4" />
-                <span>{t("payments.receive.tabTitle")}</span>
+                <span>{walletTranslations("payments.receive.tabTitle")}</span>
               </div>
             )}
           >
@@ -112,7 +112,7 @@ export function Transactions({
             title={(
               <div className="flex items-center space-x-2">
                 <ArrowUpRight className="hidden sm:block w-4 h-4" />
-                <span>{t("payments.send.tabTitle")}</span>
+                <span>{walletTranslations("payments.send.tabTitle")}</span>
               </div>
             )}
           >
@@ -127,7 +127,7 @@ export function Transactions({
             title={(
               <div className="flex items-center space-x-2">
                 <History className="hidden sm:block w-4 h-4" />
-                <span>{t("payments.history.tabTitle")}</span>
+                <span>{walletTranslations("payments.history.tabTitle")}</span>
               </div>
             )}
           >

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/HistoryTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/HistoryTab.test.jsx
@@ -1,8 +1,13 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
 import { I18nProvider } from "@i18n/I18nProvider";
 
 import { HistoryTab } from "../HistoryTab";
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: jest.fn(),
+}));
 
 const mockIncomingTransaction = {
   paymentId: "payment-1",
@@ -39,6 +44,11 @@ const originalWarn = console.warn;
 const originalError = console.error;
 
 beforeEach(() => {
+  useCurrency.mockReturnValue({
+    currency: { acronym: "USD", symbol: "$", locale: "en-US" },
+    formatAmount: (cents) => `$${(cents / 100).toFixed(2)}`,
+  });
+
   console.warn = (...args) => {
     if (
       typeof args[0] === "string" &&
@@ -275,6 +285,47 @@ describe("HistoryTab Component", () => {
       const { container } = renderHistoryTab({ transactions: [txWithoutId] });
 
       expect(container.querySelector('[class*="border"]')).toBeInTheDocument();
+    });
+  });
+
+  describe("AmountDisplay integration", () => {
+    const incomingWithRate = {
+      paymentId: "payment-btc",
+      type: "incoming_payment",
+      receivedSat: 100_000_000,
+      fees: 0,
+      completedAt: Date.now(),
+      exchangeRateAtPayment: 50000,
+    };
+
+    it("shows AmountDisplay for incoming transaction with exchangeRateAtPayment", () => {
+      renderHistoryTab({ transactions: [incomingWithRate], currentRate: 60000 });
+
+      expect(screen.getByText("$50000.00")).toBeInTheDocument();
+    });
+
+    it("shows raw sats for incoming transaction without exchangeRateAtPayment", () => {
+      renderHistoryTab({ transactions: [mockIncomingTransaction] });
+
+      expect(screen.getByText("5,000 sats")).toBeInTheDocument();
+    });
+
+    it("shows raw sats for outgoing transaction regardless of currentRate", () => {
+      renderHistoryTab({ transactions: [mockOutgoingTransaction], currentRate: 60000 });
+
+      expect(screen.getByText("3,000 sats")).toBeInTheDocument();
+    });
+
+    it("shows clock toggle when currentRate is provided", () => {
+      const { container } = renderHistoryTab({ transactions: [incomingWithRate], currentRate: 60000 });
+
+      expect(container.querySelector("svg.lucide-clock")).toBeInTheDocument();
+    });
+
+    it("does not show clock toggle when currentRate is null", () => {
+      const { container } = renderHistoryTab({ transactions: [incomingWithRate], currentRate: null });
+
+      expect(container.querySelector("svg.lucide-clock")).toBeNull();
     });
   });
 

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/HistoryTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/HistoryTab.test.jsx
@@ -317,15 +317,15 @@ describe("HistoryTab Component", () => {
     });
 
     it("shows clock toggle when currentRate is provided", () => {
-      const { container } = renderHistoryTab({ transactions: [incomingWithRate], currentRate: 60000 });
+      renderHistoryTab({ transactions: [incomingWithRate], currentRate: 60000 });
 
-      expect(container.querySelector("svg.lucide-clock")).toBeInTheDocument();
+      expect(screen.getByLabelText("showCurrentRate")).toBeInTheDocument();
     });
 
     it("does not show clock toggle when currentRate is null", () => {
-      const { container } = renderHistoryTab({ transactions: [incomingWithRate], currentRate: null });
+      renderHistoryTab({ transactions: [incomingWithRate], currentRate: null });
 
-      expect(container.querySelector("svg.lucide-clock")).toBeNull();
+      expect(screen.queryByLabelText("showCurrentRate")).toBeNull();
     });
   });
 

--- a/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, act, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import * as useBitcoinPriceHook from "@/components/hooks/useBitcoinPrice";
 import { AuthContext } from "@/providers/auth/AuthProvider";
 import * as walletService from "@/services/walletService";
 import * as useNavigationHook from "@hooks/useNavigation";
@@ -170,6 +171,11 @@ beforeEach(() => {
     setInvoiceHash: jest.fn(),
     setFetchers: jest.fn(),
     onPayment: jest.fn(() => jest.fn()),
+  });
+
+  jest.spyOn(useBitcoinPriceHook, "useBitcoinPrice").mockReturnValue({
+    currentRate: 50000,
+    isLoading: false,
   });
 });
 

--- a/client/src/components/shared/AmountDisplay.jsx
+++ b/client/src/components/shared/AmountDisplay.jsx
@@ -2,10 +2,59 @@
 
 import { useState } from "react";
 
-import { Clock } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
+
+function AnimatedClockButton({ showingHistorical, onClick, ariaLabel }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="flex items-center p-2 -m-2"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={showingHistorical ? "text-primary" : "text-foreground-400"}
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line
+          x1="12"
+          y1="12"
+          x2="12"
+          y2="6"
+          style={{
+            transformBox: "fill-box",
+            transformOrigin: "50% 100%",
+            transform: `rotate(${showingHistorical ? -720 : 0}deg)`,
+            transition: "transform 0.55s ease-out",
+          }}
+        />
+        <line
+          x1="12"
+          y1="12"
+          x2="15.5"
+          y2="12"
+          strokeWidth="2.5"
+          style={{
+            transformBox: "fill-box",
+            transformOrigin: "0% 50%",
+            transform: `rotate(${showingHistorical ? -180 : 0}deg)`,
+            transition: "transform 0.7s ease-in-out",
+          }}
+        />
+      </svg>
+    </button>
+  );
+}
 
 export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
   const [showSats, setShowSats] = useState(false);
@@ -20,7 +69,7 @@ export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
       <button
         type="button"
         onClick={() => setShowSats(false)}
-        className="text-sm tabular-nums"
+        className="tabular-nums"
       >
         {satoshis.toLocaleString()} {t("satsLabel")}
       </button>
@@ -38,27 +87,28 @@ export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
   const canToggleRate = fiatAtSaleCents != null && fiatCurrentCents != null;
 
   return (
-    <span className="inline-flex items-center gap-1">
-      <button
-        type="button"
-        onClick={() => setShowSats(true)}
-        className="text-sm tabular-nums"
-      >
-        {displayCents != null ? formatAmount(displayCents) : "—"}
-      </button>
-      {canToggleRate && (
+    <div>
+      <span className="inline-flex items-center gap-1">
         <button
           type="button"
-          onClick={() => setShowCurrentFiat((prev) => !prev)}
-          aria-label={showCurrentFiat ? t("showHistoricalRate") : t("showCurrentRate")}
-          className="flex items-center"
+          onClick={() => setShowSats(true)}
+          className="tabular-nums"
         >
-          <Clock
-            size={12}
-            className={showCurrentFiat ? "text-primary" : "text-foreground-400"}
-          />
+          {displayCents != null ? formatAmount(displayCents) : "—"}
         </button>
+        {canToggleRate && (
+          <AnimatedClockButton
+            showingHistorical={!showCurrentFiat}
+            onClick={() => setShowCurrentFiat((prev) => !prev)}
+            ariaLabel={showCurrentFiat ? t("showHistoricalRate") : t("showCurrentRate")}
+          />
+        )}
+      </span>
+      {canToggleRate && (
+        <p className="text-xs font-normal text-foreground-400 mt-0.5">
+          {showCurrentFiat ? t("amountAtCurrentRate") : t("amountAtTimeOfPayment")}
+        </p>
       )}
-    </span>
+    </div>
   );
 }

--- a/client/src/components/shared/AmountDisplay.jsx
+++ b/client/src/components/shared/AmountDisplay.jsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+
+import { Clock } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { useCurrency } from "@/components/hooks/useCurrency";
+
+export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
+  const [showSats, setShowSats] = useState(false);
+  const [showCurrentFiat, setShowCurrentFiat] = useState(false);
+  const { formatAmount } = useCurrency();
+  const t = useTranslations("amountDisplay");
+
+  if (!satoshis) return null;
+
+  if (showSats) {
+    return (
+      <button
+        type="button"
+        onClick={() => setShowSats(false)}
+        className="text-sm tabular-nums"
+      >
+        {satoshis.toLocaleString()} {t("satsLabel")}
+      </button>
+    );
+  }
+
+  const fiatAtSaleCents = exchangeRateAtSale != null
+    ? (satoshis / 100_000_000) * exchangeRateAtSale * 100
+    : null;
+  const fiatCurrentCents = currentRate != null
+    ? (satoshis / 100_000_000) * currentRate * 100
+    : null;
+
+  const displayCents = showCurrentFiat ? fiatCurrentCents : fiatAtSaleCents;
+  const canToggleRate = fiatAtSaleCents != null && fiatCurrentCents != null;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => setShowSats(true)}
+        className="text-sm tabular-nums"
+      >
+        {displayCents != null ? formatAmount(displayCents) : "—"}
+      </button>
+      {canToggleRate && (
+        <button
+          type="button"
+          onClick={() => setShowCurrentFiat((prev) => !prev)}
+          aria-label={showCurrentFiat ? t("showHistoricalRate") : t("showCurrentRate")}
+          className="flex items-center"
+        >
+          <Clock
+            size={12}
+            className={showCurrentFiat ? "text-primary" : "text-foreground-400"}
+          />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/client/src/components/shared/AmountDisplay.jsx
+++ b/client/src/components/shared/AmountDisplay.jsx
@@ -6,6 +6,12 @@ import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
 
+function calculateHistoricalCents(fiatAmountAtPayment, exchangeRateAtSale, satoshis) {
+  if (fiatAmountAtPayment != null) return fiatAmountAtPayment * 100;
+  if (exchangeRateAtSale != null) return (satoshis / 100_000_000) * exchangeRateAtSale * 100;
+  return null;
+}
+
 function AnimatedClockButton({ showingHistorical, onClick, ariaLabel }) {
   return (
     <button
@@ -56,10 +62,16 @@ function AnimatedClockButton({ showingHistorical, onClick, ariaLabel }) {
   );
 }
 
-export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
+export function AmountDisplay({
+  satoshis,
+  exchangeRateAtSale,
+  exchangeRateCurrency,
+  fiatAmountAtPayment,
+  currentRate,
+}) {
   const [showSats, setShowSats] = useState(false);
   const [showCurrentFiat, setShowCurrentFiat] = useState(false);
-  const { formatAmount } = useCurrency();
+  const { formatAmount, currency } = useCurrency();
   const t = useTranslations("amountDisplay");
 
   if (!satoshis) return null;
@@ -76,15 +88,19 @@ export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
     );
   }
 
-  const fiatAtSaleCents = exchangeRateAtSale != null
-    ? (satoshis / 100_000_000) * exchangeRateAtSale * 100
-    : null;
-  const fiatCurrentCents = currentRate != null
+  const historicalCents = calculateHistoricalCents(fiatAmountAtPayment, exchangeRateAtSale, satoshis);
+
+  const currentFiatCents = currentRate != null
     ? (satoshis / 100_000_000) * currentRate * 100
     : null;
 
-  const displayCents = showCurrentFiat ? fiatCurrentCents : fiatAtSaleCents;
-  const canToggleRate = fiatAtSaleCents != null && fiatCurrentCents != null;
+  const displayCents = showCurrentFiat ? currentFiatCents : historicalCents;
+  const canToggleRate = historicalCents != null && currentFiatCents != null;
+
+  const currentCurrencyAcronym = currency?.acronym?.toUpperCase();
+  const displayedCurrencyAcronym = showCurrentFiat
+    ? currentCurrencyAcronym
+    : (exchangeRateCurrency?.toUpperCase() ?? currentCurrencyAcronym);
 
   return (
     <div>
@@ -96,6 +112,9 @@ export function AmountDisplay({ satoshis, exchangeRateAtSale, currentRate }) {
         >
           {displayCents != null ? formatAmount(displayCents) : "—"}
         </button>
+        {displayedCurrencyAcronym && (
+          <span className="text-xs font-normal text-foreground-400">{displayedCurrencyAcronym}</span>
+        )}
         {canToggleRate && (
           <AnimatedClockButton
             showingHistorical={!showCurrentFiat}

--- a/client/src/components/shared/__tests__/AmountDisplay.test.jsx
+++ b/client/src/components/shared/__tests__/AmountDisplay.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { useCurrency } from "@/components/hooks/useCurrency";
+
+import { AmountDisplay } from "../AmountDisplay";
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: jest.fn(),
+}));
+
+const formatAmount = jest.fn((cents) => `$${(cents / 100).toFixed(2)}`);
+
+function renderComponent(props = {}) {
+  return render(<AmountDisplay {...props} />);
+}
+
+describe("AmountDisplay", () => {
+  beforeEach(() => {
+    useCurrency.mockReturnValue({ formatAmount });
+    formatAmount.mockClear();
+  });
+
+  it("returns null when satoshis is 0", () => {
+    const { container } = renderComponent({ satoshis: 0, exchangeRateAtSale: 50000, currentRate: 60000 });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows historical fiat by default", () => {
+    renderComponent({ satoshis: 100_000_000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    expect(formatAmount).toHaveBeenCalledWith(50000 * 100);
+    expect(screen.getByText("$50000.00")).toBeInTheDocument();
+  });
+
+  it("clicking amount toggles to sats mode", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByText("$10.00"));
+    expect(screen.getByText(/20,000/)).toBeInTheDocument();
+  });
+
+  it("clicking amount in sats mode returns to fiat mode", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByText("$10.00"));
+    const satsButton = screen.getByText(/20,000/);
+    fireEvent.click(satsButton);
+    expect(screen.getByText("$10.00")).toBeInTheDocument();
+  });
+
+  it("shows clock icon when both rates are available", () => {
+    const { container } = renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("does not show clock icon when currentRate is missing", () => {
+    const { container } = renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000 });
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("does not show clock icon when exchangeRateAtSale is missing", () => {
+    const { container } = renderComponent({ satoshis: 20000, currentRate: 60000 });
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("clicking clock shows current fiat", () => {
+    renderComponent({ satoshis: 100_000_000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByLabelText("showCurrentRate"));
+    expect(formatAmount).toHaveBeenCalledWith(60000 * 100);
+  });
+
+  it("clicking clock again returns to historical fiat", () => {
+    renderComponent({ satoshis: 100_000_000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByLabelText("showCurrentRate"));
+    formatAmount.mockClear();
+    fireEvent.click(screen.getByLabelText("showHistoricalRate"));
+    expect(formatAmount).toHaveBeenCalledWith(50000 * 100);
+  });
+
+  it("does not show clock icon in sats mode", () => {
+    const { container } = renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByText("$10.00"));
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("shows dash when exchangeRateAtSale is null and currentRate is null", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: null, currentRate: null });
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/__tests__/AmountDisplay.test.jsx
+++ b/client/src/components/shared/__tests__/AmountDisplay.test.jsx
@@ -84,4 +84,21 @@ describe("AmountDisplay", () => {
     renderComponent({ satoshis: 20000, exchangeRateAtSale: null, currentRate: null });
     expect(screen.getByText("—")).toBeInTheDocument();
   });
+
+  it("shows historical rate label by default when both rates are available", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    expect(screen.getByText("amountAtTimeOfPayment")).toBeInTheDocument();
+  });
+
+  it("shows current rate label after clicking clock", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000, currentRate: 60000 });
+    fireEvent.click(screen.getByLabelText("showCurrentRate"));
+    expect(screen.getByText("amountAtCurrentRate")).toBeInTheDocument();
+  });
+
+  it("does not show rate label when only one rate is available", () => {
+    renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000 });
+    expect(screen.queryByText("amountAtTimeOfPayment")).not.toBeInTheDocument();
+    expect(screen.queryByText("amountAtCurrentRate")).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/shared/__tests__/AmountDisplay.test.jsx
+++ b/client/src/components/shared/__tests__/AmountDisplay.test.jsx
@@ -16,7 +16,7 @@ function renderComponent(props = {}) {
 
 describe("AmountDisplay", () => {
   beforeEach(() => {
-    useCurrency.mockReturnValue({ formatAmount });
+    useCurrency.mockReturnValue({ formatAmount, currency: { acronym: "USD" } });
     formatAmount.mockClear();
   });
 
@@ -100,5 +100,51 @@ describe("AmountDisplay", () => {
     renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000 });
     expect(screen.queryByText("amountAtTimeOfPayment")).not.toBeInTheDocument();
     expect(screen.queryByText("amountAtCurrentRate")).not.toBeInTheDocument();
+  });
+
+  it("uses fiatAmountAtPayment directly for historical display when provided", () => {
+    renderComponent({
+      satoshis: 100_000_000,
+      exchangeRateAtSale: 50000,
+      fiatAmountAtPayment: 1.0,
+      currentRate: 60000,
+    });
+    expect(formatAmount).toHaveBeenCalledWith(100);
+  });
+
+  it("always shows historical currency tag inline", () => {
+    useCurrency.mockReturnValue({ formatAmount, currency: { acronym: "MXN" } });
+    renderComponent({
+      satoshis: 20000,
+      exchangeRateAtSale: 50000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+      currentRate: 1_900_000,
+    });
+    expect(screen.getByText("USD")).toBeInTheDocument();
+  });
+
+  it("always shows current currency tag inline when toggled", () => {
+    useCurrency.mockReturnValue({ formatAmount, currency: { acronym: "MXN" } });
+    renderComponent({
+      satoshis: 20000,
+      exchangeRateAtSale: 50000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+      currentRate: 1_900_000,
+    });
+    fireEvent.click(screen.getByLabelText("showCurrentRate"));
+    expect(screen.getByText("MXN")).toBeInTheDocument();
+  });
+
+  it("shows current currency tag even when currencies match", () => {
+    renderComponent({
+      satoshis: 20000,
+      exchangeRateAtSale: 50000,
+      exchangeRateCurrency: "usd",
+      fiatAmountAtPayment: 1.0,
+      currentRate: 60000,
+    });
+    expect(screen.getByText("USD")).toBeInTheDocument();
   });
 });

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -167,28 +167,32 @@ fun Route.wallet(
 
                 val payments = phoenixService.listIncomingPayments(from, to, limit, offset, all, externalId)
                 val hashes = payments.map { it.paymentHash }
-                val exchangeRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
-                val enriched = payments.map { payment ->
-                    IncomingPaymentWithRate(
-                        type = payment.type,
-                        subType = payment.subType,
-                        paymentHash = payment.paymentHash,
-                        preimage = payment.preimage,
-                        externalId = payment.externalId,
-                        description = payment.description,
-                        invoice = payment.invoice,
-                        isPaid = payment.isPaid,
-                        isExpired = payment.isExpired,
-                        requestedSat = payment.requestedSat,
-                        receivedSat = payment.receivedSat,
-                        fees = payment.fees,
-                        payerKey = payment.payerKey,
-                        expiresAt = payment.expiresAt,
-                        completedAt = payment.completedAt,
-                        createdAt = payment.createdAt,
-                        exchangeRateAtPayment = exchangeRates[payment.paymentHash],
-                    )
-                }
+                val bitcoinPaymentDataByHash = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val enriched =
+                    payments.map { payment ->
+                        val bitcoinPaymentData = bitcoinPaymentDataByHash[payment.paymentHash]
+                        IncomingPaymentWithRate(
+                            type = payment.type,
+                            subType = payment.subType,
+                            paymentHash = payment.paymentHash,
+                            preimage = payment.preimage,
+                            externalId = payment.externalId,
+                            description = payment.description,
+                            invoice = payment.invoice,
+                            isPaid = payment.isPaid,
+                            isExpired = payment.isExpired,
+                            requestedSat = payment.requestedSat,
+                            receivedSat = payment.receivedSat,
+                            fees = payment.fees,
+                            payerKey = payment.payerKey,
+                            expiresAt = payment.expiresAt,
+                            completedAt = payment.completedAt,
+                            createdAt = payment.createdAt,
+                            exchangeRateAtPayment = bitcoinPaymentData?.exchangeRateAtPayment,
+                            exchangeRateCurrency = bitcoinPaymentData?.exchangeRateCurrency,
+                            fiatAmountAtPayment = bitcoinPaymentData?.fiatAmountAtPayment,
+                        )
+                    }
                 call.respond(HttpStatusCode.OK, enriched)
             }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -15,6 +15,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import pos.ambrosia.db.DatabaseConnection
+import pos.ambrosia.models.IncomingPaymentWithRate
 import pos.ambrosia.models.RolePassword
 import pos.ambrosia.models.WalletAuthResponse
 import pos.ambrosia.models.phoenix.CloseChannelRequest
@@ -25,6 +26,7 @@ import pos.ambrosia.models.phoenix.PayInvoiceRequest
 import pos.ambrosia.models.phoenix.PayOfferRequest
 import pos.ambrosia.models.phoenix.PayOnchainRequest
 import pos.ambrosia.services.AuthService
+import pos.ambrosia.services.PaymentService
 import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.Bolt11Decoder
@@ -38,14 +40,16 @@ fun Application.configureWallet() {
     val phoenixService = PhoenixService(environment)
     val authService = AuthService(environment, connection)
     val tokenService = TokenService(environment, connection)
+    val paymentService = PaymentService(connection)
 
-    routing { route("/wallet") { wallet(phoenixService, tokenService, authService) } }
+    routing { route("/wallet") { wallet(phoenixService, tokenService, authService, paymentService) } }
 }
 
 fun Route.wallet(
     phoenixService: PhoenixService,
     tokenService: TokenService,
     authService: AuthService,
+    paymentService: PaymentService,
 ) {
     authenticate("auth-jwt") {
         post("/invoice") {
@@ -162,7 +166,30 @@ fun Route.wallet(
                 val externalId = call.request.queryParameters["externalId"]
 
                 val payments = phoenixService.listIncomingPayments(from, to, limit, offset, all, externalId)
-                call.respond(HttpStatusCode.OK, payments)
+                val hashes = payments.map { it.paymentHash }
+                val exchangeRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val enriched = payments.map { payment ->
+                    IncomingPaymentWithRate(
+                        type = payment.type,
+                        subType = payment.subType,
+                        paymentHash = payment.paymentHash,
+                        preimage = payment.preimage,
+                        externalId = payment.externalId,
+                        description = payment.description,
+                        invoice = payment.invoice,
+                        isPaid = payment.isPaid,
+                        isExpired = payment.isExpired,
+                        requestedSat = payment.requestedSat,
+                        receivedSat = payment.receivedSat,
+                        fees = payment.fees,
+                        payerKey = payment.payerKey,
+                        expiresAt = payment.expiresAt,
+                        completedAt = payment.completedAt,
+                        createdAt = payment.createdAt,
+                        exchangeRateAtPayment = exchangeRates[payment.paymentHash],
+                    )
+                }
+                call.respond(HttpStatusCode.OK, enriched)
             }
 
             get("/incoming/{paymentHash}") {

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -162,6 +162,8 @@ data class OrderWithPayment(
     val paymentMethodIds: List<String> = emptyList(),
     val satoshiAmount: Long? = null,
     val exchangeRateAtPayment: Double? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmountAtPayment: Double? = null,
 )
 
 data class OrderWithPaymentFilters(

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -478,6 +478,8 @@ data class ProductSaleItem(
     val saleDate: String,
     val satoshiAmount: Long? = null,
     val exchangeRateAtPayment: Double? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmountAtPayment: Double? = null,
     val paymentId: String? = null,
 )
 

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -160,6 +160,8 @@ data class OrderWithPayment(
     val createdAt: String,
     val paymentMethod: String? = null,
     val paymentMethodIds: List<String> = emptyList(),
+    val satoshiAmount: Long? = null,
+    val exchangeRateAtPayment: Double? = null,
 )
 
 data class OrderWithPaymentFilters(
@@ -449,6 +451,9 @@ data class StoreCheckoutRequest(
     val amount: Double,
     val transactionId: String? = null,
     val ticketNotes: String = "",
+    val satoshiAmount: Long? = null,
+    val exchangeRateAtPayment: Double? = null,
+    val paymentHash: String? = null,
 )
 
 @Serializable
@@ -467,6 +472,9 @@ data class ProductSaleItem(
     val userName: String,
     val paymentMethod: String,
     val saleDate: String,
+    val satoshiAmount: Long? = null,
+    val exchangeRateAtPayment: Double? = null,
+    val paymentId: String? = null,
 )
 
 @Serializable
@@ -474,4 +482,26 @@ data class ProductSalesReport(
     val totalRevenueCents: Long,
     val totalItemsSold: Int,
     val sales: List<ProductSaleItem>,
+    val totalBtcSatoshis: Long = 0L,
+)
+
+@Serializable
+data class IncomingPaymentWithRate(
+    val type: String,
+    val subType: String,
+    val paymentHash: String,
+    val preimage: String? = null,
+    val externalId: String? = null,
+    val description: String? = null,
+    val invoice: String? = null,
+    val isPaid: Boolean,
+    val isExpired: Boolean? = null,
+    val requestedSat: Long? = null,
+    val receivedSat: Long,
+    val fees: Long,
+    val payerKey: String? = null,
+    val expiresAt: Long? = null,
+    val completedAt: Long? = null,
+    val createdAt: Long,
+    val exchangeRateAtPayment: Double? = null,
 )

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -454,6 +454,8 @@ data class StoreCheckoutRequest(
     val satoshiAmount: Long? = null,
     val exchangeRateAtPayment: Double? = null,
     val paymentHash: String? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmountAtPayment: Double? = null,
 )
 
 @Serializable
@@ -485,6 +487,12 @@ data class ProductSalesReport(
     val totalBtcSatoshis: Long = 0L,
 )
 
+data class PaymentBitcoinData(
+    val exchangeRateAtPayment: Double,
+    val exchangeRateCurrency: String?,
+    val fiatAmountAtPayment: Double?,
+)
+
 @Serializable
 data class IncomingPaymentWithRate(
     val type: String,
@@ -504,4 +512,6 @@ data class IncomingPaymentWithRate(
     val completedAt: Long? = null,
     val createdAt: Long,
     val exchangeRateAtPayment: Double? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmountAtPayment: Double? = null,
 )

--- a/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
@@ -54,7 +54,7 @@ class OrderService(
         private const val STORE_INSERT_TICKET =
             "INSERT INTO tickets (id, order_id, user_id, ticket_date, status, total_amount, notes) VALUES (?, ?, ?, datetime('now'), 1, ?, ?)"
         private const val STORE_INSERT_PAYMENT =
-            "INSERT INTO payments (id, method_id, currency_id, transaction_id, amount) VALUES (?, ?, ?, ?, ?)"
+            "INSERT INTO payments (id, method_id, currency_id, transaction_id, amount, satoshi_amount, exchange_rate_at_payment, payment_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         private const val STORE_INSERT_TICKET_PAYMENT =
             "INSERT INTO ticket_payments (payment_id, ticket_id) VALUES (?, ?)"
         private const val STORE_GET_ITEMS =
@@ -596,6 +596,9 @@ class OrderService(
                 statement.setString(3, request.currencyId)
                 statement.setString(4, request.transactionId ?: "")
                 statement.setDouble(5, request.amount)
+                if (request.satoshiAmount != null) statement.setLong(6, request.satoshiAmount) else statement.setNull(6, java.sql.Types.INTEGER)
+                if (request.exchangeRateAtPayment != null) statement.setDouble(7, request.exchangeRateAtPayment) else statement.setNull(7, java.sql.Types.REAL)
+                if (request.paymentHash != null) statement.setString(8, request.paymentHash) else statement.setNull(8, java.sql.Types.VARCHAR)
                 statement.executeUpdate()
             }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
@@ -94,7 +94,11 @@ class OrderService(
                    o.total,
                    o.created_at,
                    GROUP_CONCAT(DISTINCT pm.name) AS payment_method,
-                   GROUP_CONCAT(DISTINCT p.id) AS payment_method_ids
+                   GROUP_CONCAT(DISTINCT p.id) AS payment_method_ids,
+                   MAX(p.satoshi_amount) AS satoshi_amount,
+                   MAX(p.exchange_rate_at_payment) AS exchange_rate_at_payment,
+                   MAX(p.exchange_rate_currency) AS exchange_rate_currency,
+                   MAX(p.fiat_amount_at_payment) AS fiat_amount_at_payment
             FROM orders o
             LEFT JOIN users u ON u.id = o.user_id
             LEFT JOIN tickets t ON t.order_id = o.id
@@ -157,6 +161,10 @@ class OrderService(
             createdAt = resultSet.getString("created_at").replace(" ", "T"),
             paymentMethod = paymentNames,
             paymentMethodIds = paymentIds,
+            satoshiAmount = (resultSet.getObject("satoshi_amount") as? Number)?.toLong(),
+            exchangeRateAtPayment = (resultSet.getObject("exchange_rate_at_payment") as? Number)?.toDouble(),
+            exchangeRateCurrency = resultSet.getString("exchange_rate_currency"),
+            fiatAmountAtPayment = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble(),
         )
     }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/OrderService.kt
@@ -11,7 +11,29 @@ import pos.ambrosia.models.StoreOrder
 import pos.ambrosia.models.StoreOrderItem
 import java.sql.Connection
 import java.sql.PreparedStatement
+import java.sql.Types
 import java.util.UUID
+
+private fun PreparedStatement.setNullableLong(
+    index: Int,
+    value: Long?,
+) {
+    if (value != null) setLong(index, value) else setNull(index, Types.INTEGER)
+}
+
+private fun PreparedStatement.setNullableDouble(
+    index: Int,
+    value: Double?,
+) {
+    if (value != null) setDouble(index, value) else setNull(index, Types.REAL)
+}
+
+private fun PreparedStatement.setNullableString(
+    index: Int,
+    value: String?,
+) {
+    if (value != null) setString(index, value) else setNull(index, Types.VARCHAR)
+}
 
 class OrderService(
     private val connection: Connection,
@@ -54,7 +76,7 @@ class OrderService(
         private const val STORE_INSERT_TICKET =
             "INSERT INTO tickets (id, order_id, user_id, ticket_date, status, total_amount, notes) VALUES (?, ?, ?, datetime('now'), 1, ?, ?)"
         private const val STORE_INSERT_PAYMENT =
-            "INSERT INTO payments (id, method_id, currency_id, transaction_id, amount, satoshi_amount, exchange_rate_at_payment, payment_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO payments (id, method_id, currency_id, transaction_id, amount, satoshi_amount, exchange_rate_at_payment, payment_hash, exchange_rate_currency, fiat_amount_at_payment) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         private const val STORE_INSERT_TICKET_PAYMENT =
             "INSERT INTO ticket_payments (payment_id, ticket_id) VALUES (?, ?)"
         private const val STORE_GET_ITEMS =
@@ -596,9 +618,11 @@ class OrderService(
                 statement.setString(3, request.currencyId)
                 statement.setString(4, request.transactionId ?: "")
                 statement.setDouble(5, request.amount)
-                if (request.satoshiAmount != null) statement.setLong(6, request.satoshiAmount) else statement.setNull(6, java.sql.Types.INTEGER)
-                if (request.exchangeRateAtPayment != null) statement.setDouble(7, request.exchangeRateAtPayment) else statement.setNull(7, java.sql.Types.REAL)
-                if (request.paymentHash != null) statement.setString(8, request.paymentHash) else statement.setNull(8, java.sql.Types.VARCHAR)
+                statement.setNullableLong(6, request.satoshiAmount)
+                statement.setNullableDouble(7, request.exchangeRateAtPayment)
+                statement.setNullableString(8, request.paymentHash)
+                statement.setNullableString(9, request.exchangeRateCurrency)
+                statement.setNullableDouble(10, request.fiatAmountAtPayment)
                 statement.executeUpdate()
             }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
@@ -125,9 +125,9 @@ class PaymentService(
     suspend fun getExchangeRatesByPaymentHashes(hashes: List<String>): Map<String, PaymentBitcoinData> {
         if (hashes.isEmpty()) return emptyMap()
         val placeholders = hashes.joinToString(",") { "?" }
-        val sql = String.format(GET_BITCOIN_DATA_BY_PAYMENT_HASHES, placeholders)
+        val bitcoinDataQuery = String.format(GET_BITCOIN_DATA_BY_PAYMENT_HASHES, placeholders)
         val bitcoinDataByHash = mutableMapOf<String, PaymentBitcoinData>()
-        connection.prepareStatement(sql).use { statement ->
+        connection.prepareStatement(bitcoinDataQuery).use { statement ->
             hashes.forEachIndexed { index, hash -> statement.setString(index + 1, hash) }
             val resultSet = statement.executeQuery()
             while (resultSet.next()) {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
@@ -16,6 +16,8 @@ class PaymentService(
             "SELECT id, method_id, currency_id, transaction_id, amount, date FROM payments"
         private const val GET_PAYMENT_BY_ID =
             "SELECT id, method_id, currency_id, transaction_id, amount, date FROM payments WHERE id = ?"
+        private const val GET_EXCHANGE_RATES_BY_HASHES =
+            "SELECT payment_hash, exchange_rate_at_payment FROM payments WHERE payment_hash IN (%s) AND exchange_rate_at_payment IS NOT NULL"
         private const val UPDATE_PAYMENT =
             "UPDATE payments SET method_id = ?, currency_id = ?, transaction_id = ?, amount = ? WHERE id = ?"
         private const val DELETE_PAYMENT = "DELETE FROM payments WHERE id = ?"
@@ -117,6 +119,21 @@ class PaymentService(
             logger.warn("Currency not found with ID: $id")
             null
         }
+    }
+
+    suspend fun getExchangeRatesByPaymentHashes(hashes: List<String>): Map<String, Double> {
+        if (hashes.isEmpty()) return emptyMap()
+        val placeholders = hashes.joinToString(",") { "?" }
+        val sql = String.format(GET_EXCHANGE_RATES_BY_HASHES, placeholders)
+        val result = mutableMapOf<String, Double>()
+        connection.prepareStatement(sql).use { statement ->
+            hashes.forEachIndexed { index, hash -> statement.setString(index + 1, hash) }
+            val resultSet = statement.executeQuery()
+            while (resultSet.next()) {
+                result[resultSet.getString("payment_hash")] = resultSet.getDouble("exchange_rate_at_payment")
+            }
+        }
+        return result
     }
 
     suspend fun addPayment(payment: Payment): String? {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
@@ -3,6 +3,7 @@ package pos.ambrosia.services
 import pos.ambrosia.logger
 import pos.ambrosia.models.Currency
 import pos.ambrosia.models.Payment
+import pos.ambrosia.models.PaymentBitcoinData
 import pos.ambrosia.models.PaymentMethod
 import java.sql.Connection
 
@@ -16,8 +17,8 @@ class PaymentService(
             "SELECT id, method_id, currency_id, transaction_id, amount, date FROM payments"
         private const val GET_PAYMENT_BY_ID =
             "SELECT id, method_id, currency_id, transaction_id, amount, date FROM payments WHERE id = ?"
-        private const val GET_EXCHANGE_RATES_BY_HASHES =
-            "SELECT payment_hash, exchange_rate_at_payment FROM payments WHERE payment_hash IN (%s) AND exchange_rate_at_payment IS NOT NULL"
+        private const val GET_BITCOIN_DATA_BY_PAYMENT_HASHES =
+            "SELECT payment_hash, exchange_rate_at_payment, exchange_rate_currency, fiat_amount_at_payment FROM payments WHERE payment_hash IN (%s) AND exchange_rate_at_payment IS NOT NULL"
         private const val UPDATE_PAYMENT =
             "UPDATE payments SET method_id = ?, currency_id = ?, transaction_id = ?, amount = ? WHERE id = ?"
         private const val DELETE_PAYMENT = "DELETE FROM payments WHERE id = ?"
@@ -121,19 +122,23 @@ class PaymentService(
         }
     }
 
-    suspend fun getExchangeRatesByPaymentHashes(hashes: List<String>): Map<String, Double> {
+    suspend fun getExchangeRatesByPaymentHashes(hashes: List<String>): Map<String, PaymentBitcoinData> {
         if (hashes.isEmpty()) return emptyMap()
         val placeholders = hashes.joinToString(",") { "?" }
-        val sql = String.format(GET_EXCHANGE_RATES_BY_HASHES, placeholders)
-        val result = mutableMapOf<String, Double>()
+        val sql = String.format(GET_BITCOIN_DATA_BY_PAYMENT_HASHES, placeholders)
+        val bitcoinDataByHash = mutableMapOf<String, PaymentBitcoinData>()
         connection.prepareStatement(sql).use { statement ->
             hashes.forEachIndexed { index, hash -> statement.setString(index + 1, hash) }
             val resultSet = statement.executeQuery()
             while (resultSet.next()) {
-                result[resultSet.getString("payment_hash")] = resultSet.getDouble("exchange_rate_at_payment")
+                val paymentHash = resultSet.getString("payment_hash")
+                val exchangeRate = resultSet.getDouble("exchange_rate_at_payment")
+                val exchangeRateCurrency = resultSet.getString("exchange_rate_currency")
+                val fiatAmount = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble()
+                bitcoinDataByHash[paymentHash] = PaymentBitcoinData(exchangeRate, exchangeRateCurrency, fiatAmount)
             }
         }
-        return result
+        return bitcoinDataByHash
     }
 
     suspend fun addPayment(payment: Payment): String? {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
@@ -21,7 +21,12 @@ class ReportService(
                    op.price_at_order,
                    u.name AS user_name,
                    pm.name AS payment_method,
-                   o.created_at AS sale_date
+                   o.created_at AS sale_date,
+                   pay.satoshi_amount,
+                   pay.exchange_rate_at_payment,
+                   pay.exchange_rate_currency,
+                   pay.fiat_amount_at_payment,
+                   pay.id AS payment_id
             FROM order_products op
             JOIN orders o           ON o.id  = op.order_id
             JOIN products p         ON p.id  = op.product_id
@@ -131,16 +136,28 @@ class ReportService(
                     userName = resultSet.getString("user_name"),
                     paymentMethod = resultSet.getString("payment_method"),
                     saleDate = resultSet.getString("sale_date").replace(" ", "T"),
+                    satoshiAmount = (resultSet.getObject("satoshi_amount") as? Number)?.toLong(),
+                    exchangeRateAtPayment = (resultSet.getObject("exchange_rate_at_payment") as? Number)?.toDouble(),
+                    exchangeRateCurrency = resultSet.getString("exchange_rate_currency"),
+                    fiatAmountAtPayment = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble(),
+                    paymentId = resultSet.getString("payment_id"),
                 ),
             )
         }
 
         logger.info("Product sales report: ${sales.size} line items")
 
+        val totalBtcSatoshis =
+            sales
+                .filter { it.satoshiAmount != null && it.paymentId != null }
+                .distinctBy { it.paymentId }
+                .sumOf { it.satoshiAmount!! }
+
         return ProductSalesReport(
             totalRevenueCents = sales.sumOf { it.priceAtOrder.toLong() * it.quantity },
             totalItemsSold = sales.sumOf { it.quantity },
             sales = sales,
+            totalBtcSatoshis = totalBtcSatoshis,
         )
     }
 }

--- a/server/app/src/main/resources/db/migration/V26__payments_btc_fields.sql
+++ b/server/app/src/main/resources/db/migration/V26__payments_btc_fields.sql
@@ -1,3 +1,5 @@
 ALTER TABLE payments ADD COLUMN satoshi_amount INTEGER;
 ALTER TABLE payments ADD COLUMN exchange_rate_at_payment REAL;
 ALTER TABLE payments ADD COLUMN payment_hash TEXT;
+ALTER TABLE payments ADD COLUMN exchange_rate_currency TEXT;
+ALTER TABLE payments ADD COLUMN fiat_amount_at_payment REAL;

--- a/server/app/src/main/resources/db/migration/V26__payments_btc_fields.sql
+++ b/server/app/src/main/resources/db/migration/V26__payments_btc_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE payments ADD COLUMN satoshi_amount INTEGER;
+ALTER TABLE payments ADD COLUMN exchange_rate_at_payment REAL;
+ALTER TABLE payments ADD COLUMN payment_hash TEXT;

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/OrderServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/OrderServiceTest.kt
@@ -78,6 +78,10 @@ class OrderServiceTest {
             whenever(mockResultSet.getString("created_at")).thenReturn("2025-01-10T10:00:00")
             whenever(mockResultSet.getString("payment_method")).thenReturn("Cash")
             whenever(mockResultSet.getString("payment_method_ids")).thenReturn("payment-1")
+            whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(null)
+            whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(null)
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null)
+            whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null)
 
             val service = OrderService(mockConnection)
             val result = service.getOrdersWithPaymentsFiltered(OrderWithPaymentFilters(status = "paid"))
@@ -1063,6 +1067,77 @@ class OrderServiceTest {
             val service = OrderService(mockConnection) // Arrange
             val result = service.getStoreOrders() // Act
             assertTrue(result.isEmpty()) // Assert
+        }
+    }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered SQL includes MAX aggregates for bitcoin payment fields`() {
+        runBlocking {
+            val sqlCaptor = argumentCaptor<String>()
+            whenever(mockConnection.prepareStatement(sqlCaptor.capture())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(false)
+            val service = OrderService(mockConnection)
+            service.getOrdersWithPaymentsFiltered()
+            val query = sqlCaptor.firstValue
+            assertTrue(query.contains("MAX(p.satoshi_amount)"))
+            assertTrue(query.contains("MAX(p.exchange_rate_at_payment)"))
+            assertTrue(query.contains("MAX(p.exchange_rate_currency)"))
+            assertTrue(query.contains("MAX(p.fiat_amount_at_payment)"))
+        }
+    }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered mapper extracts bitcoin fields when present`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false)
+            whenever(mockResultSet.getString("id")).thenReturn("order-1")
+            whenever(mockResultSet.getString("user_id")).thenReturn("user-1")
+            whenever(mockResultSet.getString("table_id")).thenReturn(null)
+            whenever(mockResultSet.getString("status")).thenReturn("paid")
+            whenever(mockResultSet.getDouble("total")).thenReturn(1.0)
+            whenever(mockResultSet.getString("created_at")).thenReturn("2025-01-10T10:00:00")
+            whenever(mockResultSet.getString("payment_method")).thenReturn("BTC")
+            whenever(mockResultSet.getString("payment_method_ids")).thenReturn("payment-1")
+            whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(100000L)
+            whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(95000.0)
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd")
+            whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(1.0)
+            val service = OrderService(mockConnection)
+            val result = service.getOrdersWithPaymentsFiltered()
+            assertEquals(100000L, result[0].satoshiAmount)
+            assertEquals(95000.0, result[0].exchangeRateAtPayment)
+            assertEquals("usd", result[0].exchangeRateCurrency)
+            assertEquals(1.0, result[0].fiatAmountAtPayment)
+        }
+    }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered mapper returns null bitcoin fields when not present`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false)
+            whenever(mockResultSet.getString("id")).thenReturn("order-1")
+            whenever(mockResultSet.getString("user_id")).thenReturn("user-1")
+            whenever(mockResultSet.getString("table_id")).thenReturn(null)
+            whenever(mockResultSet.getString("status")).thenReturn("paid")
+            whenever(mockResultSet.getDouble("total")).thenReturn(15.0)
+            whenever(mockResultSet.getString("created_at")).thenReturn("2025-01-10T10:00:00")
+            whenever(mockResultSet.getString("payment_method")).thenReturn("Cash")
+            whenever(mockResultSet.getString("payment_method_ids")).thenReturn("payment-1")
+            whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(null)
+            whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(null)
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null)
+            whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null)
+            val service = OrderService(mockConnection)
+            val result = service.getOrdersWithPaymentsFiltered()
+            assertNull(result[0].satoshiAmount)
+            assertNull(result[0].exchangeRateAtPayment)
+            assertNull(result[0].exchangeRateCurrency)
+            assertNull(result[0].fiatAmountAtPayment)
         }
     }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PaymentServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PaymentServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import pos.ambrosia.models.Currency
 import pos.ambrosia.models.Payment
+import pos.ambrosia.models.PaymentBitcoinData
 import pos.ambrosia.models.PaymentMethod
 import pos.ambrosia.services.PaymentService
 import java.sql.Connection
@@ -443,6 +444,67 @@ class PaymentServiceTest {
             val service = PaymentService(mockConnection) // Arrange
             val result = service.deletePayment(paymentId) // Act
             assertTrue(result) // Assert
+        }
+    }
+
+    @Test
+    fun `getExchangeRatesByPaymentHashes returns empty map when hashes list is empty`() {
+        runBlocking {
+            val service = PaymentService(mockConnection) // Arrange
+            val result = service.getExchangeRatesByPaymentHashes(emptyList()) // Act
+            assertTrue(result.isEmpty()) // Assert
+            verify(mockConnection, never()).prepareStatement(any()) // Assert
+        }
+    }
+
+    @Test
+    fun `getExchangeRatesByPaymentHashes returns PaymentBitcoinData with all fields when found`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement) // Arrange
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet) // Arrange
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false) // Arrange
+            whenever(mockResultSet.getString("payment_hash")).thenReturn("hash1") // Arrange
+            whenever(mockResultSet.getDouble("exchange_rate_at_payment")).thenReturn(95000.0) // Arrange
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd") // Arrange
+            whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(1.0) // Arrange
+            val service = PaymentService(mockConnection) // Arrange
+            val result = service.getExchangeRatesByPaymentHashes(listOf("hash1")) // Act
+            assertEquals(1, result.size) // Assert
+            assertEquals(95000.0, result["hash1"]?.exchangeRateAtPayment) // Assert
+            assertEquals("usd", result["hash1"]?.exchangeRateCurrency) // Assert
+            assertEquals(1.0, result["hash1"]?.fiatAmountAtPayment) // Assert
+        }
+    }
+
+    @Test
+    fun `getExchangeRatesByPaymentHashes returns PaymentBitcoinData with null optional fields`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement) // Arrange
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet) // Arrange
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false) // Arrange
+            whenever(mockResultSet.getString("payment_hash")).thenReturn("hash1") // Arrange
+            whenever(mockResultSet.getDouble("exchange_rate_at_payment")).thenReturn(95000.0) // Arrange
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null) // Arrange
+            whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null) // Arrange
+            val service = PaymentService(mockConnection) // Arrange
+            val result = service.getExchangeRatesByPaymentHashes(listOf("hash1")) // Act
+            val btcData = result["hash1"] // Assert
+            assertNotNull(btcData) // Assert
+            assertEquals(95000.0, btcData.exchangeRateAtPayment) // Assert
+            assertNull(btcData.exchangeRateCurrency) // Assert
+            assertNull(btcData.fiatAmountAtPayment) // Assert
+        }
+    }
+
+    @Test
+    fun `getExchangeRatesByPaymentHashes returns empty map when no matches found`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement) // Arrange
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet) // Arrange
+            whenever(mockResultSet.next()).thenReturn(false) // Arrange
+            val service = PaymentService(mockConnection) // Arrange
+            val result = service.getExchangeRatesByPaymentHashes(listOf("hash-unknown")) // Act
+            assertTrue(result.isEmpty()) // Assert
         }
     }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
@@ -48,6 +48,11 @@ class ReportServiceTest {
         whenever(mockResultSet.getString("user_name")).thenReturn(userName)
         whenever(mockResultSet.getString("payment_method")).thenReturn(paymentMethod)
         whenever(mockResultSet.getString("sale_date")).thenReturn(saleDate)
+        whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(null)
+        whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null)
+        whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("payment_id")).thenReturn("payment-default")
     }
 
     @Test
@@ -487,6 +492,11 @@ class ReportServiceTest {
         whenever(mockResultSet.getString("user_name")).thenReturn("alice").thenReturn("alice")
         whenever(mockResultSet.getString("payment_method")).thenReturn("Cash").thenReturn("Cash")
         whenever(mockResultSet.getString("sale_date")).thenReturn("2024-06-01T10:00:00").thenReturn("2024-06-01T10:00:00")
+        whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(null)
+        whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null)
+        whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("payment_id")).thenReturn(null)
 
         val service = ReportService(mockConnection)
         val report =
@@ -516,6 +526,11 @@ class ReportServiceTest {
         whenever(mockResultSet.getString("user_name")).thenReturn("u1")
         whenever(mockResultSet.getString("payment_method")).thenReturn("Cash")
         whenever(mockResultSet.getString("sale_date")).thenReturn("2024-01-01T00:00:00")
+        whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(null)
+        whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn(null)
+        whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(null)
+        whenever(mockResultSet.getString("payment_id")).thenReturn(null)
 
         val service = ReportService(mockConnection)
         val report =
@@ -530,5 +545,70 @@ class ReportServiceTest {
 
         val expected = Int.MAX_VALUE.toLong() * 1_000_000L
         assertEquals(expected, report.totalRevenueCents, "Calculation should use Long to avoid overflow")
+    }
+
+    @Test
+    fun `SQL SELECT includes bitcoin payment columns`() {
+        val sqlCaptor = argumentCaptor<String>()
+        whenever(mockConnection.prepareStatement(sqlCaptor.capture())).thenReturn(mockStatement)
+        whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+        whenever(mockResultSet.next()).thenReturn(false)
+        val service = ReportService(mockConnection)
+        service.getProductSalesReport(null, null, null, null, null, null)
+        val query = sqlCaptor.firstValue
+        assertTrue(query.contains("pay.satoshi_amount"))
+        assertTrue(query.contains("pay.exchange_rate_at_payment"))
+        assertTrue(query.contains("pay.exchange_rate_currency"))
+        assertTrue(query.contains("pay.fiat_amount_at_payment"))
+        assertTrue(query.contains("pay.id AS payment_id"))
+    }
+
+    @Test
+    fun `mapper extracts bitcoin fields when present`() {
+        whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+        whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+        whenever(mockResultSet.next()).thenReturn(true).thenReturn(false)
+        whenever(mockResultSet.getString("order_id")).thenReturn("order-1")
+        whenever(mockResultSet.getString("product_name")).thenReturn("Widget")
+        whenever(mockResultSet.getInt("quantity")).thenReturn(1)
+        whenever(mockResultSet.getInt("price_at_order")).thenReturn(1000)
+        whenever(mockResultSet.getString("user_name")).thenReturn("alice")
+        whenever(mockResultSet.getString("payment_method")).thenReturn("BTC")
+        whenever(mockResultSet.getString("sale_date")).thenReturn("2024-06-01T10:00:00")
+        whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(100000L)
+        whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(95000.0)
+        whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd")
+        whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(1.0)
+        whenever(mockResultSet.getString("payment_id")).thenReturn("payment-btc-1")
+        val service = ReportService(mockConnection)
+        val report = service.getProductSalesReport(null, null, null, null, null, null)
+        assertEquals(100000L, report.sales[0].satoshiAmount)
+        assertEquals(95000.0, report.sales[0].exchangeRateAtPayment)
+        assertEquals("usd", report.sales[0].exchangeRateCurrency)
+        assertEquals(1.0, report.sales[0].fiatAmountAtPayment)
+        assertEquals("payment-btc-1", report.sales[0].paymentId)
+    }
+
+    @Test
+    fun `totalBtcSatoshis deduplicates by paymentId to avoid double counting`() {
+        whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+        whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+        whenever(mockResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false)
+        whenever(mockResultSet.getString("order_id")).thenReturn("order-1").thenReturn("order-1")
+        whenever(mockResultSet.getString("product_name")).thenReturn("Widget A").thenReturn("Widget B")
+        whenever(mockResultSet.getInt("quantity")).thenReturn(1).thenReturn(1)
+        whenever(mockResultSet.getInt("price_at_order")).thenReturn(500).thenReturn(500)
+        whenever(mockResultSet.getString("user_name")).thenReturn("alice").thenReturn("alice")
+        whenever(mockResultSet.getString("payment_method")).thenReturn("BTC").thenReturn("BTC")
+        whenever(mockResultSet.getString("sale_date")).thenReturn("2024-06-01T10:00:00").thenReturn("2024-06-01T10:00:00")
+        whenever(mockResultSet.getObject("satoshi_amount")).thenReturn(100000L)
+        whenever(mockResultSet.getObject("exchange_rate_at_payment")).thenReturn(95000.0)
+        whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd")
+        whenever(mockResultSet.getObject("fiat_amount_at_payment")).thenReturn(1.0)
+        whenever(mockResultSet.getString("payment_id")).thenReturn("payment-shared")
+        val service = ReportService(mockConnection)
+        val report = service.getProductSalesReport(null, null, null, null, null, null)
+        assertEquals(2, report.sales.size)
+        assertEquals(100000L, report.totalBtcSatoshis, "Should count 100000 sats once, not twice")
     }
 }


### PR DESCRIPTION
## Changes:
- Add V26 DB migration persisting `satoshi_amount`, `exchange_rate_at_payment`, `payment_hash`, `exchange_rate_currency`, and `fiat_amount_at_payment` on the payments table; update Kotlin models
- Capture BTC exchange rate and currency at invoice creation time and propagate through checkout flow to server
- Add `useBitcoinPrice` hook and `AmountDisplay` component with animated clock to toggle between historical fiat and current fiat values
- Expose bitcoin payment fields in the Wallet incoming payments endpoint via batch lookup; show `AmountDisplay` in Wallet history tab
- Expose bitcoin payment fields in the Orders query; show `AmountDisplay` in Store Orders detail modal for BTC payments
- Expose bitcoin payment fields in the Sales report query; show `AmountDisplay` in Reports Sales tab and Reports Orders detail modal; calculate `totalBtcSatoshis` in summary without double-counting
- Apply destructuring across Reports Sales and Orders components

**Related issues**:
https://github.com/olympus-btc/ambrosia/issues/525

**Screenshots**:
<img width="644" height="499" alt="Screenshot 2026-06-01 at 4 40 25 p m" src="https://github.com/user-attachments/assets/0208671a-8c9c-4324-be08-de568f237d33" />
<img width="485" height="393" alt="Screenshot 2026-06-01 at 4 42 46 p m" src="https://github.com/user-attachments/assets/53ac9fc1-e1d3-43c6-af8a-da1f2ac25d20" />
<img width="487" height="408" alt="Screenshot 2026-06-01 at 4 43 06 p m" src="https://github.com/user-attachments/assets/ca3ba97c-493d-4e46-8ccf-f3d02f3dc12f" />
<img width="1208" height="244" alt="Screenshot 2026-06-01 at 4 43 37 p m" src="https://github.com/user-attachments/assets/5c69058d-0f45-4fae-847d-860c9b7aa0c6" />
