### PR TITLE
chore(bugs) Fix null input values in EditProductsModal and skip unconfigured printer templates

### DIFF
--- a/client/src/components/pages/Store/Products/EditProductsModal.jsx
+++ b/client/src/components/pages/Store/Products/EditProductsModal.jsx
@@ -82,7 +82,7 @@ export function EditProductsModal({
             <Textarea
               label={t("modal.productDescriptionLabel")}
               placeholder={t("modal.productDescriptionPlaceholder")}
-              value={data.productDescription}
+              value={data.productDescription ?? ""}
               onChange={(e) => onChange({ productDescription: e.target.value })
               }
             />
@@ -98,7 +98,7 @@ export function EditProductsModal({
             <Input
               label={t("modal.productSKULabel")}
               placeholder={t("modal.productSKUPlaceholder")}
-              value={data.productSKU}
+              value={data.productSKU ?? ""}
               onChange={(e) => onChange({ productSKU: e.target.value })
               }
             />

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
@@ -89,8 +89,9 @@ class PrintService(
                     } else {
                         configItem.templateName ?: request.templateName
                     }
-                val effectiveTemplateName = resolvedTemplateName
-                    ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+                val effectiveTemplateName =
+                    resolvedTemplateName
+                        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
                 if (effectiveTemplateName == null) {
                     logger.warn("No template configured for printer ${configItem.printerName}, skipping.")
                     successCount++

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt
@@ -89,13 +89,17 @@ class PrintService(
                     } else {
                         configItem.templateName ?: request.templateName
                     }
-                if (resolvedTemplateName.isNullOrBlank()) {
-                    throw IOException("Template not configured for printer ${configItem.printerName}.")
+                val effectiveTemplateName = resolvedTemplateName
+                    ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+                if (effectiveTemplateName == null) {
+                    logger.warn("No template configured for printer ${configItem.printerName}, skipping.")
+                    successCount++
+                    return@forEach
                 }
                 val template =
-                    templateCache.getOrPut(resolvedTemplateName) {
-                        ticketTemplateService.getTemplateByName(resolvedTemplateName)
-                            ?: throw IOException("Template '$resolvedTemplateName' not found.")
+                    templateCache.getOrPut(effectiveTemplateName) {
+                        ticketTemplateService.getTemplateByName(effectiveTemplateName)
+                            ?: throw IOException("Template '$effectiveTemplateName' not found.")
                     }
 
                 val printerOutputStream = PrinterOutputStream(printerService)


### PR DESCRIPTION
## Summary

- Fix React controlled-input warning caused by `null` values on SKU and description fields in the product edit modal.
- Prevent a server crash during auto-print after a Lightning payment when a printer has no template configured.

## Changes

### `client/src/components/pages/Store/Products/EditProductsModal.jsx`

**Problem:** `data.productSKU` and `data.productDescription` can be `null` when the server returns a product with no SKU or description. Passing `null` as the `value` prop of a controlled React `<input>` triggers the warning:
> `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.

**Fix:** Apply a nullish coalescing fallback (`?? ""`) on both fields so the components always receive a string.

```jsx
// productDescription (line 85)
value={data.productDescription ?? ""}

// productSKU (line 101)
value={data.productSKU ?? ""}
```

---

### `server/app/src/main/kotlin/pos/ambrosia/services/PrintService.kt`

**Problem:** HeroUI's `<Select>` emits the item `key` (not `value`) in `onChange`, so selecting "No template" stores the literal string `"none"` in the database as `templateName`. When a Phoenix payment webhook triggers an auto-print, `PrintService` looks up a template named `"none"`, finds nothing, and throws `IOException: Template 'none' not found.` — failing the print step even though the payment completed successfully.

**Fix:** Normalize the resolved template name before the DB lookup. If it is `null`, blank, or `"none"` (case-insensitive), log a warning, increment `successCount` (so the "no printers succeeded" guard does not misfire), and skip the printer silently. Real template names that simply don't exist in the DB still throw as before.

```kotlin
val effectiveTemplateName = resolvedTemplateName
    ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
if (effectiveTemplateName == null) {
    logger.warn("No template configured for printer ${configItem.printerName}, skipping.")
    successCount++
    return@forEach
}
```

## Test plan

- [ ] Open the Store → Products edit modal for a product with no SKU and no description — confirm no console warnings.
- [ ] Complete a Lightning payment with a printer configured but no template assigned — confirm the server logs `skipping` instead of throwing `IOException`.
- [ ] Complete a Lightning payment with a valid template assigned — confirm the ticket prints correctly.
- [ ] Run client tests: `cd client && npm test`
- [ ] Run server tests: `cd server && ./gradlew test`
