### PR TITLE
fix product cart with display zoom active on iPhones.

### DIFF
--- a/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/ProductsCard.jsx
@@ -17,7 +17,7 @@ export function ProductsCard({ product, status, normalizeNumber, formatAmount, c
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-row items-stretch gap-3 p-3 justify-between">
-        <div className="flex justify-center w-16 overflow-hidden rounded-md bg-gray-100">
+        <div className="flex justify-center w-16 shrink-0 overflow-hidden rounded-md bg-gray-100">
           {imageUrl ? (
             <Image
               removeWrapper
@@ -31,8 +31,8 @@ export function ProductsCard({ product, status, normalizeNumber, formatAmount, c
             </div>
           )}
         </div>
-        <div className="flex flex-col justify-center">
-          <p className="font-medium truncate text-sm my-1">{product.name}</p>
+        <div className="flex flex-col justify-center flex-1 min-w-0">
+          <p className="font-medium wrap-break-word text-sm my-1">{product.name}</p>
           <p className="text-green-800 font-semibold text-sm my-1">{formatAmount(product.priceCents)}</p>
           <div className="flex gap-1.5 my-1">
             <Chip


### PR DESCRIPTION
## Changes:

- Fix product list mobile cards losing their image area on narrow viewports (Display Zoom / large font on iPhone): add `shrink-0` to the image container, `flex-1 min-w-0` to the content div, and replace `truncate` with `wrap-break-word` so full product names are always readable

**Screenshots**:

<img width="576" height="864" alt="imagen" src="https://github.com/user-attachments/assets/13329325-2248-408f-8983-9fa2941c8eb9" />
