### PR TITLE
Fix: Allow currency search by currency name

### DIFF
--- a/client/src/components/pages/Onboarding/AddBusinessData.jsx
+++ b/client/src/components/pages/Onboarding/AddBusinessData.jsx
@@ -2,9 +2,10 @@
 
 import { useState, useMemo } from "react";
 
-import { Input, Autocomplete, AutocompleteItem } from "@heroui/react";
+import { Input } from "@heroui/react";
 import { useTranslations, useLocale } from "next-intl";
 
+import { CurrencyInput } from "@components/shared/CurrencyInput";
 import { ImageUploader } from "@components/shared/ImageUploader";
 
 import { CURRENCIES_EN } from "./utils/currencies_en";
@@ -94,26 +95,14 @@ export function BusinessDetailsStep({ data, onChange }) {
           errorMessage={rfcError}
         />
 
-        <Autocomplete
+        <CurrencyInput
+          currencies={CURRENCIES}
           label={t("step3.fields.businessCurrency")}
           defaultSelectedKey={data.businessCurrency}
           isInvalid={!data.businessCurrency}
           errorMessage={t("step3.fields.businessCurrencyError")}
           onSelectionChange={handleCurrencyChange}
-          isClearable
-          allowsCustomValue={false}
-          menuTrigger="focus"
-          inputProps={{
-            onClick: (e) => e.target.select(),
-          }}
-          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().includes(inputValue.toLowerCase())}
-        >
-          {CURRENCIES.map((currency) => (
-            <AutocompleteItem key={currency.code} textValue={`${currency.code} - ${currency.name}`}>
-              {`${currency.code}  -  ${currency.name}`}
-            </AutocompleteItem>
-          ))}
-        </Autocomplete>
+        />
 
         <ImageUploader
           title={data.businessType === "store" ? t("step3.fields.businessLogoLabelStore") : t("step3.fields.businessLogoLabelRestaurant")}

--- a/client/src/components/pages/Onboarding/AddBusinessData.jsx
+++ b/client/src/components/pages/Onboarding/AddBusinessData.jsx
@@ -106,7 +106,7 @@ export function BusinessDetailsStep({ data, onChange }) {
           inputProps={{
             onClick: (e) => e.target.select(),
           }}
-          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().startsWith(inputValue.toLowerCase())}
+          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().includes(inputValue.toLowerCase())}
         >
           {CURRENCIES.map((currency) => (
             <AutocompleteItem key={currency.code} textValue={`${currency.code} - ${currency.name}`}>

--- a/client/src/components/pages/Onboarding/__tests__/AddBusinessData.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/AddBusinessData.test.jsx
@@ -7,21 +7,33 @@ import { BusinessDetailsStep } from "../AddBusinessData";
 jest.mock("@heroui/react", () => ({
   ...jest.requireActual("@heroui/react"),
   Autocomplete: ({
-    children, label, onSelectionChange, selectedKey,
-  }) => (
-    <div data-testid="autocomplete-wrapper">
-      <label htmlFor="currency-select">{label}</label>
-      <select
-        id="currency-select"
-        aria-label={label}
-        value={selectedKey}
-        onChange={(e) => onSelectionChange(e.target.value)}
-      >
-        <option value="">Select currency</option>
-        {children}
-      </select>
-    </div>
-  ),
+    children, label, onSelectionChange, selectedKey, defaultFilter,
+  }) => {
+    const [inputValue, setInputValue] = require("react").useState("");
+    const filteredChildren = require("react").Children.toArray(children).filter((child) => (
+      !inputValue || defaultFilter(child.props.textValue, inputValue)
+    ));
+
+    return (
+      <div data-testid="autocomplete-wrapper">
+        <label htmlFor="currency-search">{label}</label>
+        <input
+          id="currency-search"
+          aria-label={label}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+        />
+        <select
+          aria-label={`${label} options`}
+          value={selectedKey}
+          onChange={(e) => onSelectionChange(e.target.value)}
+        >
+          <option value="">Select currency</option>
+          {filteredChildren}
+        </select>
+      </div>
+    );
+  },
   AutocompleteItem: ({ children, textValue }) => (
     <option value={children.toString().split(" ")[0]}>
       {textValue || children}
@@ -89,12 +101,21 @@ describe("Step 3 Business Details", () => {
 
   it("calls onChange when currency changes", async () => {
     remderBusinessDetails();
-    const select = screen.getByRole("combobox");
+    const select = screen.getByLabelText("step3.fields.businessCurrency options");
     fireEvent.change(select, { target: { value: "USD" } });
 
     expect(mockChange).toHaveBeenCalledWith(
       expect.objectContaining({ businessCurrency: "USD" }),
     );
+  });
+
+  it("filters currencies by currency name", async () => {
+    remderBusinessDetails();
+    const searchInput = screen.getByLabelText("step3.fields.businessCurrency");
+    fireEvent.change(searchInput, { target: { value: "mex" } });
+
+    expect(screen.getByRole("option", { name: "MXN - Peso mexicano" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "USD - United States Dollar" })).not.toBeInTheDocument();
   });
 
   it("handles logo upload and preview", async () => {

--- a/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
@@ -26,7 +26,7 @@ export function CurrencyCard({ selectedCurrency, currencies, onCurrencyChange })
           inputProps={{
             onClick: (event) => event.target.select(),
           }}
-          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().startsWith(inputValue.toLowerCase())}
+          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().includes(inputValue.toLowerCase())}
         >
           {currencies.map((currency) => (
             <AutocompleteItem key={currency.code} textValue={`${currency.code} - ${currency.name}`}>

--- a/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Card, CardBody, CardHeader, Autocomplete, AutocompleteItem } from "@heroui/react";
+import { Card, CardBody, CardHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
+
+import { CurrencyInput } from "@components/shared/CurrencyInput";
 
 export function CurrencyCard({ selectedCurrency, currencies, onCurrencyChange }) {
   const settingsTranslations = useTranslations("settings");
@@ -14,26 +16,14 @@ export function CurrencyCard({ selectedCurrency, currencies, onCurrencyChange })
         </h2>
       </CardHeader>
       <CardBody>
-        <Autocomplete
+        <CurrencyInput
+          currencies={currencies}
           className="w-full sm:max-w-xs"
           size="sm"
           label={settingsTranslations("cardCurrency.currencyLabel")}
           selectedKey={selectedCurrency}
           onSelectionChange={onCurrencyChange}
-          allowsCustomValue={false}
-          isClearable
-          menuTrigger="focus"
-          inputProps={{
-            onClick: (event) => event.target.select(),
-          }}
-          defaultFilter={(textValue, inputValue) => textValue.toLowerCase().includes(inputValue.toLowerCase())}
-        >
-          {currencies.map((currency) => (
-            <AutocompleteItem key={currency.code} textValue={`${currency.code} - ${currency.name}`}>
-              {`${currency.code}  -  ${currency.name}`}
-            </AutocompleteItem>
-          ))}
-        </Autocomplete>
+        />
       </CardBody>
     </Card>
   );

--- a/client/src/components/pages/Store/Settings/Currency/__tests__/CurrencyCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/__tests__/CurrencyCard.test.jsx
@@ -7,21 +7,33 @@ import { CurrencyCard } from "../CurrencyCard";
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   const Autocomplete = ({
-    children, label, onSelectionChange, selectedKey,
-  }) => (
-    <div data-testid="autocomplete-wrapper">
-      <label htmlFor="currency-select">{label}</label>
-      <select
-        id="currency-select"
-        aria-label={label}
-        value={selectedKey ?? ""}
-        onChange={(event) => onSelectionChange(event.target.value)}
-      >
-        <option value="">Select currency</option>
-        {children}
-      </select>
-    </div>
-  );
+    children, label, onSelectionChange, selectedKey, defaultFilter,
+  }) => {
+    const [inputValue, setInputValue] = require("react").useState("");
+    const filteredChildren = require("react").Children.toArray(children).filter((child) => (
+      !inputValue || defaultFilter(child.props.textValue, inputValue)
+    ));
+
+    return (
+      <div data-testid="autocomplete-wrapper">
+        <label htmlFor="currency-search">{label}</label>
+        <input
+          id="currency-search"
+          aria-label={label}
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+        />
+        <select
+          aria-label={`${label} options`}
+          value={selectedKey ?? ""}
+          onChange={(event) => onSelectionChange(event.target.value)}
+        >
+          <option value="">Select currency</option>
+          {filteredChildren}
+        </select>
+      </div>
+    );
+  };
   const AutocompleteItem = ({ children, textValue }) => {
     const code = textValue ? textValue.split(" ")[0] : children.toString().split(" ")[0];
     return (
@@ -99,7 +111,7 @@ describe("CurrencyCard", () => {
 
     it("pre-selects the current currency", async () => {
       await act(async () => { renderCard({ selectedCurrency: "EUR" }); });
-      const select = screen.getByLabelText("cardCurrency.currencyLabel");
+      const select = screen.getByLabelText("cardCurrency.currencyLabel options");
       expect(select.value).toBe("EUR");
     });
   });
@@ -109,12 +121,22 @@ describe("CurrencyCard", () => {
       const mockOnChange = jest.fn();
       await act(async () => { renderCard({ onCurrencyChange: mockOnChange }); });
 
-      const select = screen.getByLabelText("cardCurrency.currencyLabel");
+      const select = screen.getByLabelText("cardCurrency.currencyLabel options");
       fireEvent.change(select, { target: { value: "MXN" } });
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith("MXN");
       });
+    });
+
+    it("filters currencies by currency name", async () => {
+      await act(async () => { renderCard(); });
+
+      const searchInput = screen.getByLabelText("cardCurrency.currencyLabel");
+      fireEvent.change(searchInput, { target: { value: "mex" } });
+
+      expect(screen.getByRole("option", { name: "MXN - Mexican Peso" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "USD - United States Dollar" })).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/shared/CurrencyInput.jsx
+++ b/client/src/components/shared/CurrencyInput.jsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
+
+export function currencySearchFilter(textValue, inputValue) {
+  return textValue.toLowerCase().includes(inputValue.toLowerCase());
+}
+
+export function CurrencyInput({
+  currencies,
+  label,
+  onSelectionChange,
+  selectedKey,
+  defaultSelectedKey,
+  className,
+  size,
+  isInvalid,
+  errorMessage,
+}) {
+  return (
+    <Autocomplete
+      className={className}
+      size={size}
+      label={label}
+      selectedKey={selectedKey}
+      defaultSelectedKey={defaultSelectedKey}
+      onSelectionChange={onSelectionChange}
+      isInvalid={isInvalid}
+      errorMessage={errorMessage}
+      isClearable
+      allowsCustomValue={false}
+      menuTrigger="focus"
+      inputProps={{
+        onClick: (event) => event.target.select(),
+      }}
+      defaultFilter={currencySearchFilter}
+    >
+      {currencies.map((currency) => (
+        <AutocompleteItem key={currency.code} textValue={`${currency.code} - ${currency.name}`}>
+          {`${currency.code}  -  ${currency.name}`}
+        </AutocompleteItem>
+      ))}
+    </Autocomplete>
+  );
+}

--- a/client/src/components/shared/__tests__/CurrencyInput.test.jsx
+++ b/client/src/components/shared/__tests__/CurrencyInput.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { CurrencyInput } from "../CurrencyInput";
+
+jest.mock("@heroui/react", () => ({
+  Autocomplete: ({
+    children,
+    label,
+    onSelectionChange,
+    selectedKey,
+    defaultSelectedKey,
+    defaultFilter,
+  }) => {
+    const [inputValue, setInputValue] = require("react").useState("");
+    const filteredChildren = require("react").Children.toArray(children).filter((child) => (
+      !inputValue || defaultFilter(child.props.textValue, inputValue)
+    ));
+
+    return (
+      <div>
+        <label htmlFor="currency-search">{label}</label>
+        <input
+          id="currency-search"
+          aria-label={label}
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+        />
+        <select
+          aria-label={`${label} options`}
+          value={selectedKey ?? defaultSelectedKey ?? ""}
+          onChange={(event) => onSelectionChange(event.target.value)}
+        >
+          <option value="">Select currency</option>
+          {filteredChildren}
+        </select>
+      </div>
+    );
+  },
+  AutocompleteItem: ({ children, textValue }) => {
+    const code = textValue ? textValue.split(" ")[0] : children.toString().split(" ")[0];
+    return <option value={code}>{textValue || children}</option>;
+  },
+}));
+
+const currencies = [
+  { code: "USD", name: "United States Dollar" },
+  { code: "EUR", name: "Euro" },
+  { code: "MXN", name: "Mexican Peso" },
+];
+
+describe("CurrencyInput", () => {
+  it("filters currencies by currency name", () => {
+    render(
+      <CurrencyInput
+        currencies={currencies}
+        label="Currency"
+        selectedKey="USD"
+        onSelectionChange={jest.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "mex" } });
+
+    expect(screen.getByRole("option", { name: "MXN - Mexican Peso" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "USD - United States Dollar" })).not.toBeInTheDocument();
+  });
+
+  it("calls onSelectionChange when a currency is selected", () => {
+    const onSelectionChange = jest.fn();
+    render(
+      <CurrencyInput
+        currencies={currencies}
+        label="Currency"
+        selectedKey="USD"
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Currency options"), { target: { value: "MXN" } });
+
+    expect(onSelectionChange).toHaveBeenCalledWith("MXN");
+  });
+});


### PR DESCRIPTION
  - Allow currency autocomplete search to match currency names, not only currency codes.
  - Add a shared `CurrencyInput` component for the repeated currency picker logic.
  - Use the shared component in both Settings and Onboarding.
  - Add focused regression coverage for searching by currency name, for example `mex` matching `MXN - Mexican Peso`.

<img width="513" height="379" alt="Screenshot From 2026-06-25 20-10-29" src="https://github.com/user-attachments/assets/2f85ac12-5b53-4aad-bcd7-34de586528d2" />

<img width="513" height="379" alt="Screenshot From 2026-06-25 20-10-45" src="https://github.com/user-attachments/assets/80243b53-1ad0-40b7-bc48-7ce8a3f5face" />