### PR TITLE
ci(release): add server jar and client package to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build & Release Electron
+name: Build & Release
 
 on:
   push:
@@ -97,8 +97,49 @@ jobs:
             electron/dist/*.yml
           if-no-files-found: error
 
+  build-server-client:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Java 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: Build server JAR
+        run: |
+          chmod +x ./gradlew
+          ./gradlew jar
+        working-directory: ./server
+
+      - name: Package client
+        run: |
+          chmod +x ./package-client.sh
+          ./package-client.sh
+        working-directory: ./client
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: dist-server-client
+          path: |
+            server/app/build/libs/ambrosia-*.jar
+            client/dist/ambrosia-client-*.tar.gz
+          if-no-files-found: error
+
   release:
-    needs: build
+    needs: [build, build-server-client]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

The release workflow previously published only the **Electron** distributables
(dmg/deb/rpm/exe/zip…). This PR also ships the two other binaries the project
produces, so a single GitHub Release contains everything needed to deploy:

- **Server fat JAR** — `./gradlew jar` → `server/app/build/libs/ambrosia-*.jar`
- **Client package** — `./package-client.sh` → `client/dist/ambrosia-client-*.tar.gz`

## Changes

- Renamed `.github/workflows/electron_release.yml` → `.github/workflows/release.yml`
  (and the workflow `name:` `Build & Release Electron` → `Build & Release`), since it no
  longer only builds Electron.
- Added a `build-server-client` job (ubuntu-latest) that:
  - sets up Java 21 (temurin) and Node 24,
  - builds the server JAR (`./gradlew jar`),
  - packages the client (`./package-client.sh`),
  - uploads both as the `dist-server-client` artifact.
- The `release` job now depends on `[build, build-server-client]`. It already merges all
  artifacts (`merge-multiple: true`) and uploads `artifacts/*`, so the JAR and the tarball
  land in the same draft Release alongside the Electron distributables — no further changes
  needed there.

No source versions were touched: artifacts keep their original names (the hardcoded
version in `server/app/build.gradle.kts` and `client/package-client.sh`).

## How to test

Trigger via `workflow_dispatch` with a test `tag_name` (e.g. `v0.0.0-test`). The release is
created as a **draft**, so it stays private:

1. Confirm the `build-server-client` job succeeds and produces both artifacts.
2. Check the draft Release contains `ambrosia-*.jar` and `ambrosia-client-*.tar.gz` next to
   the Electron binaries.
3. Delete the draft.

Locally, the same commands can be reproduced:

```bash
cd server && ./gradlew jar          # -> server/app/build/libs/ambrosia-0.7.0-beta.jar
cd client && ./package-client.sh    # -> client/dist/ambrosia-client-0.7.0-beta.tar.gz