### PR TITLE
fix force dynamic rendering on root page avoiding scripts blocked by CSP.

### DIFF
--- a/client/src/app/page.jsx
+++ b/client/src/app/page.jsx
@@ -1,45 +1,7 @@
-"use client";
-
-import { useEffect, useRef } from "react";
-
-import { useRouter } from "next/navigation";
-
-import LoadingCard from "@/components/LoadingCard";
-import { useAuth } from "@/hooks/auth/useAuth";
-import { getHomeRoute } from "@/lib/getHomeRoute";
-import { useConfigurations } from "@/providers/configurations/configurationsProvider";
+import { Home } from "@/components/pages/Home/Home";
 
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {
-  const router = useRouter();
-  const { user, isLoading, isAuth } = useAuth();
-  const {
-    businessType,
-    isLoading: isConfigLoading,
-    refreshConfig,
-  } = useConfigurations();
-  const hasRequestedConfigRef = useRef(false);
-
-  useEffect(() => {
-    if (isLoading) return;
-
-    if (!isAuth) {
-      window.location.replace("/auth");
-      return;
-    }
-
-    if (isConfigLoading) return;
-
-    if (isAuth && !businessType && !hasRequestedConfigRef.current) {
-      hasRequestedConfigRef.current = true;
-      refreshConfig?.();
-      return;
-    }
-
-    const homeRoute = getHomeRoute(user, businessType);
-    router.replace(homeRoute);
-  }, [user, isAuth, isLoading, isConfigLoading, router, businessType, refreshConfig]);
-
-  return <LoadingCard />;
+  return <Home />;
 }

--- a/client/src/components/pages/Home/Home.jsx
+++ b/client/src/components/pages/Home/Home.jsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useRouter } from "next/navigation";
+
+import LoadingCard from "@/components/LoadingCard";
+import { useAuth } from "@/hooks/auth/useAuth";
+import { getHomeRoute } from "@/lib/getHomeRoute";
+import { useConfigurations } from "@/providers/configurations/configurationsProvider";
+
+export function Home() {
+  const router = useRouter();
+  const { user, isLoading, isAuth } = useAuth();
+  const {
+    businessType,
+    isLoading: isConfigLoading,
+    refreshConfig,
+  } = useConfigurations();
+  const hasRequestedConfigRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (!isAuth) {
+      window.location.replace("/auth");
+      return;
+    }
+
+    if (isConfigLoading) return;
+
+    if (isAuth && !businessType && !hasRequestedConfigRef.current) {
+      hasRequestedConfigRef.current = true;
+      refreshConfig?.();
+      return;
+    }
+
+    const homeRoute = getHomeRoute(user, businessType);
+    router.replace(homeRoute);
+  }, [user, isAuth, isLoading, isConfigLoading, router, businessType, refreshConfig]);
+
+  return <LoadingCard />;
+}


### PR DESCRIPTION
Changes:
- Split `app/page.jsx` into a Server Component wrapper and a new `Home.jsx` Client Component, fixing a bug where the root route was statically prerendered at build time — causing the CSP nonce (regenerated per request by the middleware) to never match the build-time HTML, blocking every script and leaving the app stuck on the loading screen.