### PR TITLE
remove upgrade-insecure-requests from content security policy.

### DIFF
--- a/client/src/proxy.js
+++ b/client/src/proxy.js
@@ -95,7 +95,6 @@ export default async function proxy(request) {
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    upgrade-insecure-requests;
   `.replace(/\s{2,}/g, " ").trim();
 
   const requestHeaders = new Headers(request.headers);


### PR DESCRIPTION
## Changes:
- Remove `upgrade-insecure-requests` from the CSP in `proxy.js` — the directive upgraded HTTP resources to HTTPS without fallback, breaking styles when accessing the app from another device on thelocal network (e.g. phone via `http://192.168.x.x:3000`). `localhost` is excluded from the upgrade by the W3C spec (loopback is a priori trusted), so the issue only manifested from other devices.