### PR TITLE
fix(store): unblock re-adding items pending removal

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTranslations } from "next-intl";
 
@@ -72,6 +72,17 @@ export function Cart() {
     [cart, pendingRemovals],
   );
 
+  const handleAddProduct = useCallback(
+    (product) => {
+      if (pendingRemovals.has(product.id)) {
+        cancelRemoval(product.id);
+        return;
+      }
+      addProduct(product);
+    },
+    [addProduct, cancelRemoval, pendingRemovals],
+  );
+
   const handleClearCart = () => {
     clearPendingRemovals();
     clearCart();
@@ -120,7 +131,7 @@ export function Cart() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <section className="lg:col-span-2">
-          <SearchProducts products={products} categories={categories} onAddProduct={addProduct} />
+          <SearchProducts products={products} categories={categories} onAddProduct={handleAddProduct} />
         </section>
         <div className="hidden md:block">
           <Summary

--- a/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/SummaryContent.jsx
@@ -1,6 +1,6 @@
-import { useRef, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 
-import { addToast, Button, closeToast } from "@heroui/react";
+import { addToast, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { calculateCartTotals } from "../utils/cartTotals";
@@ -25,26 +25,12 @@ export function SummaryContent({
   const cartTranslations = useTranslations("cart");
   const isMounted = useSyncExternalStore(() => () => {}, () => true, () => false);
   const isTouchDevice = useSyncExternalStore(() => () => {}, () => navigator.maxTouchPoints > 0, () => false);
-  const removalToastKeys = useRef({});
   const visibleItems = cartItems || [];
 
   const { subtotal, discountAmount, total } = calculateCartTotals(visibleItems, discount);
 
-  const handleUndoRemoval = (itemId) => {
-    cancelRemoval(itemId);
-    const toastKey = removalToastKeys.current[itemId];
-    if (toastKey) {
-      closeToast(toastKey);
-      delete removalToastKeys.current[itemId];
-    }
-  };
-
   const handleStartRemoval = (item) => {
-    startRemoval(item.id, () => {
-      onRemoveProduct(item.id);
-      delete removalToastKeys.current[item.id];
-    });
-    removalToastKeys.current[item.id] = addToast({
+    const toastKey = addToast({
       description: item.name,
       timeout: 5000,
       endContent: (
@@ -52,12 +38,13 @@ export function SummaryContent({
           size="sm"
           color="primary"
           className="bg-green-800"
-          onPress={() => handleUndoRemoval(item.id)}
+          onPress={() => cancelRemoval(item.id)}
         >
           {cartTranslations("summary.undoToast.undo")}
         </Button>
       ),
     });
+    startRemoval(item.id, () => onRemoveProduct(item.id), toastKey);
   };
 
   return (

--- a/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
+++ b/client/src/components/pages/Store/Cart/Summary/__tests__/SummaryContent.test.jsx
@@ -121,7 +121,17 @@ describe("SummaryContent", () => {
     expect(onRemoveProduct).toHaveBeenCalledWith(1);
   });
 
-  it("cancels removal and closes the toast immediately when undo is pressed", () => {
+  it("passes the toast key to startRemoval so the hook owns its dismissal", () => {
+    const startRemoval = jest.fn();
+    render(<SummaryContent {...defaultProps} startRemoval={startRemoval} />);
+
+    fireEvent.click(screen.getByLabelText("Remove Product"));
+
+    expect(mockAddToast).toHaveBeenCalled();
+    expect(startRemoval).toHaveBeenCalledWith(1, expect.any(Function), "toast-key-1");
+  });
+
+  it("cancels removal when undo is pressed", () => {
     const cancelRemoval = jest.fn();
     render(
       <SummaryContent
@@ -139,7 +149,6 @@ describe("SummaryContent", () => {
     fireEvent.click(screen.getByText("summary.undoToast.undo"));
 
     expect(cancelRemoval).toHaveBeenCalledWith(1);
-    expect(mockCloseToast).toHaveBeenCalledWith("toast-key-1");
   });
 
   it("calls onPay with correct data when Pay is pressed", () => {

--- a/client/src/components/pages/Store/Cart/Summary/hooks/__tests__/usePendingRemoval.test.js
+++ b/client/src/components/pages/Store/Cart/Summary/hooks/__tests__/usePendingRemoval.test.js
@@ -2,8 +2,15 @@ import { renderHook, act } from "@testing-library/react";
 
 import { usePendingRemoval } from "../usePendingRemoval";
 
+const mockCloseToast = jest.fn();
+
+jest.mock("@heroui/react", () => ({
+  closeToast: (...args) => mockCloseToast(...args),
+}));
+
 beforeEach(() => {
   jest.useFakeTimers();
+  mockCloseToast.mockClear();
 });
 
 afterEach(() => {
@@ -100,6 +107,50 @@ describe("usePendingRemoval", () => {
 
     expect(onConfirm1).not.toHaveBeenCalled();
     expect(onConfirm2).not.toHaveBeenCalled();
+  });
+
+  it("closes the toast when cancelRemoval is called", () => {
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, jest.fn(), "toast-key-42");
+    });
+
+    act(() => {
+      result.current.cancelRemoval(42);
+    });
+
+    expect(mockCloseToast).toHaveBeenCalledWith("toast-key-42");
+  });
+
+  it("closes the toast when the removal is confirmed after 5 seconds", () => {
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(42, jest.fn(), "toast-key-42");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockCloseToast).toHaveBeenCalledWith("toast-key-42");
+  });
+
+  it("closes every toast when clearPendingRemovals is called", () => {
+    const { result } = renderHook(() => usePendingRemoval());
+
+    act(() => {
+      result.current.startRemoval(1, jest.fn(), "toast-key-1");
+      result.current.startRemoval(2, jest.fn(), "toast-key-2");
+    });
+
+    act(() => {
+      result.current.clearPendingRemovals();
+    });
+
+    expect(mockCloseToast).toHaveBeenCalledWith("toast-key-1");
+    expect(mockCloseToast).toHaveBeenCalledWith("toast-key-2");
   });
 
   it("handles multiple independent removals simultaneously", () => {

--- a/client/src/components/pages/Store/Cart/Summary/hooks/usePendingRemoval.js
+++ b/client/src/components/pages/Store/Cart/Summary/hooks/usePendingRemoval.js
@@ -1,25 +1,13 @@
 import { useState, useRef } from "react";
 
+import { closeToast } from "@heroui/react";
+
 export function usePendingRemoval() {
   const [pendingRemovals, setPendingRemovals] = useState(new Set());
   const timers = useRef({});
+  const toastKeys = useRef({});
 
-  const startRemoval = (itemId, onConfirm) => {
-    setPendingRemovals((prev) => new Set([...prev, itemId]));
-    timers.current[itemId] = setTimeout(() => {
-      onConfirm();
-      setPendingRemovals((prev) => {
-        const next = new Set(prev);
-        next.delete(itemId);
-        return next;
-      });
-      delete timers.current[itemId];
-    }, 5000);
-  };
-
-  const cancelRemoval = (itemId) => {
-    clearTimeout(timers.current[itemId]);
-    delete timers.current[itemId];
+  const removeFromPending = (itemId) => {
     setPendingRemovals((prev) => {
       const next = new Set(prev);
       next.delete(itemId);
@@ -27,9 +15,41 @@ export function usePendingRemoval() {
     });
   };
 
+  const dismissToast = (itemId) => {
+    const toastKey = toastKeys.current[itemId];
+    if (toastKey) {
+      closeToast(toastKey);
+      delete toastKeys.current[itemId];
+    }
+  };
+
+  const clearTimer = (itemId) => {
+    clearTimeout(timers.current[itemId]);
+    delete timers.current[itemId];
+  };
+
+  const startRemoval = (itemId, onConfirm, toastKey) => {
+    toastKeys.current[itemId] = toastKey;
+    setPendingRemovals((prev) => new Set([...prev, itemId]));
+    timers.current[itemId] = setTimeout(() => {
+      onConfirm();
+      delete timers.current[itemId];
+      dismissToast(itemId);
+      removeFromPending(itemId);
+    }, 5000);
+  };
+
+  const cancelRemoval = (itemId) => {
+    clearTimer(itemId);
+    dismissToast(itemId);
+    removeFromPending(itemId);
+  };
+
   const clearPendingRemovals = () => {
-    Object.values(timers.current).forEach(clearTimeout);
+    Object.values(timers.current).forEach((timer) => clearTimeout(timer));
+    Object.values(toastKeys.current).forEach((toastKey) => closeToast(toastKey));
     timers.current = {};
+    toastKeys.current = {};
     setPendingRemovals(new Set());
   };
 


### PR DESCRIPTION
## Summary

When an item is removed from the cart it enters a 5s "pending removal" window (hidden but still in `cart`) so it can be undone via a toast. During that window, tapping the same product in the catalog incremented the **hidden** item's quantity, so it never reappeared until the timeout deleted it — making it feel like you couldn't re-add the item for 5 seconds.

## Changes

- **`usePendingRemoval.js`** — the hook now owns the toast lifecycle. `startRemoval(id, onConfirm, toastKey)` stores the toast key, and `cancelRemoval`, the natural 5s timeout, and `clearPendingRemovals` all dismiss the toast via `closeToast`. Cancelling now also cancels the timeout and removes the toast.
- **`SummaryContent.jsx`** — creates the toast, gets its key, and passes it to `startRemoval`. The "undo" button just calls `cancelRemoval(id)` (toast dismissal is the hook's job). Removed the now-unneeded local `useRef`/`closeToast` handling.
- **`Cart.jsx`** — new `handleAddProduct`: if the product is pending removal, it cancels the pending removal (restoring the item and dismissing its toast) instead of staying blocked. Wired into `SearchProducts`.

## Behavior note

Re-tapping a product that is mid-removal **restores it as-is** (undoes the removal) rather than adding +1. For a single-quantity item this yields exactly 1, which matches the natural expectation.

## Tests

- `usePendingRemoval.test.js` — toast is closed on cancel, on confirm after 5s, and on clear.
- `SummaryContent.test.jsx` — verifies the toast key is passed to `startRemoval`.

All 179 Cart tests pass; lint clean on the touched files.
