### PR TITLE
fix(client): remove upgrade-insecure-requests from CSP to fix CSS bre…

### DIFF
--- a/client/src/proxy.js
+++ b/client/src/proxy.js
@@ -98,7 +98,6 @@ export default async function proxy(request) {
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    upgrade-insecure-requests;
   `.replace(/\s{2,}/g, " ").trim();
 
   const requestHeaders = new Headers(request.headers);

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -7194,9 +7194,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/electron/package.json
+++ b/electron/package.json
@@ -45,7 +45,8 @@
     "form-data": "4.0.6",
     "joi": "18.2.1",
     "js-yaml": "4.2.0",
-    "tar": "7.5.16"
+    "tar": "7.5.16",
+    "undici": "7.28.0"
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",


### PR DESCRIPTION
Fixes an issue introduced during a recent merge/rebase where the layout's CSS and styling assets break completely when the application is served over HTTP or non-TLS environments.

### Changes
- Removed the accidental reintroduction of `upgrade-insecure-requests;` from the `Content-Security-Policy` header in `client/src/proxy.js`.
- This ensures the browser does not forcefully upgrade asset fetching to HTTPS, allowing CSS sheets to load correctly in local or non-TLS setups.

<img width="1048" height="526" alt="Screenshot From 2026-06-18 11-30-20" src="https://github.com/user-attachments/assets/18ce868a-dcd5-470a-8f82-e9ae5ddcda3f" />
