### PR TITLE
update: upload artifact and download artifact at release workflow

### DIFF
--- a/.github/workflows/electron_release.yml
+++ b/.github/workflows/electron_release.yml
@@ -83,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.artifact_name }}
           path: |
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Changes:

- Bump `actions/upload-artifact` (v5.0.0 → v7.0.1) and `actions/download-artifact` (v5.0.0 → v8.0.1) in `electron_release.yml` to versions that run on the `node24` runtime, fixing the Node 20 deprecation warning these actions triggered on GitHub-hosted runners.