### PR TITLE
feat(scripts): resolve Ambrosia version from latest GitHub release

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -38,7 +38,8 @@ jobs:
         run: chmod +x scripts/install.sh
 
       - name: Run install script
-        # Using --no-service because CI runners often lack systemd or we don't want background services
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/install.sh --yes --no-service
 
       - name: Verify phoenixd binary

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -248,9 +248,9 @@ ambrosia_resolve_tag() {
   fi
   local response
   response=$(curl -fsSL "${auth_args[@]}" "$api_url")
-  AMBROSIA_TAG=$(echo "$response" \
-    | grep -m1 '"tag_name"' \
-    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/')
+  AMBROSIA_TAG=$(printf '%s\n' "$response" \
+    | sed -E -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/p' \
+    | sed -n '1p')
   if [[ -z "$AMBROSIA_TAG" ]]; then
     log_error "Could not determine the latest Ambrosia release tag (GitHub API rate limit?)."
     log_error "You can pin a version manually: AMBROSIA_TAG=vX.Y.Z $0"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -242,8 +242,13 @@ ambrosia_resolve_tag() {
   fi
   log_info "Resolving latest Ambrosia release from $AMBROSIA_REPO..."
   local api_url="https://api.github.com/repos/${AMBROSIA_REPO}/releases"
-
-  AMBROSIA_TAG=$(curl -fsSL "$api_url" \
+  local auth_args=()
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    auth_args=(-H "Authorization: Bearer $GH_TOKEN")
+  fi
+  local response
+  response=$(curl -fsSL "${auth_args[@]}" "$api_url")
+  AMBROSIA_TAG=$(echo "$response" \
     | grep -m1 '"tag_name"' \
     | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/')
   if [[ -z "$AMBROSIA_TAG" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,6 @@
 # 🚀 Ambrosia & Phoenixd Installer
 # ==========================================
 
-# Exit immediately if a command exits with a non-zero status, undefined vars, pipe fails.
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -229,10 +228,31 @@ EOF
 
 # --- Ambrosia Server Installation Logic ---
 
-AMBROSIA_TAG="0.7.0-beta"
-AMBROSIA_URL="https://github.com/olympus-btc/ambrosia/releases/download/v${AMBROSIA_TAG}"
+AMBROSIA_REPO="olympus-btc/ambrosia"
 AMBROSIA_INSTALL_DIR="$HOME/.local/ambrosia"
 AMBROSIA_BIN_DIR="$HOME/.local/bin"
+AMBROSIA_TAG="${AMBROSIA_TAG:-}"
+
+ambrosia_resolve_tag() {
+
+  if [[ -n "$AMBROSIA_TAG" ]]; then
+    AMBROSIA_TAG="${AMBROSIA_TAG#v}"
+    log_info "Using pinned Ambrosia version: v$AMBROSIA_TAG"
+    return
+  fi
+  log_info "Resolving latest Ambrosia release from $AMBROSIA_REPO..."
+  local api_url="https://api.github.com/repos/${AMBROSIA_REPO}/releases"
+
+  AMBROSIA_TAG=$(curl -fsSL "$api_url" \
+    | grep -m1 '"tag_name"' \
+    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/')
+  if [[ -z "$AMBROSIA_TAG" ]]; then
+    log_error "Could not determine the latest Ambrosia release tag (GitHub API rate limit?)."
+    log_error "You can pin a version manually: AMBROSIA_TAG=vX.Y.Z $0"
+    exit 1
+  fi
+  log_info "Latest Ambrosia release: v$AMBROSIA_TAG"
+}
 
 ambrosia_write_initial_config() {
   local datadir="$HOME/.Ambrosia-POS"
@@ -271,8 +291,9 @@ ambrosia_install() {
   mkdir -p "$AMBROSIA_BIN_DIR" "$AMBROSIA_INSTALL_DIR"
   ambrosia_write_initial_config
 
-  download_file "${AMBROSIA_URL}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
-  download_file "https://raw.githubusercontent.com/olympus-btc/ambrosia/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
+  local ambrosia_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}"
+  download_file "${ambrosia_url}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
+  download_file "https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
   
   chmod +x "$AMBROSIA_INSTALL_DIR/ambrosia.jar" "$AMBROSIA_INSTALL_DIR/run-server.sh"
   ln -sf "$AMBROSIA_INSTALL_DIR/run-server.sh" "$AMBROSIA_BIN_DIR/ambrosia"
@@ -327,9 +348,6 @@ EOF
 
 # --- Client Installation ---
 
-CLIENT_TAG="0.7.0-beta"
-CLIENT_DIST_FILE="ambrosia-client-${CLIENT_TAG}.tar.gz"
-CLIENT_DIST_URL="https://github.com/olympus-btc/ambrosia/releases/download/v${CLIENT_TAG}/${CLIENT_DIST_FILE}"
 CLIENT_INSTALL_DIR="$HOME/.local/ambrosia/client"
 
 client_install() {
@@ -345,9 +363,11 @@ client_install() {
   fi
 
   mkdir -p "$CLIENT_INSTALL_DIR"
-  
-  download_file "$CLIENT_DIST_URL" "$GLOBAL_TEMP_DIR/$CLIENT_DIST_FILE"
-  tar -xzf "$GLOBAL_TEMP_DIR/$CLIENT_DIST_FILE" -C "$CLIENT_INSTALL_DIR" --strip-components=1
+
+  local client_dist_file="ambrosia-client-${AMBROSIA_TAG}.tar.gz"
+  local client_dist_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}/${client_dist_file}"
+  download_file "$client_dist_url" "$GLOBAL_TEMP_DIR/$client_dist_file"
+  tar -xzf "$GLOBAL_TEMP_DIR/$client_dist_file" -C "$CLIENT_INSTALL_DIR" --strip-components=1
   
   echo "   Installing Node.js dependencies..."
   pushd "$CLIENT_INSTALL_DIR" > /dev/null
@@ -417,6 +437,7 @@ EOF
 check_dependencies
 print_header
 phoenixd_install
+ambrosia_resolve_tag
 ambrosia_install
 client_install
 


### PR DESCRIPTION
## Summary

- `install.sh` now resolves the Ambrosia server JAR and client tarball from the latest GitHub release instead of a hardcoded version tag
- Uses the `/releases` API endpoint (not `/releases/latest`) to include prereleases, since all current Ambrosia releases are tagged as prerelease (`-beta`, `-alpha`)
- Supports manual version pinning via the `AMBROSIA_TAG` environment variable (`AMBROSIA_TAG=vX.Y.Z ./install.sh`)
- `GH_TOKEN` is used in CI to avoid GitHub API rate limits on shared runner IPs (transparent to end users)
- phoenixd remains pinned at `0.7.2` (third-party dependency, GPG-verified)
- No new dependencies added — resolution uses only `curl`, `grep`, and `sed`

## Test plan

- [x] Verify syntax:
  ```bash
  bash -n scripts/install.sh
  ```

- [x] Verify tag resolution returns the latest published release (no errors, no broken pipe):
  ```bash
  response=$(curl -fsSL https://api.github.com/repos/olympus-btc/ambrosia/releases)
  echo "$response" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/'
  ```
  Expected: latest published tag (e.g. `0.6.0-beta` while `0.7.0-beta` is still a draft)

- [x] Verify manual override skips the API call:
  ```bash
  AMBROSIA_TAG=v0.6.0-beta ./scripts/install.sh --yes --no-service
  ```

- [x] Verify download URLs resolve correctly:
  ```bash
  TAG=0.6.0-beta
  curl -fsIL "https://github.com/olympus-btc/ambrosia/releases/download/v${TAG}/ambrosia-${TAG}.jar"
  curl -fsIL "https://github.com/olympus-btc/ambrosia/releases/download/v${TAG}/ambrosia-client-${TAG}.tar.gz"
  ```
