### PR TITLE
Feature/historical current wallet transactions

### DIFF
--- a/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/HistoryTab.jsx
@@ -82,15 +82,15 @@ export function HistoryTab({ transactions, loading, filter, setFilter, currentRa
                             : walletTranslations("payments.history.received")}
                         </span>
                         <span className="text-xs text-gray-400 shrink-0">
-                          {format.dateTime(new Date(transaction.completedAt), { dateStyle: "short" })}
-                          {" "}
-                          {format.dateTime(new Date(transaction.completedAt), { timeStyle: "short" })}
+                          {transaction.completedAt
+                            ? `${format.dateTime(new Date(transaction.completedAt), { dateStyle: "short" })} ${format.dateTime(new Date(transaction.completedAt), { timeStyle: "short" })}`
+                            : "—"}
                         </span>
                       </div>
                       <div className={`text-lg font-bold ${transaction.type === "outgoing_payment" ? "text-red-700" : "text-deep"}`}>
-                        {transaction.type === "incoming_payment" && transaction.exchangeRateAtPayment ? (
+                        {transaction.exchangeRateAtPayment ? (
                           <AmountDisplay
-                            satoshis={transaction.receivedSat}
+                            satoshis={transaction.type === "outgoing_payment" ? transaction.sent : transaction.receivedSat}
                             exchangeRateAtSale={transaction.exchangeRateAtPayment}
                             exchangeRateCurrency={transaction.exchangeRateCurrency}
                             fiatAmountAtPayment={transaction.fiatAmountAtPayment}

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/PaymentTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/PaymentTab.jsx
@@ -10,7 +10,7 @@ import { getPaymentErrorDescription } from "./utils/paymentErrors";
 import { getBolt11ValidationError } from "./utils/validateBolt11Invoice";
 
 export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
   const {
     decodedInvoice,
     invoiceValidationError,
@@ -23,7 +23,7 @@ export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
     fetchInfo,
     fetchTransactions,
     currentRate,
-    validateInvoice: (invoiceValue) => getBolt11ValidationError(invoiceValue, t),
+    validateInvoice: (invoiceValue) => getBolt11ValidationError(invoiceValue, walletTranslations),
   });
 
   const handleOpenConfirm = async () => {
@@ -31,8 +31,8 @@ export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
 
     if (result?.status === "decode_error") {
       addToast({
-        title: t("payments.send.paymentError"),
-        description: t("payments.send.confirmModal.decodingError"),
+        title: walletTranslations("payments.send.paymentError"),
+        description: walletTranslations("payments.send.confirmModal.decodingError"),
         variant: "solid",
         color: "danger",
       });
@@ -44,8 +44,8 @@ export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
 
     if (result?.status === "success") {
       addToast({
-        title: t("payments.send.paySuccessTitle"),
-        description: t("payments.send.paySuccessDescription"),
+        title: walletTranslations("payments.send.paySuccessTitle"),
+        description: walletTranslations("payments.send.paySuccessDescription"),
         variant: "solid",
         color: "success",
       });
@@ -54,8 +54,8 @@ export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
 
     if (result?.status === "payment_error") {
       addToast({
-        title: t("payments.send.paymentError"),
-        description: getPaymentErrorDescription(t, result.error),
+        title: walletTranslations("payments.send.paymentError"),
+        description: getPaymentErrorDescription(walletTranslations, result.error),
         variant: "solid",
         color: "danger",
       });

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/PaymentTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/PaymentTab.jsx
@@ -9,7 +9,7 @@ import { PaymentForm } from "./PaymentForm";
 import { getPaymentErrorDescription } from "./utils/paymentErrors";
 import { getBolt11ValidationError } from "./utils/validateBolt11Invoice";
 
-export function PaymentTab({ fetchInfo, fetchTransactions }) {
+export function PaymentTab({ fetchInfo, fetchTransactions, currentRate }) {
   const t = useTranslations("wallet");
   const {
     decodedInvoice,
@@ -22,6 +22,7 @@ export function PaymentTab({ fetchInfo, fetchTransactions }) {
   } = useSendPaymentFlow({
     fetchInfo,
     fetchTransactions,
+    currentRate,
     validateInvoice: (invoiceValue) => getBolt11ValidationError(invoiceValue, t),
   });
 

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentConfirmModal.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentConfirmModal.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import BitcoinPriceService from "@/services/bitcoinPriceService";
 import { I18nProvider } from "@i18n/I18nProvider";
 
-import { PaymentConfirmModal } from "..";
+import { PaymentConfirmModal } from "../PaymentConfirmModal";
 
 jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentConfirmModal.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentConfirmModal.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import BitcoinPriceService from "@/services/bitcoinPriceService";
 import { I18nProvider } from "@i18n/I18nProvider";
 
-import { PaymentConfirmModal } from "../Payment";
+import { PaymentConfirmModal } from "..";
 
 jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentTab.test.jsx
@@ -5,7 +5,7 @@ import BitcoinPriceService from "@/services/bitcoinPriceService";
 import * as walletService from "@/services/walletService";
 import { I18nProvider } from "@i18n/I18nProvider";
 
-import { PaymentTab } from "..";
+import { PaymentTab } from "../PaymentTab";
 
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/PaymentTab.test.jsx
@@ -5,7 +5,7 @@ import BitcoinPriceService from "@/services/bitcoinPriceService";
 import * as walletService from "@/services/walletService";
 import { I18nProvider } from "@i18n/I18nProvider";
 
-import { PaymentTab } from "../Payment";
+import { PaymentTab } from "..";
 
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
@@ -211,7 +211,7 @@ describe("SendTab Component", () => {
       fireEvent.click(screen.getByText("payments.send.confirmModal.confirmButton"));
 
       await waitFor(() => {
-        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", null);
+        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", null, expect.any(Object));
       });
     });
 
@@ -349,7 +349,7 @@ describe("SendTab Component", () => {
       fireEvent.click(screen.getByText("payments.send.confirmModal.confirmButton"));
 
       await waitFor(() => {
-        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", 5000);
+        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", 5000, expect.any(Object));
       });
     });
 
@@ -379,7 +379,7 @@ describe("SendTab Component", () => {
       fireEvent.click(screen.getByText("payments.send.confirmModal.confirmButton"));
 
       await waitFor(() => {
-        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", 5000);
+        expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", 5000, expect.any(Object));
       });
     });
   });

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/ZeroAmountPaymentFields.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/__tests__/ZeroAmountPaymentFields.test.jsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { I18nProvider } from "@i18n/I18nProvider";
 
-import { ZeroAmountPaymentFields } from "../Payment/ZeroAmountPaymentFields";
+import { ZeroAmountPaymentFields } from "../ZeroAmountPaymentFields";
 
 jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/hooks/__tests__/useSendPaymentFlow.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/hooks/__tests__/useSendPaymentFlow.test.jsx
@@ -85,7 +85,7 @@ describe("useSendPaymentFlow", () => {
           paymentHash: "hash-123",
         },
       });
-      expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", null);
+      expect(walletService.payInvoiceFromService).toHaveBeenCalledWith("lnbc1000n1pj9h8uqpp5test", null, expect.any(Object));
       expect(fetchInfo).toHaveBeenCalledTimes(1);
       expect(fetchTransactions).toHaveBeenCalledTimes(1);
       expect(result.current.payInvoice).toBe("");

--- a/client/src/components/pages/Store/Wallet/Transactions/Payment/hooks/useSendPaymentFlow.js
+++ b/client/src/components/pages/Store/Wallet/Transactions/Payment/hooks/useSendPaymentFlow.js
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
 import { decodeInvoice, payInvoiceFromService } from "@/services/walletService";
 
 import { getBolt11ValidationError } from "../utils/validateBolt11Invoice";
@@ -9,8 +10,10 @@ import { getBolt11ValidationError } from "../utils/validateBolt11Invoice";
 export function useSendPaymentFlow({
   fetchInfo,
   fetchTransactions,
+  currentRate,
   validateInvoice,
 }) {
+  const { currency } = useCurrency();
   const [payInvoice, setPayInvoice] = useState("");
   const [paymentResult, setPaymentResult] = useState(null);
   const [invoiceValidationError, setInvoiceValidationError] = useState("");
@@ -50,7 +53,10 @@ export function useSendPaymentFlow({
   const confirmPayment = async (customAmountSat) => {
     try {
       setIsLoading(true);
-      const paymentResponse = await payInvoiceFromService(payInvoice, customAmountSat);
+      const paymentResponse = await payInvoiceFromService(payInvoice, customAmountSat, {
+        exchangeRate: currentRate ?? null,
+        exchangeRateCurrency: currentRate != null ? (currency?.acronym?.toLowerCase() ?? null) : null,
+      });
       setPaymentResult(paymentResponse);
       setPayInvoice("");
       setInvoiceValidationError("");

--- a/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
@@ -11,7 +11,7 @@ import { createInvoice } from "@/services/walletService";
 import { AmountUnitInputFields } from "./AmountUnitInputFields";
 import { useWalletAmountInput } from "./hooks/useWalletAmountInput";
 
-export function ReceiveTab({ invoiceActions }) {
+export function ReceiveTab({ invoiceActions, currentRate }) {
   const t = useTranslations("wallet");
   const { currency } = useCurrency();
   const [invoiceDesc, setInvoiceDesc] = useState("");
@@ -44,11 +44,17 @@ export function ReceiveTab({ invoiceActions }) {
     if (amountSat === undefined) {
       return;
     }
+    const fiatAmount = amountSat != null && currentRate != null
+      ? (amountSat / 100_000_000) * currentRate
+      : null;
     try {
       setIsLoading(true);
       const res = await createInvoice({
         amountSat,
         description: invoiceDesc,
+        exchangeRate: currentRate ?? null,
+        exchangeRateCurrency: currentRate != null ? (currency?.acronym?.toLowerCase() ?? null) : null,
+        fiatAmount,
       });
       invoiceActions.createInvoice(res);
       resetAmounts();

--- a/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/ReceiveTab.jsx
@@ -12,7 +12,7 @@ import { AmountUnitInputFields } from "./AmountUnitInputFields";
 import { useWalletAmountInput } from "./hooks/useWalletAmountInput";
 
 export function ReceiveTab({ invoiceActions, currentRate }) {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
   const { currency } = useCurrency();
   const [invoiceDesc, setInvoiceDesc] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -35,8 +35,8 @@ export function ReceiveTab({ invoiceActions, currentRate }) {
     isPaid: false,
     invoiceSats: null,
     currencyAcronym: currency.acronym,
-    invalidAmountMessage: t("payments.receive.invoiceAmountError"),
-    amountTooLargeMessage: t("payments.receive.invoiceAmountTooLargeError"),
+    invalidAmountMessage: walletTranslations("payments.receive.invoiceAmountError"),
+    amountTooLargeMessage: walletTranslations("payments.receive.invoiceAmountTooLargeError"),
   });
 
   const handleCreateInvoice = async () => {
@@ -60,16 +60,16 @@ export function ReceiveTab({ invoiceActions, currentRate }) {
       resetAmounts();
       setInvoiceDesc("");
       addToast({
-        title: t("payments.receive.invoiceSuccessTitle"),
-        description: t("payments.receive.invoiceSuccessDescription"),
+        title: walletTranslations("payments.receive.invoiceSuccessTitle"),
+        description: walletTranslations("payments.receive.invoiceSuccessDescription"),
         variant: "solid",
         color: "success",
       });
     } catch (err) {
       console.error(err);
       addToast({
-        title: t("errorTitle"),
-        description: t("payments.receive.invoiceCreateError"),
+        title: walletTranslations("errorTitle"),
+        description: walletTranslations("payments.receive.invoiceCreateError"),
         variant: "solid",
         color: "danger",
       });
@@ -79,17 +79,17 @@ export function ReceiveTab({ invoiceActions, currentRate }) {
   };
 
   const fieldLabels = {
-    title: t("payments.receive.invoiceAmountTitle"),
-    satLabel: t("payments.receive.invoiceAmountSatLabel"),
-    satsOptionLabel: t("payments.receive.satsOption"),
-    satPlaceholder: t("payments.receive.invoiceAmountSatPlaceholder"),
-    fiatLabel: t("payments.receive.invoiceAmountFiatLabel", { currency: currency.acronym }),
-    fiatOptionLabel: t("payments.receive.fiatOption", { currency: currency.acronym }),
-    fiatPlaceholder: t("payments.receive.invoiceAmountFiatPlaceholder"),
-    estimatedLabel: t("payments.receive.invoiceEstimatedLabel"),
-    loadingText: t("payments.receive.invoiceFiatLoading"),
-    estimatedFiatErrorText: t("payments.receive.invoiceSatsToFiatError"),
-    conversionErrorText: t("payments.receive.invoiceFiatToSatsError"),
+    title: walletTranslations("payments.receive.invoiceAmountTitle"),
+    satLabel: walletTranslations("payments.receive.invoiceAmountSatLabel"),
+    satsOptionLabel: walletTranslations("payments.receive.satsOption"),
+    satPlaceholder: walletTranslations("payments.receive.invoiceAmountSatPlaceholder"),
+    fiatLabel: walletTranslations("payments.receive.invoiceAmountFiatLabel", { currency: currency.acronym }),
+    fiatOptionLabel: walletTranslations("payments.receive.fiatOption", { currency: currency.acronym }),
+    fiatPlaceholder: walletTranslations("payments.receive.invoiceAmountFiatPlaceholder"),
+    estimatedLabel: walletTranslations("payments.receive.invoiceEstimatedLabel"),
+    loadingText: walletTranslations("payments.receive.invoiceFiatLoading"),
+    estimatedFiatErrorText: walletTranslations("payments.receive.invoiceSatsToFiatError"),
+    conversionErrorText: walletTranslations("payments.receive.invoiceFiatToSatsError"),
   };
 
   return (
@@ -106,8 +106,8 @@ export function ReceiveTab({ invoiceActions, currentRate }) {
         </div>
         <div id="wallet-receive-description" className="mx-auto w-full max-w-xl">
           <Input
-            label={t("payments.receive.invoiceDescriptionLabel")}
-            placeholder={t("payments.receive.invoiceDescriptionPlaceholder")}
+            label={walletTranslations("payments.receive.invoiceDescriptionLabel")}
+            placeholder={walletTranslations("payments.receive.invoiceDescriptionPlaceholder")}
             value={invoiceDesc}
             onChange={(e) => setInvoiceDesc(e.target.value)}
             isDisabled={isLoading}
@@ -125,7 +125,7 @@ export function ReceiveTab({ invoiceActions, currentRate }) {
             className="w-full font-medium"
             radius="lg"
           >
-            {isLoading ? t("payments.receive.invoiceLightningLoading") : t("payments.receive.invoiceLightningButton")}
+            {isLoading ? walletTranslations("payments.receive.invoiceLightningLoading") : walletTranslations("payments.receive.invoiceLightningButton")}
           </Button>
         </div>
       </div>

--- a/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/Transactions.jsx
@@ -104,6 +104,7 @@ export function Transactions({
           >
             <ReceiveTab
               invoiceActions={invoiceActions}
+              currentRate={currentRate}
             />
           </Tab>
 
@@ -119,6 +120,7 @@ export function Transactions({
             <PaymentTab
               fetchInfo={fetchInfo}
               fetchTransactions={fetchTransactions}
+              currentRate={currentRate}
             />
           </Tab>
 

--- a/client/src/components/pages/Store/Wallet/Transactions/__tests__/ReceiveTab.test.jsx
+++ b/client/src/components/pages/Store/Wallet/Transactions/__tests__/ReceiveTab.test.jsx
@@ -154,7 +154,7 @@ describe("ReceiveTab Component", () => {
       fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
 
       await waitFor(() => {
-        expect(walletService.createInvoice).toHaveBeenCalledWith({ amountSat: 1000, description: "" });
+        expect(walletService.createInvoice).toHaveBeenCalledWith(expect.objectContaining({ amountSat: 1000, description: "" }));
       });
     });
 
@@ -217,7 +217,7 @@ describe("ReceiveTab Component", () => {
       fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
 
       await waitFor(() => {
-        expect(walletService.createInvoice).toHaveBeenCalledWith({ amountSat: 5000, description: "Test payment" });
+        expect(walletService.createInvoice).toHaveBeenCalledWith(expect.objectContaining({ amountSat: 5000, description: "Test payment" }));
       });
     });
 
@@ -236,7 +236,46 @@ describe("ReceiveTab Component", () => {
       fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
 
       await waitFor(() => {
-        expect(walletService.createInvoice).toHaveBeenCalledWith({ amountSat: 5000, description: "" });
+        expect(walletService.createInvoice).toHaveBeenCalledWith(expect.objectContaining({ amountSat: 5000, description: "" }));
+      });
+    });
+
+    it("sends exchangeRate and fiatAmount when currentRate is provided", async () => {
+      renderReceiveTab({ currentRate: 95000 });
+
+      fireEvent.change(screen.getByLabelText("payments.receive.invoiceAmountSatLabel"), {
+        target: { value: "100000" },
+      });
+
+      fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
+
+      await waitFor(() => {
+        expect(walletService.createInvoice).toHaveBeenCalledWith(
+          expect.objectContaining({
+            amountSat: 100000,
+            exchangeRate: 95000,
+            fiatAmount: (100000 / 100_000_000) * 95000,
+          }),
+        );
+      });
+    });
+
+    it("sends null rate fields when currentRate is not provided", async () => {
+      renderReceiveTab();
+
+      fireEvent.change(screen.getByLabelText("payments.receive.invoiceAmountSatLabel"), {
+        target: { value: "100000" },
+      });
+
+      fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
+
+      await waitFor(() => {
+        expect(walletService.createInvoice).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exchangeRate: null,
+            fiatAmount: null,
+          }),
+        );
       });
     });
 
@@ -344,7 +383,7 @@ describe("ReceiveTab Component", () => {
       fireEvent.click(screen.getByText("payments.receive.invoiceLightningButton"));
 
       await waitFor(() => {
-        expect(walletService.createInvoice).toHaveBeenCalledWith({ amountSat: 1000, description: "" });
+        expect(walletService.createInvoice).toHaveBeenCalledWith(expect.objectContaining({ amountSat: 1000, description: "" }));
       });
     });
 

--- a/client/src/components/shared/AmountDisplay.jsx
+++ b/client/src/components/shared/AmountDisplay.jsx
@@ -124,7 +124,7 @@ export function AmountDisplay({
         )}
       </span>
       {displayCents != null && (
-        <p className="text-xs font-normal text-foreground-400 mt-0.5">
+        <p className="text-xs font-normal text-deep mt-0.5">
           {canToggleRate
             ? (showCurrentFiat ? t("amountAtCurrentRate") : t("amountAtTimeOfPayment"))
             : historicalCents != null

--- a/client/src/components/shared/AmountDisplay.jsx
+++ b/client/src/components/shared/AmountDisplay.jsx
@@ -94,7 +94,7 @@ export function AmountDisplay({
     ? (satoshis / 100_000_000) * currentRate * 100
     : null;
 
-  const displayCents = showCurrentFiat ? currentFiatCents : historicalCents;
+  const displayCents = showCurrentFiat ? currentFiatCents : (historicalCents ?? currentFiatCents);
   const canToggleRate = historicalCents != null && currentFiatCents != null;
 
   const currentCurrencyAcronym = currency?.acronym?.toUpperCase();
@@ -123,9 +123,13 @@ export function AmountDisplay({
           />
         )}
       </span>
-      {canToggleRate && (
+      {displayCents != null && (
         <p className="text-xs font-normal text-foreground-400 mt-0.5">
-          {showCurrentFiat ? t("amountAtCurrentRate") : t("amountAtTimeOfPayment")}
+          {canToggleRate
+            ? (showCurrentFiat ? t("amountAtCurrentRate") : t("amountAtTimeOfPayment"))
+            : historicalCents != null
+              ? t("amountAtTimeOfPayment")
+              : t("amountAtCurrentRate")}
         </p>
       )}
     </div>

--- a/client/src/components/shared/__tests__/AmountDisplay.test.jsx
+++ b/client/src/components/shared/__tests__/AmountDisplay.test.jsx
@@ -96,10 +96,16 @@ describe("AmountDisplay", () => {
     expect(screen.getByText("amountAtCurrentRate")).toBeInTheDocument();
   });
 
-  it("does not show rate label when only one rate is available", () => {
+  it("shows amountAtTimeOfPayment label when only historical rate is available", () => {
     renderComponent({ satoshis: 20000, exchangeRateAtSale: 50000 });
-    expect(screen.queryByText("amountAtTimeOfPayment")).not.toBeInTheDocument();
+    expect(screen.getByText("amountAtTimeOfPayment")).toBeInTheDocument();
     expect(screen.queryByText("amountAtCurrentRate")).not.toBeInTheDocument();
+  });
+
+  it("shows amountAtCurrentRate label when only currentRate is available", () => {
+    renderComponent({ satoshis: 20000, currentRate: 60000 });
+    expect(screen.getByText("amountAtCurrentRate")).toBeInTheDocument();
+    expect(screen.queryByText("amountAtTimeOfPayment")).not.toBeInTheDocument();
   });
 
   it("uses fiatAmountAtPayment directly for historical display when provided", () => {

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -133,7 +133,13 @@ describe("walletService", () => {
       expect(httpClient).toHaveBeenCalledWith("/wallet/createinvoice", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: "Wallet invoice", amountSat: 2000 }),
+        body: JSON.stringify({
+          description: "Wallet invoice",
+          amountSat: 2000,
+          exchangeRate: null,
+          exchangeRateCurrency: null,
+          fiatAmount: null,
+        }),
       });
     });
 

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -64,6 +64,9 @@ export async function createInvoiceForCart(invoiceAmount, invoiceDesc) {
 export async function createInvoice({
   amountSat,
   description,
+  exchangeRate = null,
+  exchangeRateCurrency = null,
+  fiatAmount = null,
 }) {
   const response = await httpClient("/wallet/createinvoice", {
     method: "POST",
@@ -73,18 +76,26 @@ export async function createInvoice({
     body: JSON.stringify({
       description,
       amountSat: Number.parseInt(amountSat, 10),
+      exchangeRate,
+      exchangeRateCurrency,
+      fiatAmount,
     }),
   });
   return await parseJsonResponse(response, null);
 }
 
-export async function payInvoiceFromService(invoice, amountSat) {
+export async function payInvoiceFromService(invoice, amountSat, { exchangeRate = null, exchangeRateCurrency = null } = {}) {
   const response = await httpClient("/wallet/payinvoice", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ invoice: invoice.trim(), ...(amountSat != null ? { amountSat } : {}) }),
+    body: JSON.stringify({
+      invoice: invoice.trim(),
+      ...(amountSat != null ? { amountSat } : {}),
+      exchangeRate,
+      exchangeRateCurrency,
+    }),
   });
   const responseBody = await parseJsonResponse(response, null);
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -18,6 +18,7 @@ import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.models.IncomingPaymentWithRate
 import pos.ambrosia.models.RolePassword
 import pos.ambrosia.models.WalletAuthResponse
+import pos.ambrosia.models.WalletInvoiceRate
 import pos.ambrosia.models.phoenix.CloseChannelRequest
 import pos.ambrosia.models.phoenix.CreateInvoiceRequest
 import pos.ambrosia.models.phoenix.CsvExport
@@ -29,6 +30,7 @@ import pos.ambrosia.services.AuthService
 import pos.ambrosia.services.PaymentService
 import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.TokenService
+import pos.ambrosia.services.WalletRateService
 import pos.ambrosia.utils.Bolt11Decoder
 import pos.ambrosia.utils.InvalidCredentialsException
 import pos.ambrosia.utils.authenticateAdmin
@@ -40,9 +42,10 @@ fun Application.configureWallet() {
     val phoenixService = PhoenixService(environment)
     val authService = AuthService(environment, connection)
     val tokenService = TokenService(environment, connection)
-    val paymentService = PaymentService(connection)
+    val walletRateService = WalletRateService(connection)
+    val paymentService = PaymentService(connection, walletRateService)
 
-    routing { route("/wallet") { wallet(phoenixService, tokenService, authService, paymentService) } }
+    routing { route("/wallet") { wallet(phoenixService, tokenService, authService, paymentService, walletRateService) } }
 }
 
 fun Route.wallet(
@@ -50,6 +53,7 @@ fun Route.wallet(
     tokenService: TokenService,
     authService: AuthService,
     paymentService: PaymentService,
+    walletRateService: WalletRateService,
 ) {
     authenticate("auth-jwt") {
         post("/invoice") {
@@ -94,6 +98,17 @@ fun Route.wallet(
         post("/createinvoice") {
             val request = call.receive<CreateInvoiceRequest>()
             val invoice = phoenixService.createInvoice(request)
+            if (request.exchangeRate != null && request.exchangeRateCurrency != null) {
+                walletRateService.saveInvoiceRate(
+                    WalletInvoiceRate(
+                        paymentHash = invoice.paymentHash,
+                        satoshiAmount = request.amountSat,
+                        exchangeRate = request.exchangeRate,
+                        exchangeRateCurrency = request.exchangeRateCurrency,
+                        fiatAmount = request.fiatAmount,
+                    ),
+                )
+            }
             call.respond(HttpStatusCode.OK, invoice)
         }
         post("/decodeinvoice") {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -16,6 +16,7 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.models.IncomingPaymentWithRate
+import pos.ambrosia.models.OutgoingPaymentWithRate
 import pos.ambrosia.models.RolePassword
 import pos.ambrosia.models.WalletAuthResponse
 import pos.ambrosia.models.WalletInvoiceRate
@@ -129,6 +130,18 @@ fun Route.wallet(
         post("/payinvoice") {
             val request = call.receive<PayInvoiceRequest>()
             val result = phoenixService.payInvoice(request)
+            if (request.exchangeRate != null && request.exchangeRateCurrency != null) {
+                val fiatAmount = (result.recipientAmountSat.toDouble() / 100_000_000) * request.exchangeRate
+                walletRateService.saveInvoiceRate(
+                    WalletInvoiceRate(
+                        paymentHash = result.paymentHash,
+                        satoshiAmount = result.recipientAmountSat,
+                        exchangeRate = request.exchangeRate,
+                        exchangeRateCurrency = request.exchangeRateCurrency,
+                        fiatAmount = fiatAmount,
+                    ),
+                )
+            }
             call.respond(HttpStatusCode.OK, result)
         }
         post("/payoffer") {
@@ -182,9 +195,9 @@ fun Route.wallet(
 
                 val payments = phoenixService.listIncomingPayments(from, to, limit, offset, all, externalId)
                 val hashes = payments.map { it.paymentHash }
-                val posRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
-                val walletRates = walletRateService.getRatesByPaymentHashes(hashes.filter { it !in posRates })
-                val bitcoinPaymentDataByHash = posRates + walletRates
+                val salesPaymentRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val walletInvoiceRates = walletRateService.getRatesByPaymentHashes(hashes.filter { it !in salesPaymentRates })
+                val bitcoinPaymentDataByHash = salesPaymentRates + walletInvoiceRates
                 val enriched =
                     payments.map { payment ->
                         val bitcoinPaymentData = bitcoinPaymentDataByHash[payment.paymentHash]
@@ -228,7 +241,33 @@ fun Route.wallet(
                 val all = call.request.queryParameters["all"]?.toBoolean() ?: false
 
                 val payments = phoenixService.listOutgoingPayments(from, to, limit, offset, all)
-                call.respond(HttpStatusCode.OK, payments)
+                val hashes = payments.mapNotNull { it.paymentHash }
+                val salesPaymentRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val walletInvoiceRates = walletRateService.getRatesByPaymentHashes(hashes.filter { it !in salesPaymentRates })
+                val bitcoinDataByHash = salesPaymentRates + walletInvoiceRates
+                val enriched =
+                    payments.map { payment ->
+                        val bitcoinData = payment.paymentHash?.let { bitcoinDataByHash[it] }
+                        OutgoingPaymentWithRate(
+                            type = payment.type,
+                            subType = payment.subType,
+                            paymentId = payment.paymentId,
+                            paymentHash = payment.paymentHash,
+                            txId = payment.txId,
+                            preimage = payment.preimage,
+                            isPaid = payment.isPaid,
+                            sent = payment.sent,
+                            fees = payment.fees,
+                            invoice = payment.invoice,
+                            description = payment.description,
+                            completedAt = payment.completedAt,
+                            createdAt = payment.createdAt,
+                            exchangeRateAtPayment = bitcoinData?.exchangeRateAtPayment,
+                            exchangeRateCurrency = bitcoinData?.exchangeRateCurrency,
+                            fiatAmountAtPayment = bitcoinData?.fiatAmountAtPayment,
+                        )
+                    }
+                call.respond(HttpStatusCode.OK, enriched)
             }
 
             get("/outgoing/{paymentId}") {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -43,7 +43,7 @@ fun Application.configureWallet() {
     val authService = AuthService(environment, connection)
     val tokenService = TokenService(environment, connection)
     val walletRateService = WalletRateService(connection)
-    val paymentService = PaymentService(connection, walletRateService)
+    val paymentService = PaymentService(connection)
 
     routing { route("/wallet") { wallet(phoenixService, tokenService, authService, paymentService, walletRateService) } }
 }
@@ -182,7 +182,9 @@ fun Route.wallet(
 
                 val payments = phoenixService.listIncomingPayments(from, to, limit, offset, all, externalId)
                 val hashes = payments.map { it.paymentHash }
-                val bitcoinPaymentDataByHash = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val posRates = paymentService.getExchangeRatesByPaymentHashes(hashes)
+                val walletRates = walletRateService.getRatesByPaymentHashes(hashes.filter { it !in posRates })
+                val bitcoinPaymentDataByHash = posRates + walletRates
                 val enriched =
                     payments.map { payment ->
                         val bitcoinPaymentData = bitcoinPaymentDataByHash[payment.paymentHash]

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -491,6 +491,14 @@ data class ProductSalesReport(
     val totalBtcSatoshis: Long = 0L,
 )
 
+data class WalletInvoiceRate(
+    val paymentHash: String,
+    val satoshiAmount: Long?,
+    val exchangeRate: Double,
+    val exchangeRateCurrency: String,
+    val fiatAmount: Double?,
+)
+
 data class PaymentBitcoinData(
     val exchangeRateAtPayment: Double,
     val exchangeRateCurrency: String?,

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -491,6 +491,26 @@ data class ProductSalesReport(
     val totalBtcSatoshis: Long = 0L,
 )
 
+@Serializable
+data class OutgoingPaymentWithRate(
+    val type: String,
+    val subType: String,
+    val paymentId: String,
+    val paymentHash: String? = null,
+    val txId: String? = null,
+    val preimage: String? = null,
+    val isPaid: Boolean,
+    val sent: Long,
+    val fees: Long,
+    val invoice: String? = null,
+    val description: String? = null,
+    val completedAt: Long? = null,
+    val createdAt: Long,
+    val exchangeRateAtPayment: Double? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmountAtPayment: Double? = null,
+)
+
 data class WalletInvoiceRate(
     val paymentHash: String,
     val satoshiAmount: Long?,

--- a/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
@@ -10,6 +10,9 @@ data class CreateInvoiceRequest(
     val amountSat: Long? = null,
     val externalId: String? = null,
     val expirySeconds: Long? = null,
+    val exchangeRate: Double? = null,
+    val exchangeRateCurrency: String? = null,
+    val fiatAmount: Double? = null,
 )
 
 @Serializable

--- a/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
@@ -39,6 +39,8 @@ data class CreateInvoiceResponse(
 @Serializable data class PayInvoiceRequest(
     val amountSat: Long? = null,
     val invoice: String,
+    val exchangeRate: Double? = null,
+    val exchangeRateCurrency: String? = null,
 )
 
 @Serializable

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
@@ -5,10 +5,12 @@ import pos.ambrosia.models.Currency
 import pos.ambrosia.models.Payment
 import pos.ambrosia.models.PaymentBitcoinData
 import pos.ambrosia.models.PaymentMethod
+import pos.ambrosia.models.WalletInvoiceRate
 import java.sql.Connection
 
 class PaymentService(
     private val connection: Connection,
+    private val walletRateService: WalletRateService = WalletRateService(connection),
 ) {
     companion object {
         private const val ADD_PAYMENT =
@@ -138,7 +140,9 @@ class PaymentService(
                 bitcoinDataByHash[paymentHash] = PaymentBitcoinData(exchangeRate, exchangeRateCurrency, fiatAmount)
             }
         }
-        return bitcoinDataByHash
+        val remainingHashes = hashes.filter { it !in bitcoinDataByHash }
+        val walletRates = walletRateService.getRatesByPaymentHashes(remainingHashes)
+        return bitcoinDataByHash + walletRates
     }
 
     suspend fun addPayment(payment: Payment): String? {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PaymentService.kt
@@ -5,12 +5,10 @@ import pos.ambrosia.models.Currency
 import pos.ambrosia.models.Payment
 import pos.ambrosia.models.PaymentBitcoinData
 import pos.ambrosia.models.PaymentMethod
-import pos.ambrosia.models.WalletInvoiceRate
 import java.sql.Connection
 
 class PaymentService(
     private val connection: Connection,
-    private val walletRateService: WalletRateService = WalletRateService(connection),
 ) {
     companion object {
         private const val ADD_PAYMENT =
@@ -140,9 +138,7 @@ class PaymentService(
                 bitcoinDataByHash[paymentHash] = PaymentBitcoinData(exchangeRate, exchangeRateCurrency, fiatAmount)
             }
         }
-        val remainingHashes = hashes.filter { it !in bitcoinDataByHash }
-        val walletRates = walletRateService.getRatesByPaymentHashes(remainingHashes)
-        return bitcoinDataByHash + walletRates
+        return bitcoinDataByHash
     }
 
     suspend fun addPayment(payment: Payment): String? {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/WalletRateService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/WalletRateService.kt
@@ -1,0 +1,65 @@
+package pos.ambrosia.services
+
+import pos.ambrosia.logger
+import pos.ambrosia.models.PaymentBitcoinData
+import pos.ambrosia.models.WalletInvoiceRate
+import java.sql.Connection
+
+class WalletRateService(
+    private val connection: Connection,
+) {
+    companion object {
+        private const val INSERT_WALLET_INVOICE_RATE =
+            """
+            INSERT OR REPLACE INTO wallet_invoice_rates
+                (payment_hash, satoshi_amount, exchange_rate, exchange_rate_currency, fiat_amount)
+            VALUES (?, ?, ?, ?, ?)
+            """
+
+        private const val GET_RATES_BY_PAYMENT_HASHES =
+            """
+            SELECT payment_hash, exchange_rate, exchange_rate_currency, fiat_amount
+            FROM wallet_invoice_rates
+            WHERE payment_hash IN (%s)
+            """
+    }
+
+    suspend fun saveInvoiceRate(rate: WalletInvoiceRate) {
+        connection.prepareStatement(INSERT_WALLET_INVOICE_RATE).use { statement ->
+            statement.setString(1, rate.paymentHash)
+            if (rate.satoshiAmount != null) {
+                statement.setLong(2, rate.satoshiAmount)
+            } else {
+                statement.setNull(2, java.sql.Types.INTEGER)
+            }
+            statement.setDouble(3, rate.exchangeRate)
+            statement.setString(4, rate.exchangeRateCurrency)
+            if (rate.fiatAmount != null) {
+                statement.setDouble(5, rate.fiatAmount)
+            } else {
+                statement.setNull(5, java.sql.Types.REAL)
+            }
+            statement.executeUpdate()
+        }
+        logger.info("Saved wallet invoice rate for paymentHash=${rate.paymentHash}")
+    }
+
+    suspend fun getRatesByPaymentHashes(hashes: List<String>): Map<String, PaymentBitcoinData> {
+        if (hashes.isEmpty()) return emptyMap()
+        val placeholders = hashes.joinToString(",") { "?" }
+        val walletRatesQuery = String.format(GET_RATES_BY_PAYMENT_HASHES, placeholders)
+        val walletRatesByHash = mutableMapOf<String, PaymentBitcoinData>()
+        connection.prepareStatement(walletRatesQuery).use { statement ->
+            hashes.forEachIndexed { index, hash -> statement.setString(index + 1, hash) }
+            val resultSet = statement.executeQuery()
+            while (resultSet.next()) {
+                val paymentHash = resultSet.getString("payment_hash")
+                val exchangeRate = resultSet.getDouble("exchange_rate")
+                val exchangeRateCurrency = resultSet.getString("exchange_rate_currency")
+                val fiatAmount = (resultSet.getObject("fiat_amount") as? Number)?.toDouble()
+                walletRatesByHash[paymentHash] = PaymentBitcoinData(exchangeRate, exchangeRateCurrency, fiatAmount)
+            }
+        }
+        return walletRatesByHash
+    }
+}

--- a/server/app/src/main/resources/db/migration/V27__wallet_invoice_rates.sql
+++ b/server/app/src/main/resources/db/migration/V27__wallet_invoice_rates.sql
@@ -1,0 +1,8 @@
+CREATE TABLE wallet_invoice_rates (
+    payment_hash TEXT PRIMARY KEY,
+    satoshi_amount INTEGER,
+    exchange_rate REAL NOT NULL,
+    exchange_rate_currency TEXT NOT NULL,
+    fiat_amount REAL,
+    created_at DATETIME DEFAULT (datetime('now'))
+);

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/WalletRateServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/WalletRateServiceTest.kt
@@ -1,0 +1,122 @@
+package pos.ambrosia.utest
+
+import kotlinx.coroutines.runBlocking
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import pos.ambrosia.models.WalletInvoiceRate
+import pos.ambrosia.services.WalletRateService
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WalletRateServiceTest {
+    private val mockConnection: Connection = mock()
+    private val mockStatement: PreparedStatement = mock()
+    private val mockResultSet: ResultSet = mock()
+
+    @Test
+    fun `saveInvoiceRate executes insert with all fields`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            val rate =
+                WalletInvoiceRate(
+                    paymentHash = "hash-abc",
+                    satoshiAmount = 100000L,
+                    exchangeRate = 95000.0,
+                    exchangeRateCurrency = "usd",
+                    fiatAmount = 1.0,
+                )
+            val service = WalletRateService(mockConnection)
+            service.saveInvoiceRate(rate)
+            verify(mockStatement).setString(1, "hash-abc")
+            verify(mockStatement).setLong(2, 100000L)
+            verify(mockStatement).setDouble(3, 95000.0)
+            verify(mockStatement).setString(4, "usd")
+            verify(mockStatement).setDouble(5, 1.0)
+            verify(mockStatement).executeUpdate()
+        }
+    }
+
+    @Test
+    fun `saveInvoiceRate sets null for optional fields when absent`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            val rate =
+                WalletInvoiceRate(
+                    paymentHash = "hash-abc",
+                    satoshiAmount = null,
+                    exchangeRate = 95000.0,
+                    exchangeRateCurrency = "usd",
+                    fiatAmount = null,
+                )
+            val service = WalletRateService(mockConnection)
+            service.saveInvoiceRate(rate)
+            verify(mockStatement).setNull(2, java.sql.Types.INTEGER)
+            verify(mockStatement).setNull(5, java.sql.Types.REAL)
+        }
+    }
+
+    @Test
+    fun `getRatesByPaymentHashes returns empty map when hashes list is empty`() {
+        runBlocking {
+            val service = WalletRateService(mockConnection)
+            val result = service.getRatesByPaymentHashes(emptyList())
+            assertTrue(result.isEmpty())
+            verify(mockConnection, never()).prepareStatement(any())
+        }
+    }
+
+    @Test
+    fun `getRatesByPaymentHashes returns PaymentBitcoinData for matching hashes`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false)
+            whenever(mockResultSet.getString("payment_hash")).thenReturn("hash-abc")
+            whenever(mockResultSet.getDouble("exchange_rate")).thenReturn(95000.0)
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd")
+            whenever(mockResultSet.getObject("fiat_amount")).thenReturn(1.0)
+            val service = WalletRateService(mockConnection)
+            val result = service.getRatesByPaymentHashes(listOf("hash-abc"))
+            assertEquals(1, result.size)
+            assertEquals(95000.0, result["hash-abc"]?.exchangeRateAtPayment)
+            assertEquals("usd", result["hash-abc"]?.exchangeRateCurrency)
+            assertEquals(1.0, result["hash-abc"]?.fiatAmountAtPayment)
+        }
+    }
+
+    @Test
+    fun `getRatesByPaymentHashes returns null fiatAmount when not set`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(true).thenReturn(false)
+            whenever(mockResultSet.getString("payment_hash")).thenReturn("hash-abc")
+            whenever(mockResultSet.getDouble("exchange_rate")).thenReturn(95000.0)
+            whenever(mockResultSet.getString("exchange_rate_currency")).thenReturn("usd")
+            whenever(mockResultSet.getObject("fiat_amount")).thenReturn(null)
+            val service = WalletRateService(mockConnection)
+            val result = service.getRatesByPaymentHashes(listOf("hash-abc"))
+            assertNull(result["hash-abc"]?.fiatAmountAtPayment)
+        }
+    }
+
+    @Test
+    fun `getRatesByPaymentHashes returns empty map when no matches found`() {
+        runBlocking {
+            whenever(mockConnection.prepareStatement(any())).thenReturn(mockStatement)
+            whenever(mockStatement.executeQuery()).thenReturn(mockResultSet)
+            whenever(mockResultSet.next()).thenReturn(false)
+            val service = WalletRateService(mockConnection)
+            val result = service.getRatesByPaymentHashes(listOf("hash-unknown"))
+            assertTrue(result.isEmpty())
+        }
+    }
+}


### PR DESCRIPTION
## Changes:
- Add V27 migration creating `wallet_invoice_rates` table and `WalletInvoiceRate` model to store exchange rates for direct Wallet operations independently from POS payments
- Add `WalletRateService` with save and batch lookup; move rate merge logic from `PaymentService` to the `Wallet.kt` handler to keep services independent
- Capture BTC exchange rate when creating invoices from Wallet Receive tab and when confirming payments from Wallet Send tab; persist to `wallet_invoice_rates`
- Enrich `GET /wallet/payments/outgoing` with rate data via batch lookup; show `AmountDisplay` with clock for outgoing payments in Wallet history
- Improve `AmountDisplay` to show current fiat rate when no historical rate is available
- Move Payment component tests to `Payment/__tests__/` and rename `SendTab.test.jsx` to `PaymentTab.test.jsx`

**Screenshots**:

<img width="425" height="342" alt="Screenshot 2026-06-04 at 12 16 27 a m" src="https://github.com/user-attachments/assets/c60ffbe4-a6d8-4ddc-badc-8d7bd260e301" />
<img width="425" height="343" alt="Screenshot 2026-06-04 at 12 16 45 a m" src="https://github.com/user-attachments/assets/a9625ecf-e707-496e-987c-ecea3bfb7ab4" />


**Related Issues**:
https://github.com/olympus-btc/ambrosia/issues/581