### PR TITLE
Fix/reports cleanup

### DIFF
--- a/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
@@ -45,7 +45,7 @@ export function OrdersDetailCard({ orders, formatCurrency, disabled, currentRate
           <h2 className="font-bold text-lg">
             {reportsTranslations("orders.title")}
             <span className="ml-2 text-sm font-normal text-default-400">
-              ({filteredOrders.length} {reportsTranslations("sales.records")})
+              ({filteredOrders.length} {reportsTranslations("orders.records")})
             </span>
           </h2>
           <Button
@@ -56,7 +56,7 @@ export function OrdersDetailCard({ orders, formatCurrency, disabled, currentRate
             isDisabled={!orders.length}
             onPress={exportToCsv}
           >
-            {reportsTranslations("sales.export")}
+            {reportsTranslations("orders.export")}
           </Button>
         </div>
 

--- a/client/src/components/pages/Store/Reports/Orders/__tests__/OrdersDetailCard.test.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/__tests__/OrdersDetailCard.test.jsx
@@ -97,7 +97,7 @@ describe("OrdersDetailCard", () => {
 
   it("shows record count of filtered orders", () => {
     render(<OrdersDetailCard orders={ORDERS} formatCurrency={formatCurrency} />);
-    expect(screen.getByText(/2 sales\.records/)).toBeInTheDocument();
+    expect(screen.getByText(/2 orders\.records/)).toBeInTheDocument();
   });
 
   it("export button is disabled when orders is empty", () => {

--- a/client/src/components/pages/Store/Reports/Reports.jsx
+++ b/client/src/components/pages/Store/Reports/Reports.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useMemo, useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 
 import { Card, CardBody, Tab, Tabs } from "@heroui/react";
 import { AlertCircle, Loader2, Package, ShoppingCart } from "lucide-react";
@@ -26,7 +26,6 @@ export default function Reports() {
   const { filters, handleFilters } = useFiltersState(fetchReport);
   const { formatAmount, loading: currencyLoading, currency } = useCurrency();
   const { currentRate } = useBitcoinPrice({ currencyAcronym: currency?.acronym });
-  const formatCurrency = useCallback((cents) => formatAmount(cents), [formatAmount]);
   const [activeTab, setActiveTab] = useState("orders");
   const [pendingTab, setPendingTab] = useState(null);
   const [isPending, startTransition] = useTransition();
@@ -38,17 +37,17 @@ export default function Reports() {
   const { totalRevenue: productsRevenue, totalItems, productLines, uniqueProducts } = useSummaryData(reportData);
 
   const orderStats = useMemo(() => [
-    { label: reportsTranslations("summary.revenue"), value: formatCurrency(ordersRevenue) },
+    { label: reportsTranslations("summary.revenue"), value: formatAmount(ordersRevenue) },
     { label: reportsTranslations("summary.orderCount"), value: orderCount },
-    { label: reportsTranslations("summary.averageTicket"), value: formatCurrency(averageTicket) },
+    { label: reportsTranslations("summary.averageTicket"), value: formatAmount(averageTicket) },
     { label: reportsTranslations("summary.avgItemsPerOrder"), value: avgItemsPerOrder },
-  ], [reportsTranslations, ordersRevenue, orderCount, averageTicket, avgItemsPerOrder, formatCurrency]);
+  ], [reportsTranslations, ordersRevenue, orderCount, averageTicket, avgItemsPerOrder, formatAmount]);
 
   const totalBtcSatoshis = reportData?.totalBtcSatoshis ?? 0;
 
   const productStats = useMemo(() => {
     const stats = [
-      { label: reportsTranslations("summary.revenue"), value: formatCurrency(productsRevenue) },
+      { label: reportsTranslations("summary.revenue"), value: formatAmount(productsRevenue) },
       { label: reportsTranslations("summary.items"), value: totalItems },
       { label: reportsTranslations("summary.productLines"), value: productLines },
       { label: reportsTranslations("summary.uniqueProducts"), value: uniqueProducts },
@@ -60,7 +59,7 @@ export default function Reports() {
       });
     }
     return stats;
-  }, [reportsTranslations, productsRevenue, totalItems, productLines, uniqueProducts, formatCurrency, totalBtcSatoshis]);
+  }, [reportsTranslations, productsRevenue, totalItems, productLines, uniqueProducts, formatAmount, totalBtcSatoshis]);
 
   if ((reportsLoading || currencyLoading) && !reportData) return <ReportSkeleton />;
 
@@ -134,11 +133,11 @@ export default function Reports() {
             <div className="space-y-6">
               <SummaryCard stats={orderStats} />
               {orders.length > 0 && (
-                <OrdersAnalyticsCard sales={sales} orders={orders} formatCurrency={formatCurrency} />
+                <OrdersAnalyticsCard sales={sales} orders={orders} formatCurrency={formatAmount} />
               )}
               <OrdersDetailCard
                 orders={orders}
-                formatCurrency={formatCurrency}
+                formatCurrency={formatAmount}
                 disabled={currencyLoading}
                 currentRate={currentRate}
               />
@@ -148,11 +147,11 @@ export default function Reports() {
             <div className="space-y-6">
               <SummaryCard stats={productStats} />
               {sales.length > 0 && (
-                <AnalyticsCard sales={sales} formatCurrency={formatCurrency} />
+                <AnalyticsCard sales={sales} formatCurrency={formatAmount} />
               )}
               <SalesDetailCard
                 sales={sales}
-                formatCurrency={formatCurrency}
+                formatCurrency={formatAmount}
                 disabled={currencyLoading}
                 currentRate={currentRate}
               />

--- a/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesList.jsx
@@ -90,15 +90,15 @@ export function SalesList({ sales, formatCurrency, currentRate }) {
   return (
     <section aria-label={reportsTranslations("sales.tableAriaLabel")} className="w-full">
       <div className="md:hidden space-y-3">
-        {sales.map((sale, saleIndex) => (
-          <SalesCard key={saleIndex} sale={sale} formatCurrency={formatCurrency} currentRate={currentRate} />
+        {sales.map((sale) => (
+          <SalesCard key={`${sale.orderId}-${sale.productName}`} sale={sale} formatCurrency={formatCurrency} currentRate={currentRate} />
         ))}
       </div>
       <div className="hidden md:block overflow-x-auto">
         <DataTable
           columns={columns}
           items={sales}
-          getKey={(_, rowIndex) => String(rowIndex)}
+          getKey={(sale) => `${sale.orderId}-${sale.productName}`}
         />
       </div>
     </section>

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersChartData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersChartData.test.js
@@ -111,7 +111,7 @@ describe("useOrdersChartData", () => {
         { orderId: "order-x", date: "2024-01-02T10:00:00", userName: null, paymentMethod: "Cash", total: 1000 },
       ];
       const { result } = renderHook(() => useOrdersChartData(ordersWithNullUser));
-      expect(result.current.topUsersByOrders[0].name).toBe("Unknown");
+      expect(result.current.topUsersByOrders[0].name).toBe("orders.unknownUser");
     });
 
     it("uses 'Unknown' as fallback for empty string userName", () => {
@@ -119,7 +119,7 @@ describe("useOrdersChartData", () => {
         { orderId: "order-y", date: "2024-01-02T10:00:00", userName: "", paymentMethod: "Cash", total: 1000 },
       ];
       const { result } = renderHook(() => useOrdersChartData(ordersWithEmptyUser));
-      expect(result.current.topUsersByOrders[0].name).toBe("Unknown");
+      expect(result.current.topUsersByOrders[0].name).toBe("orders.unknownUser");
     });
 
     it("limits results to 8 users", () => {

--- a/client/src/components/pages/Store/Reports/hooks/useFilters.js
+++ b/client/src/components/pages/Store/Reports/hooks/useFilters.js
@@ -7,8 +7,6 @@ export const defaultFilters = {
   activePeriod: "month",
   startDate: "",
   endDate: "",
-  productName: "",
-  paymentMethod: "",
 };
 
 export function useDateRangeFilters(filters, onFiltersChange) {
@@ -32,7 +30,7 @@ export function useFiltersState(fetchReport) {
   const [filters, setFilters] = useState(defaultFilters);
   const latestFiltersRef = useRef(defaultFilters);
 
-  useEffect(() => { latestFiltersRef.current = filters; });
+  useEffect(() => { latestFiltersRef.current = filters; }, [filters]);
 
   useEffect(() => {
     fetchReport({ period: defaultFilters.activePeriod });

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersChartData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersChartData.js
@@ -1,9 +1,12 @@
 "use client";
 import { useMemo } from "react";
 
+import { useTranslations } from "next-intl";
+
 import { formatDateParts } from "@lib/formatDate";
 
 export function useOrdersChartData(orders) {
+  const reportsTranslations = useTranslations("reports");
   const { ordersPerDay, paymentMethodByOrders, topUsersByOrders } = useMemo(() => {
     const dailyStatsMap = {};
     const paymentMethodMap = {};
@@ -12,7 +15,7 @@ export function useOrdersChartData(orders) {
     for (const order of orders) {
       const dateKey = formatDateParts(order.date).localDay;
       const method = order.paymentMethod;
-      const userName = order.userName || "Unknown";
+      const userName = order.userName || reportsTranslations("orders.unknownUser");
 
       if (!dailyStatsMap[dateKey]) dailyStatsMap[dateKey] = { date: dateKey, orders: 0, revenue: 0 };
       dailyStatsMap[dateKey].orders += 1;
@@ -34,7 +37,7 @@ export function useOrdersChartData(orders) {
         .sort((left, right) => right.orderCount - left.orderCount)
         .slice(0, 8),
     };
-  }, [orders]);
+  }, [orders, reportsTranslations]);
 
   return { ordersPerDay, paymentMethodByOrders, topUsersByOrders };
 }

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersSummaryData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersSummaryData.js
@@ -2,16 +2,12 @@
 import { useMemo } from "react";
 
 export function useOrdersSummaryData(reportData, orders) {
-  const totalRevenue = useMemo(() => reportData?.totalRevenueCents ?? 0, [reportData]);
-  const orderCount = useMemo(() => orders.length, [orders]);
-  const averageTicket = useMemo(
-    () => (orderCount > 0 ? Math.round(totalRevenue / orderCount) : 0),
-    [totalRevenue, orderCount],
-  );
-  const avgItemsPerOrder = useMemo(() => {
+  return useMemo(() => {
+    const totalRevenue = reportData?.totalRevenueCents ?? 0;
+    const orderCount = orders.length;
+    const averageTicket = orderCount > 0 ? Math.round(totalRevenue / orderCount) : 0;
     const totalItems = reportData?.totalItemsSold ?? 0;
-    return orderCount > 0 ? Math.round((totalItems / orderCount) * 10) / 10 : 0;
-  }, [reportData, orderCount]);
-
-  return { totalRevenue, orderCount, averageTicket, avgItemsPerOrder };
+    const avgItemsPerOrder = orderCount > 0 ? Math.round((totalItems / orderCount) * 10) / 10 : 0;
+    return { totalRevenue, orderCount, averageTicket, avgItemsPerOrder };
+  }, [reportData, orders]);
 }

--- a/client/src/components/pages/Store/Reports/hooks/useReports.js
+++ b/client/src/components/pages/Store/Reports/hooks/useReports.js
@@ -1,9 +1,6 @@
 "use client";
 import { useCallback, useState } from "react";
 
-import { addToast } from "@heroui/react";
-import { useTranslations } from "next-intl";
-
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
 function buildReportsQueryString(filters = {}) {
@@ -16,7 +13,6 @@ function buildReportsQueryString(filters = {}) {
 }
 
 export function useReports() {
-  const t = useTranslations("reports");
   const [reportData, setReportData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -38,12 +34,5 @@ export function useReports() {
     }
   }, []);
 
-  const showError = useCallback(
-    (message) => {
-      addToast({ title: t("statuses.errorTitle"), description: message, variant: "solid", color: "danger" });
-    },
-    [t],
-  );
-
-  return { fetchReport, reportData, loading, error, showError };
+  return { fetchReport, reportData, loading, error };
 }

--- a/client/src/components/pages/Store/Reports/hooks/useSalesData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useSalesData.js
@@ -8,7 +8,7 @@ import formatDate from "@lib/formatDate";
 const DEFAULT_ROWS_PER_PAGE = 10;
 
 export function useSalesData(sales, formatCurrency) {
-  const t = useTranslations("reports");
+  const reportsTranslations = useTranslations("reports");
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const [prevSales, setPrevSales] = useState(sales);
@@ -32,8 +32,8 @@ export function useSalesData(sales, formatCurrency) {
   const exportToCsv = useCallback(() => {
     if (!sales.length) return;
     const headers = [
-      t("sales.product"), t("sales.user"), t("sales.quantity"),
-      t("sales.price"), t("sales.total"), t("sales.paymentMethod"), t("sales.date"),
+      reportsTranslations("sales.product"), reportsTranslations("sales.user"), reportsTranslations("sales.quantity"),
+      reportsTranslations("sales.price"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"), reportsTranslations("sales.date"),
     ];
     const rows = sales.map((sale) => [
       sale.productName,
@@ -53,7 +53,7 @@ export function useSalesData(sales, formatCurrency) {
     link.download = `sales-report-${new Date().toISOString().slice(0, 10)}.csv`;
     link.click();
     URL.revokeObjectURL(url);
-  }, [sales, formatCurrency, t]);
+  }, [sales, formatCurrency, reportsTranslations]);
 
   return { paginatedSales, totalPages, page, setPage, rowsPerPage, handleRowsPerPageChange, exportToCsv };
 }

--- a/client/src/components/pages/Store/Reports/hooks/useSummaryData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useSummaryData.js
@@ -2,12 +2,13 @@
 import { useMemo } from "react";
 
 export function useSummaryData(reportData) {
-  const totalRevenue = useMemo(() => reportData?.totalRevenueCents ?? 0, [reportData]);
-  const totalItems = useMemo(() => reportData?.totalItemsSold ?? 0, [reportData]);
-  const productLines = useMemo(() => reportData?.sales?.length ?? 0, [reportData]);
-  const uniqueProducts = useMemo(
-    () => new Set((reportData?.sales ?? []).map((sale) => sale.productName)).size,
-    [reportData],
-  );
-  return { totalRevenue, totalItems, productLines, uniqueProducts };
+  return useMemo(() => {
+    const sales = reportData?.sales ?? [];
+    return {
+      totalRevenue: reportData?.totalRevenueCents ?? 0,
+      totalItems: reportData?.totalItemsSold ?? 0,
+      productLines: sales.length,
+      uniqueProducts: new Set(sales.map((sale) => sale.productName)).size,
+    };
+  }, [reportData]);
 }

--- a/client/src/components/pages/Store/Reports/locales/en.js
+++ b/client/src/components/pages/Store/Reports/locales/en.js
@@ -74,6 +74,9 @@ const reportsEn = {
       subtotal: "Subtotal",
       actions: "Actions",
       view: "Details",
+      records: "records",
+      export: "Export CSV",
+      unknownUser: "Unknown",
     },
     payment: {
       unknown: "Unknown",

--- a/client/src/components/pages/Store/Reports/locales/es.js
+++ b/client/src/components/pages/Store/Reports/locales/es.js
@@ -74,6 +74,9 @@ const reportsEs = {
       subtotal: "Subtotal",
       actions: "Acciones",
       view: "Detalles",
+      records: "registros",
+      export: "Exportar CSV",
+      unknownUser: "Desconocido",
     },
     payment: {
       unknown: "Desconocido",

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
@@ -5,6 +5,7 @@ import pos.ambrosia.models.ProductSaleItem
 import pos.ambrosia.models.ProductSalesReport
 import java.sql.Connection
 import java.sql.PreparedStatement
+import java.sql.ResultSet
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -37,9 +38,24 @@ class ReportService(
             JOIN payment_methods pm ON pm.id = pay.method_id
             WHERE o.status = 'paid'
               AND o.is_deleted = 0
-              AND p.is_deleted = 0
             """
     }
+
+    private fun mapRowToProductSaleItem(resultSet: ResultSet): ProductSaleItem =
+        ProductSaleItem(
+            orderId = resultSet.getString("order_id"),
+            productName = resultSet.getString("product_name"),
+            quantity = resultSet.getInt("quantity"),
+            priceAtOrder = resultSet.getInt("price_at_order"),
+            userName = resultSet.getString("user_name"),
+            paymentMethod = resultSet.getString("payment_method"),
+            saleDate = resultSet.getString("sale_date").replace(" ", "T"),
+            satoshiAmount = (resultSet.getObject("satoshi_amount") as? Number)?.toLong(),
+            exchangeRateAtPayment = (resultSet.getObject("exchange_rate_at_payment") as? Number)?.toDouble(),
+            exchangeRateCurrency = resultSet.getString("exchange_rate_currency"),
+            fiatAmountAtPayment = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble(),
+            paymentId = resultSet.getString("payment_id"),
+        )
 
     private fun bindQueryParameters(
         statement: PreparedStatement,
@@ -121,28 +137,14 @@ class ReportService(
                 append("\nORDER BY o.created_at DESC")
             }
 
-        val preparedStatement = connection.prepareStatement(query)
-        bindQueryParameters(preparedStatement, parameters)
-        val resultSet = preparedStatement.executeQuery()
-
         val sales = mutableListOf<ProductSaleItem>()
-        while (resultSet.next()) {
-            sales.add(
-                ProductSaleItem(
-                    orderId = resultSet.getString("order_id"),
-                    productName = resultSet.getString("product_name"),
-                    quantity = resultSet.getInt("quantity"),
-                    priceAtOrder = resultSet.getInt("price_at_order"),
-                    userName = resultSet.getString("user_name"),
-                    paymentMethod = resultSet.getString("payment_method"),
-                    saleDate = resultSet.getString("sale_date").replace(" ", "T"),
-                    satoshiAmount = (resultSet.getObject("satoshi_amount") as? Number)?.toLong(),
-                    exchangeRateAtPayment = (resultSet.getObject("exchange_rate_at_payment") as? Number)?.toDouble(),
-                    exchangeRateCurrency = resultSet.getString("exchange_rate_currency"),
-                    fiatAmountAtPayment = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble(),
-                    paymentId = resultSet.getString("payment_id"),
-                ),
-            )
+        connection.prepareStatement(query).use { statement ->
+            bindQueryParameters(statement, parameters)
+            statement.executeQuery().use { resultSet ->
+                while (resultSet.next()) {
+                    sales.add(mapRowToProductSaleItem(resultSet))
+                }
+            }
         }
 
         logger.info("Product sales report: ${sales.size} line items")


### PR DESCRIPTION
## Changes:
- Close JDBC resources in `ReportService` with `.use {}` blocks; include sales of soft-deleted products in report query; extract row mapping to `mapRowToProductSaleItem`
- Fix cross-namespace i18n keys in `OrdersDetailCard` (was referencing `sales.*`); add `orders.records`, `orders.export`, and `orders.unknownUser` translation keys; translate hardcoded "Unknown" in chart data
- Remove dead code (`showError`, unused `productName`/`paymentMethod` filter fields); consolidate fragmented `useMemo` calls in `useSummaryData` and `useOrdersSummaryData`; rename `t` to `reportsTranslations`; fix missing `[filters]` dep in `useEffect`
- Remove redundant `formatCurrency` wrapper in `Reports.jsx`; replace array index keys with stable `orderId + productName` keys in `SalesList`