### PR TITLE
fix(client): render payment modals once in Cart to fix duplicate modal on mobile

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -8,6 +8,9 @@ import { PageHeader } from "@/components/shared/PageHeader";
 import { useCategories } from "../hooks/useCategories";
 import { useProducts } from "../hooks/useProducts";
 
+import { BitcoinPaymentModal } from "./BitcoinPaymentModal";
+import { CardPaymentModal } from "./CardPaymentModal";
+import { CashPaymentModal } from "./CashPaymentModal";
 import { useCartOperations } from "./hooks/useCartOperations";
 import { useCartPayment } from "./hooks/useCartPayment";
 import { usePersistentCart } from "./hooks/usePersistentCart";
@@ -87,25 +90,6 @@ export function Cart() {
     return subtotal - (subtotal * discountRate) / 100;
   }, [cart, discount]);
 
-  const btcPayment = {
-    config: btcPaymentConfig,
-    onInvoiceReady: handleBtcInvoiceReady,
-    onComplete: handleBtcComplete,
-    onClose: clearBtcPaymentConfig,
-  };
-
-  const cashPayment = {
-    config: cashPaymentConfig,
-    onComplete: handleCashComplete,
-    onClose: clearCashPaymentConfig,
-  };
-
-  const cardPayment = {
-    config: cardPaymentConfig,
-    onComplete: handleCardComplete,
-    onClose: clearCardPaymentConfig,
-  };
-
   return (
     <div className={`transition-[padding] duration-200 md:pt-0 ${cart.length ? "pt-14" : "pt-0"}`}>
       <PageHeader title={cartTranslations("title")} subtitle={cartTranslations("subtitle")} />
@@ -125,9 +109,6 @@ export function Cart() {
             isPaying={isPaying}
             paymentError={paymentError}
             onClearPaymentError={clearPaymentError}
-            btcPayment={btcPayment}
-            cashPayment={cashPayment}
-            cardPayment={cardPayment}
           />
         </div>
       </div>
@@ -150,9 +131,35 @@ export function Cart() {
         isPaying={isPaying}
         paymentError={paymentError}
         onClearPaymentError={clearPaymentError}
-        btcPayment={btcPayment}
-        cashPayment={cashPayment}
-        cardPayment={cardPayment}
+      />
+
+      <BitcoinPaymentModal
+        isOpen={!!btcPaymentConfig}
+        amountFiat={btcPaymentConfig?.amountFiat}
+        currencyAcronym={btcPaymentConfig?.currencyAcronym}
+        paymentId={btcPaymentConfig?.paymentId}
+        invoiceDescription={btcPaymentConfig?.invoiceDescription}
+        displayTotal={btcPaymentConfig?.displayTotal}
+        onClose={clearBtcPaymentConfig}
+        onInvoiceReady={handleBtcInvoiceReady}
+        onComplete={handleBtcComplete}
+      />
+
+      <CashPaymentModal
+        isOpen={!!cashPaymentConfig}
+        amountDue={cashPaymentConfig?.amountDue}
+        displayTotal={cashPaymentConfig?.displayTotal}
+        onClose={clearCashPaymentConfig}
+        onComplete={handleCashComplete}
+      />
+
+      <CardPaymentModal
+        isOpen={!!cardPaymentConfig}
+        amountDue={cardPaymentConfig?.amountDue}
+        displayTotal={cardPaymentConfig?.displayTotal}
+        methodLabel={cardPaymentConfig?.methodLabel}
+        onClose={clearCardPaymentConfig}
+        onComplete={handleCardComplete}
       />
     </div>
   );

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -3,10 +3,6 @@ import { useSyncExternalStore } from "react";
 import { addToast, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
-import { BitcoinPaymentModal } from "../BitcoinPaymentModal";
-import { CardPaymentModal } from "../CardPaymentModal";
-import { CashPaymentModal } from "../CashPaymentModal";
-
 import { CartItemCard } from "./CartItemCard";
 import { CartPaymentSection } from "./CartPaymentSection";
 import { CartTotals } from "./CartTotals";
@@ -22,9 +18,6 @@ export function SummaryContent({
   isPaying,
   paymentError,
   onClearPaymentError,
-  btcPayment,
-  cashPayment,
-  cardPayment,
 }) {
   const cartTranslations = useTranslations("cart");
   const { pendingRemovals, startRemoval, cancelRemoval } = usePendingRemoval();
@@ -56,64 +49,33 @@ export function SummaryContent({
   };
 
   return (
-    <>
-      <div className="space-y-4">
-        {visibleItems.map((item) => (
-          <SwipeableCartItem
-            key={item.id}
+    <div className="space-y-4">
+      {visibleItems.map((item) => (
+        <SwipeableCartItem
+          key={item.id}
+          onRemove={() => handleStartRemoval(item)}
+          isTouchDevice={isTouchDevice}
+        >
+          <CartItemCard
+            item={item}
             onRemove={() => handleStartRemoval(item)}
-            isTouchDevice={isTouchDevice}
-          >
-            <CartItemCard
-              item={item}
-              onRemove={() => handleStartRemoval(item)}
-              onUpdateQuantity={onUpdateQuantity}
-            />
-          </SwipeableCartItem>
-        ))}
+            onUpdateQuantity={onUpdateQuantity}
+          />
+        </SwipeableCartItem>
+      ))}
 
-        <CartTotals subtotal={subtotal} discountAmount={discountAmount} total={total} />
+      <CartTotals subtotal={subtotal} discountAmount={discountAmount} total={total} />
 
-        <CartPaymentSection
-          isPaying={isPaying}
-          isDisabled={!isMounted || !visibleItems.length}
-          paymentError={paymentError}
-          onClearPaymentError={onClearPaymentError}
-          onPay={(selectedPaymentMethod) => {
-            onClearPaymentError?.();
-            onPay?.({ items, subtotal, discount, discountAmount, total, selectedPaymentMethod });
-          }}
-        />
-      </div>
-
-      <BitcoinPaymentModal
-        isOpen={!!btcPayment?.config}
-        amountFiat={btcPayment?.config?.amountFiat}
-        currencyAcronym={btcPayment?.config?.currencyAcronym}
-        paymentId={btcPayment?.config?.paymentId}
-        invoiceDescription={btcPayment?.config?.invoiceDescription}
-        displayTotal={btcPayment?.config?.displayTotal}
-        onClose={btcPayment?.onClose}
-        onInvoiceReady={btcPayment?.onInvoiceReady}
-        onComplete={btcPayment?.onComplete}
+      <CartPaymentSection
+        isPaying={isPaying}
+        isDisabled={!isMounted || !visibleItems.length}
+        paymentError={paymentError}
+        onClearPaymentError={onClearPaymentError}
+        onPay={(selectedPaymentMethod) => {
+          onClearPaymentError?.();
+          onPay?.({ items, subtotal, discount, discountAmount, total, selectedPaymentMethod });
+        }}
       />
-
-      <CashPaymentModal
-        isOpen={!!cashPayment?.config}
-        amountDue={cashPayment?.config?.amountDue}
-        displayTotal={cashPayment?.config?.displayTotal}
-        onClose={cashPayment?.onClose}
-        onComplete={cashPayment?.onComplete}
-      />
-
-      <CardPaymentModal
-        isOpen={!!cardPayment?.config}
-        amountDue={cardPayment?.config?.amountDue}
-        displayTotal={cardPayment?.config?.displayTotal}
-        methodLabel={cardPayment?.config?.methodLabel}
-        onClose={cardPayment?.onClose}
-        onComplete={cardPayment?.onComplete}
-      />
-    </>
+    </div>
   );
 }

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -82,18 +82,6 @@ jest.mock("@heroui/react", () => {
   };
 });
 
-jest.mock("../../BitcoinPaymentModal", () => ({
-  BitcoinPaymentModal: ({ isOpen }) => (isOpen ? <div>btc-modal</div> : null),
-}));
-
-jest.mock("../../CashPaymentModal", () => ({
-  CashPaymentModal: ({ isOpen }) => (isOpen ? <div>cash-modal</div> : null),
-}));
-
-jest.mock("../../CardPaymentModal", () => ({
-  CardPaymentModal: ({ isOpen }) => (isOpen ? <div>card-modal</div> : null),
-}));
-
 const cartItems = [{ id: 1, imageUrl: "/uploads/jade-wallet.png", name: "Jade Wallet", price: 1000, quantity: 2, subtotal: 2000 }];
 
 const defaultProps = {
@@ -171,20 +159,5 @@ describe("SummaryContent", () => {
     render(<SummaryContent {...defaultProps} cartItems={undefined} />);
 
     expect(screen.getByText("summary.pay")).toBeDisabled();
-  });
-
-  it("renders payment modals when configs are provided", () => {
-    render(
-      <SummaryContent
-        {...defaultProps}
-        btcPayment={{ config: { paymentId: "btc-1" } }}
-        cashPayment={{ config: { paymentId: "cash-1" } }}
-        cardPayment={{ config: { paymentId: "card-1" } }}
-      />,
-    );
-
-    expect(screen.getByText("btc-modal")).toBeInTheDocument();
-    expect(screen.getByText("cash-modal")).toBeInTheDocument();
-    expect(screen.getByText("card-modal")).toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -16,6 +16,18 @@ const mockUpdateQuantity = jest.fn();
 const mockRemoveProduct = jest.fn();
 const mockClearCart = jest.fn();
 
+jest.mock("../BitcoinPaymentModal", () => ({
+  BitcoinPaymentModal: ({ isOpen }) => (isOpen ? <div>btc-modal</div> : null),
+}));
+
+jest.mock("../CashPaymentModal", () => ({
+  CashPaymentModal: ({ isOpen }) => (isOpen ? <div>cash-modal</div> : null),
+}));
+
+jest.mock("../CardPaymentModal", () => ({
+  CardPaymentModal: ({ isOpen }) => (isOpen ? <div>card-modal</div> : null),
+}));
+
 jest.mock("../SearchProducts", () => ({
   SearchProducts: ({ onAddProduct }) => (
     <div>


### PR DESCRIPTION
## Problem

  On mobile, after a Lightning payment is confirmed, the QR code reappears as if waiting for payment again.

  **Root cause:** `SummaryContent` rendered `BitcoinPaymentModal`, `CashPaymentModal`, and `CardPaymentModal` inline. Since `SummaryContent` is used in two
  places — the desktop sidebar (`Summary`) and the mobile modal (`SummaryModal`) — there were always **two simultaneous instances** of each payment modal
  mounted in the DOM, each generating its own independent Lightning invoice.

  HeroUI `Modal` renders via a portal at the document root, bypassing the `hidden md:block` CSS on the desktop sidebar. This means both modal instances were
  **visually active on mobile** at the same time.

  When the user paid the mobile instance's invoice:
  1. The mobile modal showed "confirmed" and closed (cart reset → `SummaryModal` closed → modal unmounted).
  2. The desktop instance's portal — which had its own unpaid invoice and `paymentReceived = false` — remained open and became visible, showing a new QR
  waiting for payment.

  ## Fix

  Moved the three payment modals out of `SummaryContent` and rendered them **once** at the `Cart` level, outside the desktop/mobile split.