### PR TITLE
fix(productList): add new masonry layout on product list

### DIFF
--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -18,8 +18,7 @@ const DEFAULT_COLUMN_COUNT = 2;
 function useColumnCount() {
   const [columnCount, setColumnCount] = useState(DEFAULT_COLUMN_COUNT);
   useEffect(() => {
-    const syncColumnCount = () =>
-      setColumnCount(window.innerWidth >= XL_BREAKPOINT_PX ? XL_COLUMN_COUNT : DEFAULT_COLUMN_COUNT);
+    const syncColumnCount = () => setColumnCount(window.innerWidth >= XL_BREAKPOINT_PX ? XL_COLUMN_COUNT : DEFAULT_COLUMN_COUNT);
     syncColumnCount();
     window.addEventListener("resize", syncColumnCount);
     return () => window.removeEventListener("resize", syncColumnCount);

--- a/client/src/components/pages/Store/Cart/ProductList.jsx
+++ b/client/src/components/pages/Store/Cart/ProductList.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Accordion, AccordionItem, Button, Card, CardBody, CardFooter, CardHeader, Chip, Image } from "@heroui/react";
 import { ChevronUp, ImageIcon } from "lucide-react";
@@ -11,12 +11,34 @@ import { ProductDetailsModal } from "@/components/shared/ProductDetailsModal";
 import { ViewButton } from "@/components/shared/ViewButton";
 import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 
+const XL_BREAKPOINT_PX = 1280;
+const XL_COLUMN_COUNT = 3;
+const DEFAULT_COLUMN_COUNT = 2;
+
+function useColumnCount() {
+  const [columnCount, setColumnCount] = useState(DEFAULT_COLUMN_COUNT);
+  useEffect(() => {
+    const syncColumnCount = () =>
+      setColumnCount(window.innerWidth >= XL_BREAKPOINT_PX ? XL_COLUMN_COUNT : DEFAULT_COLUMN_COUNT);
+    syncColumnCount();
+    window.addEventListener("resize", syncColumnCount);
+    return () => window.removeEventListener("resize", syncColumnCount);
+  }, []);
+  return columnCount;
+}
+
 export function ProductList({ products, onAddProduct, categories }) {
   const cardProductTranslation = useTranslations("cart");
   const { formatAmount } = useCurrency();
   const defaultMaxStock = 11;
   const [showProductDetails, setShowProductDetails] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState(null);
+  const columnCount = useColumnCount();
+  const productColumns = useMemo(() => {
+    const columnGroups = Array.from({ length: columnCount }, () => []);
+    products.forEach((product, productIndex) => columnGroups[productIndex % columnCount].push(product));
+    return columnGroups;
+  }, [products, columnCount]);
 
   const getCategoryNames = (categoryIds) => {
     const ids = categoryIds ?? [];
@@ -45,101 +67,98 @@ export function ProductList({ products, onAddProduct, categories }) {
 
   return (
     <>
-      <div className="grid grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4">
-        {products.map((product) => {
-          const status = stockStatus(product);
-          const { id, description, priceCents, name, imageUrl, SKU, categoryIds, quantity } = product;
-          const productImageUrl = storedAssetUrl(imageUrl);
-          return (
-            <Card
-              shadow="none"
-              className="bg-white rounded-lg"
-              key={id}
-            >
-              <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
-                {productImageUrl ? (
-                  <Image
-                    removeWrapper
-                    alt={name}
-                    src={productImageUrl}
-                    className="w-full h-full object-cover rounded-none"
-                  />
-                ) : (
-                  <div data-testid={`product-image-placeholder-${id}`}>
-                    <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
+      <div className="flex gap-3 md:gap-4 w-full">
+        {productColumns.map((productColumn, columnIndex) => (
+          <div key={columnIndex} className="flex flex-col gap-3 md:gap-4 flex-1 min-w-0">
+            {productColumn.map((product) => {
+              const status = stockStatus(product);
+              const { id, description, priceCents, name, imageUrl, SKU, categoryIds, quantity } = product;
+              const productImageUrl = storedAssetUrl(imageUrl);
+              return (
+                <Card shadow="none" className="bg-white rounded-lg w-full" key={id}>
+                  <div className="h-28 md:h-36 bg-gray-100 overflow-hidden flex items-center justify-center">
+                    {productImageUrl ? (
+                      <Image
+                        removeWrapper
+                        alt={name}
+                        src={productImageUrl}
+                        className="w-full h-full object-cover rounded-none"
+                      />
+                    ) : (
+                      <div data-testid={`product-image-placeholder-${id}`}>
+                        <ImageIcon aria-hidden="true" className="h-8 w-8 text-gray-400" />
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-              <CardHeader className="flex flex-col items-start pb-1">
-                <h2 className="text-sm md:text-lg font-medium">{name}</h2>
-                <p className="text-xs">{getCategoryNames(categoryIds)}</p>
-              </CardHeader>
-              <CardBody className="py-1">
-                <h2 className="text-lg md:text-2xl font-bold text-green-800">
-                  {formatAmount(priceCents)}
-                </h2>
-                <p className="hidden md:block text-xs">
-                  SKU: <span className="text-gray-800">{SKU}</span>
-                </p>
-                {description && (
-                  <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
-                    <AccordionItem
-                      key={id}
-                      indicator={<ChevronUp className="text-primary h-4 w-4" />}
-                      classNames={{
-                        trigger: "px-0 rounded-lg",
-                        content: "px-0",
-                        indicator: [
-                          "rotate-0",
-                          "data-[open=true]:rotate-180",
-                          "transition-transform",
-                          "duration-200",
-                        ].join(" "),
-                        title: "text-xs",
-                      }}
-                      aria-label={`${cardProductTranslation("card.showProductDescription")} ${product.name}`}
-                      title={cardProductTranslation("card.showProductDescription")}
-                      className="text-gray-400 text-justify text-xs"
+                  <CardHeader className="flex flex-col items-start pb-1">
+                    <h2 className="text-sm md:text-lg font-medium">{name}</h2>
+                    <p className="text-xs">{getCategoryNames(categoryIds)}</p>
+                  </CardHeader>
+                  <CardBody className="py-1">
+                    <h2 className="text-lg md:text-2xl font-bold text-green-800">
+                      {formatAmount(priceCents)}
+                    </h2>
+                    <p className="hidden md:block text-xs">
+                      SKU: <span className="text-gray-800">{SKU}</span>
+                    </p>
+                    {description && (
+                      <Accordion isCompact className="hidden md:block px-0 m-0 w-full">
+                        <AccordionItem
+                          key={id}
+                          indicator={<ChevronUp className="text-primary h-4 w-4" />}
+                          classNames={{
+                            trigger: "px-0 rounded-lg",
+                            content: "px-0",
+                            indicator: [
+                              "rotate-0",
+                              "data-[open=true]:rotate-180",
+                              "transition-transform",
+                              "duration-200",
+                            ].join(" "),
+                            title: "text-xs",
+                          }}
+                          aria-label={`${cardProductTranslation("card.showProductDescription")} ${product.name}`}
+                          title={cardProductTranslation("card.showProductDescription")}
+                          className="text-gray-400 text-justify text-xs"
+                        >
+                          {description}
+                        </AccordionItem>
+                      </Accordion>
+                    )}
+                  </CardBody>
+                  <CardFooter className="flex flex-col pt-0 items-stretch gap-2 md:gap-5 sm:flex-row sm:items-center sm:justify-between">
+                    <Chip
+                      size="sm"
+                      className={
+                        status === "out"
+                          ? "bg-rose-100 text-rose-800 border border-rose-200 text-xs"
+                          : status === "low"
+                            ? "bg-amber-100 text-amber-800 border border-amber-200 text-xs"
+                            : "bg-green-200 text-xs text-green-800 border border-green-300"
+                      }
                     >
-                      {description}
-                    </AccordionItem>
-                  </Accordion>
-                )}
-              </CardBody>
-              <CardFooter
-                className="flex flex-col pt-0 items-stretch gap-2 md:gap-5 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <Chip
-                  size="sm"
-                  className={
-                    status === "out"
-                      ? "bg-rose-100 text-rose-800 border border-rose-200 text-xs"
-                      : status === "low"
-                        ? "bg-amber-100 text-amber-800 border border-amber-200 text-xs"
-                        : "bg-green-200 text-xs text-green-800 border border-green-300"
-                  }
-                >
-                  {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
-                </Chip>
-                <div className="flex justify-between">
-                  <div className="md:hidden">
-                    <ViewButton onPress={() => handleShowProductDetails(product)} />
-                  </div>
-
-                  <Button
-                    className="w-full ml-3"
-                    color="primary"
-                    size="sm"
-                    isDisabled={quantity === 0}
-                    onPress={() => onAddProduct(product)}
-                  >
-                    {cardProductTranslation("card.add")}
-                  </Button>
-                </div>
-              </CardFooter>
-            </Card>
-          );
-        })}
+                      {normalizeNumber(quantity)} {cardProductTranslation("card.stock")}
+                    </Chip>
+                    <div className="flex justify-between">
+                      <div className="md:hidden">
+                        <ViewButton onPress={() => handleShowProductDetails(product)} />
+                      </div>
+                      <Button
+                        className="w-full ml-3"
+                        color="primary"
+                        size="sm"
+                        isDisabled={quantity === 0}
+                        onPress={() => onAddProduct(product)}
+                      >
+                        {cardProductTranslation("card.add")}
+                      </Button>
+                    </div>
+                  </CardFooter>
+                </Card>
+              );
+            })}
+          </div>
+        ))}
       </div>
       <ProductDetailsModal
         isOpen={showProductDetails}


### PR DESCRIPTION
This pull request refactors the `ProductList` component to make the product grid responsive to the window size using JavaScript rather than relying solely on CSS grid classes. The main improvement is dynamically determining the number of columns based on the current window width, which enhances layout consistency and flexibility across different screen sizes.

**Responsive grid layout improvements:**

* Introduced a `useColumnCount` hook to determine the number of product columns based on the window width, switching between 2 columns by default and 3 columns for extra-large screens (`>=1280px`).
* Used `useMemo` to group products into columns according to the current column count, ensuring products are distributed evenly.
* Replaced the previous CSS grid implementation with a flexbox layout that renders one column per computed group, making the grid structure responsive to window resizing.

**Screenshot**
<img width="1899" height="981" alt="image" src="https://github.com/user-attachments/assets/5fe0a4ac-43f3-46c3-8037-b83516e67e20" />

**Code quality and maintainability:**

* Cleaned up and adjusted component structure for better readability and maintainability, including minor formatting fixes and prop usage. [[1]](diffhunk://#diff-d803cbc0bf31e4eade9bbe49a30845fc86e109b9a04bd9d70acea67209d5dfcdL109-R129) [[2]](diffhunk://#diff-d803cbc0bf31e4eade9bbe49a30845fc86e109b9a04bd9d70acea67209d5dfcdL128) [[3]](diffhunk://#diff-d803cbc0bf31e4eade9bbe49a30845fc86e109b9a04bd9d70acea67209d5dfcdR161-R162)