### PR TITLE
Chore/readme docs

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,240 @@
+# Ambrosia Client
+
+Next.js frontend for Ambrosia — a self-sovereign, local-first Bitcoin Point-of-Sale system. It renders the POS interface, proxies all API requests to the Kotlin/Ktor backend, and handles authentication, i18n, and real-time payment notifications.
+
+This document is a map for contributors: how the app boots, how a request flows through it, and where each concern lives.
+
+## Commands
+
+```bash
+npm run dev              # development server (localhost:3000)
+npm run dev:electron     # development mode for Electron
+npm run build            # production build
+npm run build:electron   # build for Electron packaging
+npm run lint             # ESLint check
+npm run lint:fix         # auto-fix lint issues
+npm test                 # run all Jest tests
+npm run test:coverage    # tests with coverage report
+```
+
+## Tech stack
+
+- **Next.js 16** with App Router (not Pages Router)
+- **React 19** with hooks
+- **HeroUI** component library built on top of Tailwind CSS
+- **Tailwind CSS** for styling
+- **Framer Motion** for animations
+- **next-intl** for i18n (Spanish default, English available)
+- **Jest + React Testing Library** for tests
+
+## Startup flow
+
+1. **`src/proxy.js`** — Next.js middleware that runs on every non-API, non-static request. It:
+   - calls `/api/initial-setup` to determine whether the app is initialized and whether a `businessType` is configured
+   - redirects to `/onboarding` if not initialized or if `businessType` is missing
+   - redirects to `/auth` if there is no `refreshToken` cookie
+   - sets an `x-business-type` response header and a `businessType` cookie used by downstream layout and navigation logic
+
+2. **`src/app/layout.jsx`** — the root layout. It mounts the full provider tree (see [Provider hierarchy](#provider-hierarchy)), loads the root font, and renders the top-level shell.
+
+3. **`src/app/(protected)/store/layout.jsx`** — wraps every store route inside `RequireOpenTurn`, which enforces that a shift is open before the POS can be used.
+
+Everything the client can render is reachable by following route files under `src/app/` — that is the index of pages.
+
+## Request flow
+
+A typical API call travels through four layers:
+
+```text
+Component / hook
+   │
+   ▼
+lib/http/httpClient.js     — auto token refresh on 401, auth event dispatching
+   │
+   ▼
+lib/http/httpWrapper.js    — builds fetch call with base URL, headers, timeout
+   │
+   ▼
+app/api/[...slug]/route.js — Next.js API proxy: forwards request to Kotlin backend,
+                             forwards Set-Cookie headers back to the browser
+   │
+   ▼
+Kotlin/Ktor backend        — REST API on port 9154 / 9443
+```
+
+### Key layers
+
+- **`lib/http/httpClient.js`** — the single entry point for all API calls. Handles automatic token refresh: on a 401 it calls `POST /auth/refresh` (deduplicated with a shared promise), retries the original request, and dispatches `auth:expired` or `wallet:unauthorized` window events if refresh fails.
+- **`lib/http/httpWrapper.js`** — builds the raw `fetch` call with the correct base URL, JSON headers, and a 30-second timeout.
+- **`app/api/[...slug]/route.js`** — the proxy. Strips `content-length` (which breaks streaming), forwards the Kotlin backend's `Set-Cookie` headers to the browser (HTTP-only cookies cannot be set by client JS), and handles `204 No Content` responses.
+- **`services/`** — one file per feature (`authService.js`, `walletService.js`, `shiftsService.js`, `ticketsService.js`, …). Services call `httpClient` and convert raw responses to typed data. Components and hooks import from services, never from `httpClient` directly.
+
+### API client usage
+
+```js
+import { httpClient } from "@/lib/http";
+
+const data = await httpClient("/users", { method: "GET" });
+const result = await httpClient("/orders", { method: "POST", body: { ... } });
+```
+
+Options: `silentAuth` (suppress error toasts on 401), `skipRefresh` (skip token refresh), `notShowError` (suppress all error toasts).
+
+### Component structure
+
+Each feature component lives in its own folder. As it grows, it splits into subcomponent folders. Every subcomponent folder follows the same layout:
+
+```text
+YourFeature/
+├── YourFeature.jsx         # root component exported by this feature
+├── __tests__/              # tests for components at this level
+├── locales/                # translation files for this level (en.js, es.js)
+├── hooks/                  # optional — hooks scoped to this component tree
+├── SubComponentA/
+│   ├── SubComponentA.jsx
+│   ├── __tests__/
+│   ├── locales/
+│   └── hooks/              # optional
+└── SubComponentB/
+    ├── SubComponentB.jsx
+    ├── __tests__/
+    └── locales/
+```
+
+Tests and locales are always colocated at the same level as the component they belong to. The `hooks/` folder is added only when the component or its children need hooks that are not shared outside that subtree.
+
+### Adding a new feature
+
+1. Add a service in `services/YourFeatureService.js` with functions that call `httpClient`.
+2. Add a hook in `hooks/` if components need reactive state derived from the service.
+3. Add the page component following the [component structure](#component-structure) above under `components/pages/Store/YourFeature/`.
+4. Add the route file in `app/(protected)/store/your-feature/page.jsx` that renders the component.
+5. Register the route in `lib/features.js` so it appears in navigation for the right `businessType`.
+6. Add locale files colocated at `components/pages/Store/YourFeature/locales/` (see [Internationalization](#internationalization)).
+
+## Authentication flow
+
+1. PIN login at `/auth` — calls `POST /auth/login` through the proxy.
+2. Backend sets three HTTP-only cookies: `accessToken` (60 s), `refreshToken` (30 days), `walletAccessToken` (8 h).
+3. `httpClient` auto-refreshes `accessToken` on 401 via `POST /auth/refresh` — components never handle this manually.
+4. Wallet operations require `walletAccessToken`, minted at `POST /wallet/auth` after a password challenge.
+5. Auth state is held in `AuthProvider` and updated via window events — listen with `window.addEventListener("auth:expired", handler)`.
+
+## Provider hierarchy
+
+```jsx
+AuthProvider               // user authentication state and session
+  → ConfigurationsProvider // business config and logo
+    → TurnProvider         // open/close shift management
+      → I18nProvider       // next-intl, merges all page locale files flat
+        → HeroUIProvider   // component library theming
+```
+
+Providers are mounted in `src/app/layout.jsx`. Each provider is colocated with its context and hook under `src/providers/`.
+
+## Internationalization
+
+Wrap user-facing strings with `t()` from `useTranslations`:
+
+```jsx
+import { useTranslations } from "next-intl";
+
+function Component() {
+  const t = useTranslations("namespace");
+  return <span>{t("key")}</span>;
+}
+```
+
+Locale files are colocated with their component in a `locales/` subfolder. `I18nProvider.jsx` imports only the top-level page locales and merges them flat — no changes are needed to `I18nProvider` when adding sub-locales.
+
+```text
+components/locales/           # shared (shifts, tours, loadingCard, offlinePage…)
+pages/Store/locales/          # Store-level (navbar, dashboard) — imports sub-locales
+  ├── Cart/locales/
+  ├── Orders/locales/
+  ├── Products/locales/
+  ├── Reports/locales/
+  ├── Settings/locales/       # imports sub-locales: Lightning, Printers, Seed, StoreInfo…
+  ├── Users/locales/          # imports Roles/locales/
+  └── Wallet/locales/         # imports CloseChannel, NodeInfo, Transactions
+```
+
+## Directory layout
+
+```text
+client/
+├── src/
+│   ├── proxy.js                    # Next.js middleware: auth guard, onboarding redirect, businessType routing
+│   ├── app/                        # Next.js App Router
+│   │   ├── (protected)/store/      # Auth-required POS routes (cart, orders, products, reports, settings, users, wallet)
+│   │   ├── (public)/auth/          # PIN login page
+│   │   ├── [section]/[...slug]/    # Catch-all — returns 404 for unknown paths
+│   │   ├── api/[...slug]/          # API proxy — forwards requests to the Kotlin backend
+│   │   ├── api/auth/               # Token refresh route
+│   │   ├── api/ws-payments/        # SSE bridge for payment WebSocket notifications
+│   │   ├── uploads/[...path]/      # File upload proxy route
+│   │   ├── onboarding/             # Setup wizard
+│   │   ├── unauthorized/           # Unauthorized page
+│   │   ├── offline/                # PWA offline fallback (static)
+│   │   ├── not-found.jsx           # Custom 404
+│   │   └── layout.jsx / page.jsx   # Root layout (provider tree) and root redirect
+│   ├── services/                   # One file per feature — calls httpClient, returns typed data
+│   ├── hooks/                      # Shared React hooks (auth, turn/shift, tour, payments, PWA…)
+│   ├── components/
+│   │   ├── shared/                 # Reusable UI: AmountDisplay, DataTable, PageHeader,
+│   │   │                           #   ImageUploader, CopyButton, DeleteButton, EditButton, ViewButton
+│   │   ├── turn/                   # CloseTurnModal, OpenTurnForm, RequireOpenTurn, ShiftWidget
+│   │   ├── auth/                   # WalletGuard
+│   │   ├── hooks/                  # Component-scoped hooks: useBitcoinPrice, useCurrency, useUpload
+│   │   ├── locales/                # Shared translation files
+│   │   └── pages/                  # Page-level components (Auth, Onboarding, Store, NotFound, Unauthorized)
+│   ├── lib/
+│   │   ├── http/                   # httpClient, httpWrapper, parseJsonResponse
+│   │   ├── auth/                   # authEvents, authLocalState, authSession
+│   │   ├── features.js             # Feature/nav definitions by businessType
+│   │   ├── getHomeRoute.js         # Resolves home route based on user role + businessType
+│   │   └── utils.jsx               # Shared utilities
+│   ├── providers/
+│   │   ├── auth/                   # AuthProvider — user authentication state
+│   │   ├── turn/                   # TurnProvider — shift/session management
+│   │   └── configurations/         # ConfigurationsProvider — business config and logo
+│   ├── reducers/auth/              # authReducer
+│   ├── i18n/                       # I18nProvider — merges all page locales flat
+│   ├── config/api.js               # API base URL config
+│   └── utils/                      # array.js, storedAssetUrl.js
+├── public/                         # Static assets (icons, manifest, offline page)
+├── next.config.mjs                 # Next.js config: security headers, image domains, build settings
+├── tailwind.config.js              # Tailwind config with HeroUI theme
+└── Dockerfile                      # Multi-stage build → static export served by Nginx
+```
+
+## Testing
+
+Test files are colocated in `__tests__/` directories next to the code they test.
+
+```bash
+npm test                                  # run all tests
+npm test -- --watch                      # watch mode
+npm test -- path/to/file.test.jsx        # single file
+npm run test:coverage                     # coverage report
+```
+
+- Global mocks: `__tests__/__mocks__/` — next-intl, Next.js Image, framer-motion, SVGs, fetch
+- Setup: `jest.setup.js` (jest-dom matchers), `__tests__/__mocks__/globals.js`
+- Environment: jsdom
+
+## Environment variables
+
+Generated by `generate-env.cjs` from `~/.Ambrosia-POS/ambrosia.conf` or Docker environment:
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_API_URL` | Backend base URL (used in Docker mode) |
+| `NEXT_PUBLIC_WS_URL` | WebSocket URL for payment notifications |
+| `NEXT_PUBLIC_ELECTRON` | Set to `true` in Electron mode |
+
+## Where to go next
+
+- [`../server/README.md`](../server/README.md) — Kotlin/Ktor backend architecture
+- [`../electron/README.md`](../electron/README.md) — Electron desktop app
+- [Project root README](../README.md) — installation guide and contribution guidelines

--- a/electron/README.md
+++ b/electron/README.md
@@ -1,571 +1,167 @@
-# Ambrosia POS - Electron Desktop Application
+# Ambrosia Electron
 
-Complete and standalone desktop application for Ambrosia POS built with Electron.
+Electron desktop app for Ambrosia — a self-sovereign, local-first Bitcoin Point-of-Sale system. It bundles the entire stack (phoenixd daemon, Kotlin/Ktor backend, Next.js frontend) into a single installable application and manages the lifecycle of all three services.
 
-## Architecture
+This document is a map for contributors: how the app boots, how services are orchestrated, and where each concern lives.
 
-Ambrosia POS Electron is a **complete standalone application** that integrates the entire stack:
+## Commands
 
+```bash
+npm run dev              # start in development mode (only Next.js on :3000)
+npm run dev:inspect      # development mode with Node.js inspector on port 5858
+npm run lint             # ESLint check
+npm run lint:fix         # auto-fix lint issues
+npm run build            # full production build (prepare resources + electron-builder)
+npm run clean            # clean dist/ and resources/
+
+npm run dist:mac:arm64   # macOS Apple Silicon (.dmg, .zip)
+npm run dist:mac:x64     # macOS Intel
+npm run dist:win:x64     # Windows x64 (.exe NSIS)
+npm run dist:win:arm64   # Windows ARM64
+npm run dist:linux:x64   # Linux x64 (.deb, .rpm, .tar.gz)
+npm run dist:linux:arm64 # Linux ARM64
 ```
-Electron Main Process
-├── ServiceManager (orchestrator)
-│   ├── PhoenixdService → phoenixd daemon (Bitcoin/Lightning)
-│   ├── BackendService  → Kotlin/Ktor API server
-│   └── NextJsService   → Next.js web server
-├── ConfigurationBootstrap (auto-config with BIP39)
-├── Port Allocator (dynamic port assignment)
-├── Health Checks (wait-on with retries)
-└── BrowserWindow → http://localhost:[DYNAMIC_PORT]
 
-Renderer Process
-├── Next.js App Router (React 19)
-├── API calls → Internal Backend (127.0.0.1:[BACKEND_PORT])
-└── Complete POS interface
-```
+**Pre-build requirement**: the client must be built before any `dist:*` command — `cd ../client && npm run build:electron`.
 
-### Two Operation Modes
+## Tech stack
 
-**Development** (`NODE_ENV=development` or `!app.isPackaged`):
-- Only starts **Next.js** on port 3000
-- Assumes external phoenixd (9740) and backend (9154)
-- DevTools automatically enabled
-- Ideal for frontend development
+- **Electron** (main process: CommonJS/Node.js, renderer: Chromium)
+- **electron-builder** for cross-platform packaging and installers
+- **electron-updater** for auto-updates
+- **cross-spawn** + **tree-kill** for child process management
+- **wait-on** for service health checks
+
+## Two operation modes
+
+**Development** (`!app.isPackaged`):
+
+- Starts only Next.js on port 3000.
+- Assumes an external backend on `:9154` and external phoenixd on `:9740`.
+- DevTools open automatically.
+- Uses the system `java` command — if the installed JDK is not Temurin 21, the backend will crash silently. Production builds are unaffected because they use the bundled JRE.
 
 **Production** (packaged app):
-- Starts sequentially: **Phoenixd → Backend → Next.js**
-- Dynamic ports (avoids conflicts)
-- Completely standalone application
-- No external services required
 
-## Prerequisites
+- Starts services sequentially: **phoenixd → backend → Next.js**.
+- Ports are allocated dynamically to avoid conflicts.
+- Fully self-contained — no external services required.
 
-- **Node.js 18+** and npm
-- **Java Runtime** (included in production bundle)
-- For development only: Backend running externally on 9154
+## Startup flow
 
-## Installing Dependencies
+1. **`main.js`** — the Electron entry point. It:
+   - acquires a single-instance lock; if the lock fails it quits and focuses the existing window
+   - shows a splash screen that tracks startup progress
+   - calls `ServiceManager.startAll()`, which emits `service:started` events at 33 % → 66 % → 100 % progress
+   - creates a `BrowserWindow` pointing to the Next.js URL once `all:started` fires
+   - on quit, calls `ServiceManager.stopAll()` (SIGTERM with a SIGKILL fallback via `tree-kill`)
 
-```bash
-# From the electron/ folder
-npm install
+2. **`services/ConfigurationBootstrap.js`** — on first run, generates `~/.Ambrosia-POS/ambrosia.conf` and `~/.phoenix/phoenix.conf` with `crypto.randomBytes(32)` secrets, a BIP39 12-word mnemonic as the backend secret, and phoenixd credentials.
 
-# Install client dependencies
-cd ../client
-npm install
-cd ../electron
+3. **`services/ServiceManager.js`** — resolves dynamic ports via `portAllocator`, starts each service in order, and emits lifecycle events consumed by the splash screen and the main window.
+
+Everything the app can do is reachable from the `ServiceManager` startup sequence and the IPC handlers registered in `main.js`.
+
+## Service layer
+
+Each service in `services/` implements a common interface:
+
+| Method | Description |
+| --- | --- |
+| `start(port, config)` | Spawns the child process and begins health checks |
+| `stop()` | Sends SIGTERM; falls back to SIGKILL after timeout |
+| `getStatus()` | Returns `starting` \| `running` \| `stopped` \| `error` |
+| `getPort()` | Returns the assigned port |
+
+| File | Role |
+| --- | --- |
+| `ServiceManager.js` | Orchestrates startup/shutdown order and emits lifecycle events |
+| `PhoenixdService.js` | Spawns the platform-specific phoenixd binary |
+| `BackendService.js` | Spawns `java -jar ambrosia.jar` using the bundled JRE |
+| `NextJsService.js` | Spawns the Next.js standalone server |
+| `ConfigurationBootstrap.js` | First-run config generation |
+| `AutoUpdater.js` | Auto-update checks and installation via electron-updater |
+
+stdout/stderr from each service is routed to daily log files under `~/.Ambrosia-POS/logs/`.
+
+## IPC bridge
+
+`preload.js` exposes a whitelist of IPC channels to the renderer. Components call `window.electron.invoke()`:
+
+```js
+window.electron.invoke('services:get-statuses')
+window.electron.invoke('services:restart', 'backend')
+window.electron.invoke('services:get-logs')
 ```
 
-## Development
+Any channel not on the whitelist is silently dropped. Arguments are sanitized by `sanitizeArg()` in `preload.js` before reaching the main process.
 
-### Development Prerequisites
+## Build pipeline
 
-Before running Electron in development mode, make sure you have:
+`npm run build` runs `scripts/prepare-resources-wrapper.js` before electron-builder. The wrapper calls:
 
-1. **Backend running**:
-   ```bash
-   cd server && ./gradlew run
-   ```
+| Script | What it does |
+| --- | --- |
+| `download-phoenixd.js` | Downloads the platform-specific phoenixd binary |
+| `download-jre.js` | Downloads a JRE for the target platform |
+| `download-node.js` | Downloads Node.js for the Next.js standalone server |
+| `build-backend.js` | Builds the Kotlin JAR (detects the version dynamically) |
+| `build-client.js` | Copies the Next.js standalone build from `client/.next/standalone` |
 
-2. **Phoenixd running** (optional, only if you need payments):
-   ```bash
-   # See phoenixd documentation
-   ```
+All resources land in `electron/resources/` and are bundled via electron-builder's `extraResources` key in `package.json`.
 
-### Using the Development Script
+## Directory layout
 
-**macOS/Linux:**
-```bash
-./scripts/dev.sh
-```
-
-**Windows:**
-```bash
-scripts\dev.bat
-```
-
-### Using npm directly
-
-```bash
-npm run dev
-```
-
-### Using Make (from project root)
-
-```bash
-make electron-dev
-```
-
-### What happens when running in development mode?
-
-1. **ServiceManager detects development mode**
-2. **Only starts Next.js** on port 3000
-3. Assumes external backend at `http://localhost:9154`
-4. Assumes external phoenixd at `http://localhost:9740`
-5. Creates BrowserWindow and loads `http://localhost:3000`
-6. Automatically enables DevTools
-7. Next.js hot reload working
-
-## Production Build
-
-### Complete Build
-
-```bash
-# Using the script
-./scripts/build.sh
-
-# Or using npm
-npm run build
-
-# Or using Make
-make electron-build
-```
-
-### Build by Platform
-
-```bash
-# macOS
-npm run dist:mac:arm64           # ARM64 (Apple Silicon)
-npm run dist:mac:x64             # Intel
-make electron-build-mac
-
-# Windows
-npm run dist:win:x64             # x64
-npm run dist:win:arm64           # ARM64
-make electron-build-win
-
-# Linux
-npm run dist:linux:x64           # x64
-npm run dist:linux:arm64         # ARM64
-make electron-build-linux
-```
-
-### Build Output
-
-Installers are generated in `electron/dist/`:
-- **macOS**: `Ambrosia POS-1.0.0.dmg`, `Ambrosia POS-1.0.0-mac.zip`
-- **Windows**: `Ambrosia POS Setup 1.0.0.exe`, portable `.exe`
-- **Linux**:
-  - `.deb` (Debian/Ubuntu/Mint/Pop!_OS): `ambrosia-pos-electron_1.0.0_amd64.deb`, `ambrosia-pos-electron_1.0.0_arm64.deb`
-  - `.rpm` (Fedora/RHEL/CentOS/openSUSE): `ambrosia-pos-electron-1.0.0.x86_64.rpm`, `ambrosia-pos-electron-1.0.0.aarch64.rpm`
-
-### Linux Installation
-
-#### Debian/Ubuntu and derivatives
-
-```bash
-# x64
-sudo apt install ./ambrosia-pos-electron_1.0.0_amd64.deb
-
-# ARM64
-sudo apt install ./ambrosia-pos-electron_1.0.0_arm64.deb
-```
-
-#### Fedora/RHEL/CentOS and derivatives
-
-```bash
-# x64
-sudo dnf install ambrosia-pos-electron-1.0.0.x86_64.rpm
-
-# ARM64
-sudo dnf install ambrosia-pos-electron-1.0.0.aarch64.rpm
-```
-
-**Features:**
-- Includes all dependencies automatically
-- GTK 3 forced (compatible with GTK 4 systems)
-- RPM includes `libxcrypt-compat` for Fedora compatibility
-- Installs to `/opt/AmbrosiaPos/`
-
-## Project Structure
-
-```
+```text
 electron/
-├── main.js                          # Electron main process
-├── preload.js                       # Preload script (secure APIs)
-├── package.json                     # Configuration and dependencies
-├── services/                        # Embedded services management
-│   ├── ServiceManager.js            # Main orchestrator
-│   ├── PhoenixdService.js           # Phoenixd management
-│   ├── BackendService.js            # Kotlin backend management
-│   ├── NextJsService.js             # Next.js management
-│   └── ConfigurationBootstrap.js    # Automatic config generation
-├── utils/                           # Utilities
-│   ├── portAllocator.js             # Dynamic port assignment
-│   ├── healthCheck.js               # Health checks with retries
-│   └── resourcePaths.js             # Resource paths and mode detection
-├── build/                           # Assets for electron-builder
-│   ├── icon.icns                    # macOS icon
-│   ├── icon.ico                     # Windows icon
-│   ├── icon.png                     # Linux icon
+├── main.js                          # Electron main process: window, IPC handlers, app lifecycle
+├── preload.js                       # IPC bridge: exposes whitelisted channels to renderer
+├── services/
+│   ├── ServiceManager.js            # Orchestrates service startup/shutdown and port allocation
+│   ├── PhoenixdService.js           # phoenixd daemon lifecycle
+│   ├── BackendService.js            # Kotlin backend (JRE + JAR) lifecycle
+│   ├── NextJsService.js             # Next.js standalone server lifecycle
+│   ├── ConfigurationBootstrap.js    # First-run config file generation
+│   └── AutoUpdater.js               # Auto-update via electron-updater
+├── utils/
+│   ├── portAllocator.js             # Finds free ports dynamically
+│   ├── healthCheck.js               # wait-on health checks with retries
+│   ├── resourcePaths.js             # Resolves paths for dev vs production
+│   ├── logger.js                    # Silent in production unless DEBUG=true; warn/error always print
+│   └── constants.js                 # Timeouts, port ranges, version constants
+├── scripts/
+│   ├── prepare-resources-wrapper.js # Orchestrates the full pre-build pipeline
+│   ├── download-phoenixd.js
+│   ├── download-jre.js
+│   ├── download-node.js
+│   ├── build-backend.js
+│   ├── build-client.js
+│   ├── platform-utils.js            # Shared platform/arch detection helpers
+│   ├── dev.sh / dev.bat             # Dev launcher scripts
+│   └── clean-build.js
+├── build/                           # electron-builder assets
+│   ├── icon.icns / icon.ico / icon.png
 │   ├── entitlements.mac.plist
-│   └── ICONS_README.md              # Instructions for generating icons
-├── scripts/                         # Development and build scripts
-│   ├── dev.sh                       # Development script (Unix)
-│   ├── dev.bat                      # Development script (Windows)
-│   ├── build.sh                     # Build script
-│   ├── prepare-resources-wrapper.js # Resource preparation for build
-│   └── clean-build.js               # Build cleanup
-├── resources/                       # Embedded resources (generated during build)
-│   ├── phoenixd/                    # Phoenixd binaries per platform
-│   ├── backend/                     # Backend JAR + JRE
-│   └── client/                      # Next.js standalone build
+│   └── postinst                     # Linux post-install: creates GTK 3 wrapper
+├── resources/                       # Generated during build — bundled into the app
+│   ├── phoenixd/
+│   ├── backend/
+│   └── client/
 └── dist/                            # electron-builder output (generated)
 ```
 
-## Configuration
-
-### Automatic Configuration Generation
-
-The application automatically generates all necessary configuration on first startup:
-
-**Generated files**:
-```
-~/.Ambrosia-POS/
-├── ambrosia.conf              # Backend configuration
-├── ambrosia.db                # SQLite database
-├── phoenix/
-│   └── phoenix.conf           # Phoenixd configuration
-└── logs/
-    ├── phoenixd-YYYY-MM-DD.log
-    ├── backend-YYYY-MM-DD.log
-    └── nextjs-YYYY-MM-DD.log
-```
-
-**ambrosia.conf** (automatically generated):
-```properties
-http-bind-ip=127.0.0.1
-http-bind-port=9154  # Dynamic in production
-secret=<BIP39 12-word mnemonic>  # 132 bits entropy
-secret-hash=<SHA256 hash>
-phoenixd-url=http://localhost:9740
-```
-
-**phoenix.conf** (automatically generated):
-```properties
-http-password=<random 64 hex chars>
-http-password-limited-access=<random 64 hex chars>
-webhook-secret=<random 64 hex chars>
-webhook=http://127.0.0.1:9154/webhook/phoenixd
-auto-liquidity=off
-max-mining-fee=5000
-```
-
-### Secret Security
-
-- **BIP39 Mnemonic**: Uses BIP39 standard for secrets (128 bits of entropy + 4 bits checksum)
-- **Validation**: Checksums included for error detection
-- **Compatibility**: Compatible with standard Bitcoin wallets
-
-### Electron Builder
-
-Configuration is in `package.json` under the `build` key. Customize:
-- `appId`: Application identifier
-- `productName`: Visible name
-- `mac/win/linux`: Per-platform configuration
-
-## Troubleshooting
-
-### Error: Application doesn't start (Production Mode)
-
-**Cause**: Phoenixd or Backend fail to start.
-
-**Solution**:
-1. Check logs in `~/.Ambrosia-POS/logs/`
-2. Verify dynamic ports are available
-3. Verify execution permissions on binaries
-4. In the error dialog, select "Logs" to see details
-
-### Error: Backend not found (Development Mode)
-
-**Cause**: External backend is not running.
-
-**Solution**:
-```bash
-cd ../server
-./gradlew run
-```
-
-### Error: Port 3000 in use (Development Mode)
-
-**Cause**: Another process is using port 3000.
-
-**Solution**:
-```bash
-# Find and stop the process
-lsof -i :3000
-kill <PID>
-```
-
-### Error: Services don't stop correctly
-
-**Cause**: Zombie processes from phoenixd/backend/nextjs.
-
-**Solution**:
-```bash
-# Kill all related processes
-pkill -f phoenixd
-pkill -f "java.*ambrosia"
-pkill -f "node.*next"
-```
-
-### Error: Build fails
-
-**Cause**: Missing dependencies or incomplete Next.js build.
-
-**Solution**:
-```bash
-# Clean and rebuild everything
-cd ../client
-rm -rf .next node_modules
-npm install
-npm run build:electron
-cd ../electron
-npm run clean
-npm install
-npm run build
-```
-
-### Error: Health check timeout
-
-**Cause**: Service takes too long to start or fails silently.
-
-**Solution**:
-1. Check logs for the specific service in `~/.Ambrosia-POS/logs/`
-2. Verify that the previous service in the chain started correctly
-3. Increase timeout in `utils/healthCheck.js` if necessary
-
-### Linux-Specific Issues
-
-#### Error: GTK 2/3 symbols detected
-
-**Symptoms**:
-```
-Gtk-ERROR **: GTK 2/3 symbols detected. Using GTK 2/3 and GTK 4 in the same process is not supported
-Trace/breakpoint trap
-```
-
-**Cause**: System has GTK 4 but Electron tries to load multiple GTK versions.
-
-**Solution**: The `.deb` and `.rpm` packages automatically include a wrapper that forces GTK 3. If you installed manually, run:
-```bash
-/opt/AmbrosiaPos/ambrosia-pos-electron --gtk-version=3
-```
-
-#### Error: libcrypt.so.1 not found (Fedora/RHEL)
-
-**Symptoms**:
-```
-error while loading shared libraries: libcrypt.so.1: cannot open shared object file
-```
-
-**Cause**: Fedora/RHEL migrated to libcrypt.so.2 but phoenixd requires libcrypt.so.1.
-
-**Solution**: The `.rpm` packages automatically include the `libxcrypt-compat` dependency. If you installed manually:
-```bash
-sudo dnf install libxcrypt-compat
-```
-
-#### Build Dependencies for Ubuntu/Debian
-
-To build `.rpm` packages from Ubuntu/Debian:
-```bash
-sudo apt install rpm
-```
-
-### Viewing Service Logs
-
-Logs are saved by date in `~/.Ambrosia-POS/logs/`:
-```bash
-# View logs in real-time
-tail -f ~/.Ambrosia-POS/logs/phoenixd-$(date +%Y-%m-%d).log
-tail -f ~/.Ambrosia-POS/logs/backend-$(date +%Y-%m-%d).log
-tail -f ~/.Ambrosia-POS/logs/nextjs-$(date +%Y-%m-%d).log
-```
-
-### Complete Reinstallation
-
-If all else fails:
-```bash
-# 1. Clean existing configuration (WARNING: deletes the database)
-rm -rf ~/.Ambrosia-POS
-
-# 2. Clean builds
-cd electron
-npm run clean
-
-# 3. Rebuild everything
-cd ../client
-npm install
-npm run build:electron
-cd ../electron
-npm install
-npm run build
-```
-
-## Application Icons
-
-Icons should be in `build/`:
-- `icon.icns` - macOS (512x512+)
-- `icon.ico` - Windows (multiple sizes)
-- `icon.png` - Linux (512x512)
-
-See `build/ICONS_README.md` for instructions on how to generate icons.
-
-## Security
-
-The application implements the following security measures:
-
-- ✅ `contextIsolation: true` - Context isolation
-- ✅ `nodeIntegration: false` - Node.js disabled in renderer
-- ✅ `sandbox: true` - Sandbox enabled
-- ✅ Preload script with IPC channel whitelist
-- ✅ Backend configuration validation
-
-## Features
-
-### Development Mode
-- DevTools automatically enabled
-- Next.js hot reload
-- Fixed port (3000)
-- Detailed logging
-
-### Production Mode
-- Optimized bundle with `output: 'standalone'`
-- Dynamic port (avoids conflicts)
-- Clean Next.js server shutdown
-- Robust error handling with informative dialogs
-
-### Linux Multi-Platform Support
-- **Distribution formats**: `.deb` and `.rpm` for maximum compatibility
-- **Supported distributions**:
-  - Debian, Ubuntu, Linux Mint, Pop!_OS (`.deb`)
-  - Fedora, RHEL, CentOS, openSUSE (`.rpm`)
-- **Architectures**: x64 (amd64/x86_64) and ARM64 (arm64/aarch64)
-- **GTK Compatibility**: Automatic wrapper forces GTK 3 (compatible with GTK 4)
-- **Dependencies included**: RPM includes `libxcrypt-compat` for Fedora/RHEL
-- **Complete installation**: phoenixd, Kotlin backend and Next.js frontend bundled
-
-## Available Commands
-
-```bash
-# Development
-npm run dev              # Start in development mode
-npm run dev:inspect      # With Node.js inspector
-
-# Build
-npm run build            # Complete build
-npm run build:client     # Only Next.js client build
-npm run pack             # Package without creating installer
-npm run dist             # Create installer for current platform
-npm run dist:mac:arm64   # macOS ARM64 installer
-npm run dist:mac:x64     # macOS x64 installer
-npm run dist:win:x64     # Windows x64 installer
-npm run dist:win:arm64   # Windows ARM64 installer
-npm run dist:linux:x64   # Linux x64 installer (.deb + .rpm)
-npm run dist:linux:arm64 # Linux ARM64 installer (.deb + .rpm)
-```
-
-## Implementation Notes
-
-### Services Architecture
-
-Each service (`PhoenixdService`, `BackendService`, `NextJsService`) implements:
-- `start(port, config)` - Starts the service with configuration
-- `stop()` - Stops the service cleanly
-- `getStatus()` - Returns current state (`starting`, `running`, `stopped`, `error`)
-- `getPort()` - Returns assigned port
-
-### Lifecycle Management
-
-Each service manages its child process:
-1. **Startup**:
-   - Spawn with `cross-spawn`
-   - Redirect stdout/stderr to logs
-   - Health check with retries
-2. **Runtime**:
-   - Continuous logging to daily files
-   - Process state monitoring
-3. **Shutdown**:
-   - `tree-kill` with SIGTERM (graceful)
-   - 5-10s timeout
-   - Fallback to SIGKILL if necessary
-
-### ServiceManager - Orchestration
-
-The `ServiceManager` coordinates the start/stop of all services:
-```javascript
-async startAll() {
-  // Development mode: only Next.js
-  // Production mode: Phoenixd → Backend → Next.js (sequential)
-
-  // Emits events:
-  // - 'service:started' → { service, port }
-  // - 'service:error' → { service, error }
-  // - 'all:started'
-}
-```
-
-### Available IPC Handlers
-
-The renderer can communicate with services:
-```javascript
-// Get status of all services
-window.electron.invoke('services:get-statuses')
-// → { statuses: {...}, ports: {...}, devMode: boolean }
-
-// Restart a specific service
-window.electron.invoke('services:restart', 'backend')
-// → { success: true } | { success: false, error: "..." }
-
-// Get logs directory
-window.electron.invoke('services:get-logs')
-// → { logsDir: "/path/to/logs" }
-```
-
-### Environment Detection
-
-The application automatically detects if it's in development or production:
-```javascript
-const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
-```
-
-### Resource Paths
-
-Smart path management based on mode:
-- **Development**:
-  - Client: `path.join(__dirname, '..', 'client')`
-  - Backend JAR: Assumes external
-  - Phoenixd: Assumes external
-- **Production**:
-  - Client: `path.join(process.resourcesPath, 'client')`
-  - Backend JAR: `path.join(process.resourcesPath, 'backend', 'ambrosia.jar')`
-  - Phoenixd: `path.join(process.resourcesPath, 'phoenixd', 'bin', 'phoenixd')`
-  - JRE: `path.join(process.resourcesPath, 'jre', platform-arch, 'bin', 'java')`
-
-### Multi-Platform Support
-
-Platform-specific management:
-- **macOS**: Native binaries (ARM64 and x64)
-- **Windows x64**: Native binaries
-- **Windows ARM64**: Phoenixd JVM + x64 JRE (emulation), Backend with ARM64 JRE
-- **Linux x64**: Native binaries
-- **Linux ARM64**: Native ARM64 Phoenixd, Backend with ARM64 JRE
-
-### Multiple Instance Prevention
-
-```javascript
-const gotTheLock = app.requestSingleInstanceLock();
-if (!gotTheLock) app.quit();
-// If second instance tries to open, focus the first one
-```
-
-## Resources
-
-- [Electron Documentation](https://www.electronjs.org/docs)
-- [electron-builder](https://www.electron.build/)
-- [Next.js Documentation](https://nextjs.org/docs)
-- [Ambrosia POS Repository](https://github.com/olympus-btc/ambrosia)
-
-## License
-
-MIT - See LICENSE in the project root
+## Platform notes
+
+| Platform | Notes |
+| --- | --- |
+| macOS | Hardened runtime with `build/entitlements.mac.plist`; ARM64 and x64 native binaries |
+| Windows x64 | Native phoenixd binary + Temurin 21 JRE |
+| Windows ARM64 | No native phoenixd binary — uses phoenixd JVM + x64 JRE (emulation) |
+| Linux x64/ARM64 | Post-install script (`build/postinst`) wraps the binary to force GTK 3 |
+| Linux RPM | Declares `libxcrypt-compat` dependency for Fedora/RHEL compatibility |
+
+## Where to go next
+
+- [`../server/README.md`](../server/README.md) — Kotlin/Ktor backend architecture
+- [`../client/README.md`](../client/README.md) — Next.js frontend architecture
+- [Project root README](../README.md) — installation guide and contribution guidelines


### PR DESCRIPTION
## Changes:
- Add `client/README.md` as a contributor architecture guide: startup flow, request flow, component structure pattern, auth flow, provider hierarchy, i18n, directory layout, testing, and environment variables
- Improve `electron/README.md` to match the server README style: two operation modes, startup flow, service layer interface, IPC bridge, build pipeline, directory layout, and platform notes