### PR TITLE
fix: pin login view

### DIFF
--- a/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
@@ -122,7 +122,7 @@ export default function PinLogin() {
   };
 
   return (
-    <div className="min-h-screen gradient-fresh flex items-center justify-center p-4">
+    <div className="min-h-screen gradient-fresh flex items-center justify-center p-4 overflow-x-hidden">
       <Card className="w-full max-w-md rounded-lg shadow-lg mx-auto my-auto">
         <CardHeader className="text-center space-y-3 pb-4 flex flex-col items-center justify-center">
           <BusinessHeader
@@ -131,7 +131,7 @@ export default function PinLogin() {
           />
         </CardHeader>
 
-        <CardBody className="space-y-4 px-6 pb-6">
+        <CardBody className="space-y-4 px-3 sm:px-6 pb-6">
           <EmployeeSelect
             employees={employees}
             selectedUser={selectedUser}

--- a/client/src/components/pages/Auth/PinLogin/PinPad.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinPad.jsx
@@ -72,14 +72,14 @@ export function PinPad({ pin, error, isLoading, lockedUntil, onNumberClick, onDe
         </div>
       ) : null}
 
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-3 gap-2 sm:gap-4">
         {NUMBER_PAD.flat().map((number, index) => (
           <Button
             key={index}
             color="default"
             variant={number ? "bordered" : "light"}
             size="lg"
-            className={`h-14 text-xl font-bold bg-white border border-primary-400 shadow-sm hover:shadow-md active:scale-95 transition-all ${!number && "invisible"}`}
+            className={`min-w-0 h-14 text-xl font-bold bg-white border border-primary-400 shadow-sm hover:shadow-md active:scale-95 transition-all ${!number && "invisible"}`}
             onPress={() => number && onNumberClick(number)}
             isDisabled={isLoading || isLocked || !number}
           >
@@ -88,7 +88,7 @@ export function PinPad({ pin, error, isLoading, lockedUntil, onNumberClick, onDe
         ))}
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-2 gap-2 sm:gap-4">
         <Button
           variant="bordered"
           size="md"


### PR DESCRIPTION
## Changes:

- Fix PIN login layout breaking on iPhone with Display Zoom enabled: add `min-w-0` to numpad buttons to override HeroUI's internal `min-width` and allow the grid to distribute column widths correctly; reduce grid gaps and card body padding on small viewports; add `overflow-x-hidden` to the login wrapper

**Screenshots**:

<img width="596" height="974" alt="imagen" src="https://github.com/user-attachments/assets/749ca1cc-ec50-4a5d-9393-dd5618a0f657" />
