### PR TITLE
Feature/order details

### DIFF
--- a/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
+++ b/client/src/components/pages/Store/Orders/OrderDetailsModal.jsx
@@ -4,6 +4,8 @@ import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from
 import { useTranslations } from "next-intl";
 
 import { AmountDisplay } from "@/components/shared/AmountDisplay";
+import { CopyButton } from "@/components/shared/CopyButton";
+import { OrderProductsTable } from "@/components/shared/OrderProductsTable";
 import formatDate from "@lib/formatDate";
 
 import { StatusChip } from "./OrdersList/StatusChip";
@@ -21,56 +23,89 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, curren
     exchangeRateAtPayment,
     exchangeRateCurrency,
     fiatAmountAtPayment,
+    paymentHash,
+    items,
   } = order ?? {};
 
   return (
     <Modal
       isOpen={isOpen}
       onOpenChange={onClose}
+      size="md"
+      scrollBehavior="inside"
       backdrop="blur"
-      shouldBlockScroll={false}
       classNames={{
         backdrop: "backdrop-blur-xs bg-white/10",
-        wrapper: "items-start h-auto",
-        base: "my-auto overflow-hidden",
-        body: "overflow-y-auto max-h-[65vh]",
+        base: "my-auto",
       }}
     >
       <ModalContent>
-        <ModalHeader>{ordersTranslations("details.title")}</ModalHeader>
-        <ModalBody>
-          <div className="space-y-3 text-sm text-deep">
-            <DetailRow label={ordersTranslations("details.id")} value={id} />
-            <DetailRow label={ordersTranslations("details.user")} value={userName ?? ordersTranslations("details.unassigned")} />
-            <DetailRow
-              label={ordersTranslations("details.status")}
-              value={status ? <StatusChip status={status} /> : ordersTranslations("details.unassigned")}
-            />
-            <DetailRow
-              label={ordersTranslations("details.paymentMethod")}
-              value={paymentMethod || ordersTranslations("details.noPayment")}
-            />
-            <DetailRow
-              label={ordersTranslations("details.total")}
-              value={
-                satoshiAmount != null
-                  ? (
-                    <AmountDisplay
-                      satoshis={satoshiAmount}
-                      exchangeRateAtSale={exchangeRateAtPayment}
-                      exchangeRateCurrency={exchangeRateCurrency}
-                      fiatAmountAtPayment={fiatAmountAtPayment}
-                      currentRate={currentRate}
-                    /> ?? formatAmount(total * 100)
-                    )
-                  : formatAmount(total * 100 ?? 0)
-              }
-            />
-            <DetailRow
-              label={ordersTranslations("details.createdAt")}
-              value={createdAt ? formatDate(createdAt) : ordersTranslations("details.unassigned")}
-            />
-          </div>
+        <ModalHeader className="flex flex-col gap-0.5 pb-2">
+          <span>{ordersTranslations("details.title")}</span>
+          {id && <span className="font-mono text-sm font-normal text-gray-400">#{id.slice(0, 8)}</span>}
+        </ModalHeader>
+        <ModalBody className="pb-6">
+          {order && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <MetaField
+                  label={ordersTranslations("details.createdAt")}
+                  value={createdAt ? formatDate(createdAt) : "—"}
+                />
+                <MetaField label={ordersTranslations("details.user")} value={userName ?? "—"} />
+                <MetaField
+                  label={ordersTranslations("details.paymentMethod")}
+                  value={paymentMethod || ordersTranslations("details.noPayment")}
+                />
+                <MetaField
+                  label={ordersTranslations("details.status")}
+                  value={status ? <StatusChip status={status} /> : "—"}
+                />
+                {paymentHash && (
+                  <div className="col-span-2">
+                    <HashRow
+                      label={ordersTranslations("details.lightning.paymentHash")}
+                      value={paymentHash}
+                      copyLabel={ordersTranslations("details.lightning.copy")}
+                    />
+                  </div>
+                )}
+              </div>
+
+              {items?.length > 0 && (
+                <div className="border-t border-gray-100 pt-3">
+                  <OrderProductsTable
+                    items={items}
+                    formatAmount={formatAmount}
+                    labels={{
+                      products: ordersTranslations("details.products"),
+                      quantity: ordersTranslations("details.quantity"),
+                      unitPrice: ordersTranslations("details.unitPrice"),
+                      subtotal: ordersTranslations("details.subtotal"),
+                    }}
+                  />
+                </div>
+              )}
+
+              <div className="border-t border-gray-200 pt-3 flex justify-between items-center">
+                <span className="font-semibold text-sm">{ordersTranslations("details.total")}</span>
+                <div className="font-bold text-green-700">
+                  {satoshiAmount != null
+                    ? (
+                      <AmountDisplay
+                        satoshis={satoshiAmount}
+                        exchangeRateAtSale={exchangeRateAtPayment}
+                        exchangeRateCurrency={exchangeRateCurrency}
+                        fiatAmountAtPayment={fiatAmountAtPayment}
+                        currentRate={currentRate}
+                      /> ?? formatAmount(total * 100)
+                      )
+                    : formatAmount(total * 100 ?? 0)}
+                </div>
+              </div>
+
+            </div>
+          )}
         </ModalBody>
         <ModalFooter>
           <Button
@@ -86,11 +121,24 @@ export function OrderDetailsModal({ order, isOpen, onClose, formatAmount, curren
   );
 }
 
-function DetailRow({ label, value }) {
+function MetaField({ label, value }) {
   return (
-    <div className="flex justify-between gap-4">
-      <span className="text-gray-500">{label}</span>
-      <span className="font-semibold wrap-break-words text-right">{value}</span>
+    <div>
+      <p className="text-xs text-gray-400">{label}</p>
+      <div className="font-medium">{value}</div>
+    </div>
+  );
+}
+
+function HashRow({ label, value, copyLabel }) {
+  const truncated = `${value.slice(0, 12)}…${value.slice(-8)}`;
+  return (
+    <div>
+      <p className="text-xs text-gray-400 mb-1">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-xs text-gray-700" title={value}>{truncated}</span>
+        <CopyButton value={value} label={copyLabel} size="sm" />
+      </div>
     </div>
   );
 }

--- a/client/src/components/pages/Store/Orders/__tests__/OrderDetailsModal.test.jsx
+++ b/client/src/components/pages/Store/Orders/__tests__/OrderDetailsModal.test.jsx
@@ -23,9 +23,7 @@ jest.mock("@heroui/react", () => {
   const ModalBody = ({ children }) => <div>{children}</div>;
   const ModalFooter = ({ children }) => <div>{children}</div>;
   const Button = ({ onPress, children }) => (
-    <button type="button" onClick={onPress}>
-      {children}
-    </button>
+    <button type="button" onClick={onPress}>{children}</button>
   );
   const Chip = ({ children }) => <span>{children}</span>;
 
@@ -66,7 +64,7 @@ describe("OrderDetailsModal", () => {
     );
 
     expect(screen.getByText("details.title")).toBeInTheDocument();
-    expect(screen.getByText("order-1")).toBeInTheDocument();
+    expect(screen.getByText("#order-1")).toBeInTheDocument();
     expect(screen.getByText("Luis")).toBeInTheDocument();
     expect(screen.getByText("Cash")).toBeInTheDocument();
     expect(screen.getByText("formatted-date")).toBeInTheDocument();
@@ -132,7 +130,7 @@ describe("OrderDetailsModal", () => {
     expect(screen.queryByText(/amount-display/)).not.toBeInTheDocument();
   });
 
-  it("renders fallbacks when order is missing", () => {
+  it("renders only the title when order is null", () => {
     render(
       <OrderDetailsModal
         order={null}
@@ -143,6 +141,7 @@ describe("OrderDetailsModal", () => {
       />,
     );
 
-    expect(screen.getAllByText("details.unassigned").length).toBeGreaterThan(0);
+    expect(screen.getByText("details.title")).toBeInTheDocument();
+    expect(screen.queryByText("details.user")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Orders/locales/en.js
+++ b/client/src/components/pages/Store/Orders/locales/en.js
@@ -58,7 +58,6 @@ const ordersEn = {
     },
     details: {
       title: "Order details",
-      id: "Order ID",
       user: "User",
       status: "Status",
       paymentMethod: "Payment Method",
@@ -67,6 +66,14 @@ const ordersEn = {
       close: "Close",
       unassigned: "Unassigned",
       noPayment: "Payment not registered",
+      products: "Products",
+      quantity: "Quantity",
+      unitPrice: "Unit Price",
+      subtotal: "Subtotal",
+      lightning: {
+        paymentHash: "Payment hash",
+        copy: "Copy",
+      },
     },
   },
 };

--- a/client/src/components/pages/Store/Orders/locales/es.js
+++ b/client/src/components/pages/Store/Orders/locales/es.js
@@ -58,7 +58,6 @@ const ordersEs = {
     },
     details: {
       title: "Detalles de la orden",
-      id: "ID de la orden",
       user: "Usuario",
       status: "Estado",
       paymentMethod: "Método de pago",
@@ -67,6 +66,14 @@ const ordersEs = {
       close: "Cerrar",
       unassigned: "Sin asignar",
       noPayment: "Pago no registrado",
+      products: "Productos",
+      quantity: "Cant.",
+      unitPrice: "Precio Unit.",
+      subtotal: "Subtotal",
+      lightning: {
+        paymentHash: "Hash del pago",
+        copy: "Copiar",
+      },
     },
   },
 };

--- a/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrderDetailModal.jsx
@@ -1,11 +1,9 @@
 "use client";
-import {
-  Modal, ModalBody, ModalContent, ModalHeader,
-  Table, TableHeader, TableColumn, TableBody, TableRow, TableCell,
-} from "@heroui/react";
+import { Modal, ModalBody, ModalContent, ModalHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { AmountDisplay } from "@/components/shared/AmountDisplay";
+import { OrderProductsTable } from "@/components/shared/OrderProductsTable";
 import formatDate from "@lib/formatDate";
 
 export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }) {
@@ -59,28 +57,16 @@ export function OrderDetailModal({ order, formatCurrency, currentRate, onClose }
               </div>
 
               <div className="border-t border-gray-100 pt-3">
-                <Table
-                  removeWrapper
-                  aria-label={reportsTranslations("orders.detailTitle")}
-                  classNames={{ th: "text-xs text-gray-400 bg-transparent font-medium px-0", td: "px-0" }}
-                >
-                  <TableHeader>
-                    <TableColumn align="start">{reportsTranslations("orders.products")}</TableColumn>
-                    <TableColumn align="center">{reportsTranslations("sales.quantity")}</TableColumn>
-                    <TableColumn align="end">{reportsTranslations("sales.price")}</TableColumn>
-                    <TableColumn align="end">{reportsTranslations("orders.subtotal")}</TableColumn>
-                  </TableHeader>
-                  <TableBody>
-                    {items?.map((item, itemIndex) => (
-                      <TableRow key={itemIndex}>
-                        <TableCell className="py-2 text-gray-700">{item.productName}</TableCell>
-                        <TableCell className="py-2 text-center text-gray-500">×{item.quantity}</TableCell>
-                        <TableCell className="py-2 text-right text-gray-500">{formatCurrency(item.priceAtOrder)}</TableCell>
-                        <TableCell className="py-2 text-right font-semibold">{formatCurrency(item.quantity * item.priceAtOrder)}</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                <OrderProductsTable
+                  items={items ?? []}
+                  formatAmount={formatCurrency}
+                  labels={{
+                    products: reportsTranslations("orders.products"),
+                    quantity: reportsTranslations("sales.quantity"),
+                    unitPrice: reportsTranslations("sales.price"),
+                    subtotal: reportsTranslations("orders.subtotal"),
+                  }}
+                />
               </div>
 
               <div className="border-t border-gray-200 pt-3 flex justify-between items-center">

--- a/client/src/components/shared/OrderProductsTable.jsx
+++ b/client/src/components/shared/OrderProductsTable.jsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from "@heroui/react";
+
+export function OrderProductsTable({ items, formatAmount, labels }) {
+  return (
+    <Table
+      removeWrapper
+      aria-label={labels.products}
+      classNames={{ th: "text-xs text-gray-400 bg-transparent font-medium px-1 whitespace-nowrap", td: "px-1" }}
+    >
+      <TableHeader>
+        <TableColumn align="start">{labels.products}</TableColumn>
+        <TableColumn align="center">{labels.quantity}</TableColumn>
+        <TableColumn align="end">{labels.unitPrice}</TableColumn>
+        <TableColumn align="end">{labels.subtotal}</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {items.map((item, index) => (
+          <TableRow key={index}>
+            <TableCell className="py-2 text-gray-700">{item.productName}</TableCell>
+            <TableCell className="py-2 text-center text-gray-500">×{item.quantity}</TableCell>
+            <TableCell className="py-2 text-right text-gray-500">{formatAmount(item.priceAtOrder)}</TableCell>
+            <TableCell className="py-2 text-right font-semibold">{formatAmount(item.quantity * item.priceAtOrder)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/client/src/components/shared/__tests__/OrderProductsTable.test.jsx
+++ b/client/src/components/shared/__tests__/OrderProductsTable.test.jsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+
+import { OrderProductsTable } from "../OrderProductsTable";
+
+jest.mock("@heroui/react", () => ({
+  Table: ({ children }) => <table>{children}</table>,
+  TableHeader: ({ children }) => <thead><tr>{children}</tr></thead>,
+  TableColumn: ({ children }) => <th>{children}</th>,
+  TableBody: ({ children }) => <tbody>{children}</tbody>,
+  TableRow: ({ children }) => <tr>{children}</tr>,
+  TableCell: ({ children }) => <td>{children}</td>,
+}));
+
+const LABELS = {
+  products: "Products",
+  quantity: "Qty",
+  unitPrice: "Unit Price",
+  subtotal: "Subtotal",
+};
+
+const formatAmount = (cents) => `$${cents}`;
+
+describe("OrderProductsTable", () => {
+  it("renders column headers from labels", () => {
+    render(<OrderProductsTable items={[]} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.getByText("Products")).toBeInTheDocument();
+    expect(screen.getByText("Qty")).toBeInTheDocument();
+    expect(screen.getByText("Unit Price")).toBeInTheDocument();
+    expect(screen.getByText("Subtotal")).toBeInTheDocument();
+  });
+
+  it("renders a row for each item", () => {
+    const items = [
+      { productName: "Tacos", quantity: 2, priceAtOrder: 500 },
+      { productName: "Soda", quantity: 1, priceAtOrder: 200 },
+    ];
+
+    render(<OrderProductsTable items={items} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.getByText("Tacos")).toBeInTheDocument();
+    expect(screen.getByText("Soda")).toBeInTheDocument();
+  });
+
+  it("renders quantity with × prefix", () => {
+    const items = [{ productName: "Burger", quantity: 3, priceAtOrder: 1000 }];
+
+    render(<OrderProductsTable items={items} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.getByText("×3")).toBeInTheDocument();
+  });
+
+  it("renders unit price using formatAmount", () => {
+    const items = [{ productName: "Fries", quantity: 2, priceAtOrder: 750 }];
+
+    render(<OrderProductsTable items={items} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.getByText("$750")).toBeInTheDocument();
+  });
+
+  it("renders subtotal as quantity × priceAtOrder", () => {
+    const items = [{ productName: "Pizza", quantity: 2, priceAtOrder: 1200 }];
+
+    render(<OrderProductsTable items={items} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.getByText("$2400")).toBeInTheDocument();
+  });
+
+  it("renders nothing in the table body when items is empty", () => {
+    render(<OrderProductsTable items={[]} formatAmount={formatAmount} labels={LABELS} />);
+
+    expect(screen.queryByRole("row", { name: /tacos/i })).not.toBeInTheDocument();
+  });
+});

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -150,6 +150,13 @@ data class Order(
 )
 
 @Serializable
+data class OrderItem(
+    val productName: String,
+    val quantity: Int,
+    val priceAtOrder: Int,
+)
+
+@Serializable
 data class OrderWithPayment(
     val id: String,
     val userId: String,
@@ -164,6 +171,8 @@ data class OrderWithPayment(
     val exchangeRateAtPayment: Double? = null,
     val exchangeRateCurrency: String? = null,
     val fiatAmountAtPayment: Double? = null,
+    val paymentHash: String? = null,
+    val items: List<OrderItem> = emptyList(),
 )
 
 data class OrderWithPaymentFilters(

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
@@ -25,6 +25,7 @@ import pos.ambrosia.db.tables.TicketPaymentsTable
 import pos.ambrosia.db.tables.TicketsTable
 import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.logger
+import pos.ambrosia.models.OrderItem
 import pos.ambrosia.models.OrderWithPayment
 import pos.ambrosia.models.OrderWithPaymentFilters
 import pos.ambrosia.models.ProductSaleItem
@@ -53,13 +54,17 @@ class ReportService {
                    MAX(p.satoshi_amount) AS satoshi_amount,
                    MAX(p.exchange_rate_at_payment) AS exchange_rate_at_payment,
                    MAX(p.exchange_rate_currency) AS exchange_rate_currency,
-                   MAX(p.fiat_amount_at_payment) AS fiat_amount_at_payment
+                   MAX(p.fiat_amount_at_payment) AS fiat_amount_at_payment,
+                   MAX(p.payment_hash) AS payment_hash,
+                   GROUP_CONCAT(pr.name || '|||' || op.quantity || '|||' || op.price_at_order, ';;;') AS items
             FROM orders o
             LEFT JOIN users u ON u.id = o.user_id
             LEFT JOIN tickets t ON t.order_id = o.id
             LEFT JOIN ticket_payments tp ON tp.ticket_id = t.id
             LEFT JOIN payments p ON p.id = tp.payment_id
             LEFT JOIN payment_methods pm ON pm.id = p.method_id
+            LEFT JOIN order_products op ON op.order_id = o.id
+            LEFT JOIN products pr ON pr.id = op.product_id
             WHERE o.is_deleted = 0
             """
     }
@@ -82,6 +87,22 @@ class ReportService {
 
     private fun isValidStatus(status: String): Boolean = validStatuses.contains(status)
 
+    private fun parseOrderItems(rawItems: String?): List<OrderItem> =
+        rawItems
+            ?.split(";;;")
+            ?.mapNotNull { entry ->
+                val parts = entry.split("|||")
+                if (parts.size == 3) {
+                    OrderItem(
+                        productName = parts[0],
+                        quantity = parts[1].toIntOrNull() ?: 1,
+                        priceAtOrder = parts[2].toIntOrNull() ?: 0,
+                    )
+                } else {
+                    null
+                }
+            } ?: emptyList()
+
     private fun mapResultSetToOrderWithPayment(resultSet: ResultSet): OrderWithPayment {
         val paymentNames = resultSet.getString("payment_method") ?: ""
         val paymentIdsConcat = resultSet.getString("payment_method_ids") ?: ""
@@ -102,6 +123,8 @@ class ReportService {
             exchangeRateAtPayment = (resultSet.getObject("exchange_rate_at_payment") as? Number)?.toDouble(),
             exchangeRateCurrency = resultSet.getString("exchange_rate_currency"),
             fiatAmountAtPayment = (resultSet.getObject("fiat_amount_at_payment") as? Number)?.toDouble(),
+            paymentHash = resultSet.getString("payment_hash"),
+            items = parseOrderItems(resultSet.getString("items")),
         )
     }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
@@ -650,4 +650,69 @@ class ReportServiceTest {
 
             assertEquals(0.0, result)
         }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered maps items from order_products`() =
+        runBlocking {
+            val sale = seedSale()
+            addOrderProduct(sale.orderId, productName = "Tacos", quantity = 3, priceAtOrder = 500)
+            addOrderProduct(sale.orderId, productName = "Soda", quantity = 1, priceAtOrder = 200)
+
+            val result = service.getOrdersWithPaymentsFiltered()
+
+            assertEquals(1, result.size)
+            val items = result[0].items
+            assertEquals(2, items.size)
+            val tacos = items.first { it.productName == "Tacos" }
+            assertEquals(3, tacos.quantity)
+            assertEquals(500, tacos.priceAtOrder)
+            val soda = items.first { it.productName == "Soda" }
+            assertEquals(1, soda.quantity)
+            assertEquals(200, soda.priceAtOrder)
+        }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered returns empty items list when order has no products`() =
+        runBlocking {
+            seedSale()
+
+            val result = service.getOrdersWithPaymentsFiltered()
+
+            assertEquals(1, result.size)
+            assertTrue(result[0].items.isEmpty())
+        }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered maps paymentHash when present`() =
+        runBlocking {
+            val userId = ExposedTestDb.seedUser("alice")
+            val orderId = ExposedTestDb.seedOrder(userId, status = "paid")
+            val methodId = ExposedTestDb.seedPaymentMethod("BTC")
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val paymentId =
+                ExposedTestDb.seedPayment(
+                    methodId = methodId,
+                    currencyId = currencyId,
+                    transactionId = "txn-hash",
+                    paymentHash = "abc123def456",
+                )
+            val ticketId = ExposedTestDb.seedTicket(orderId, userId)
+            ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+
+            val result = service.getOrdersWithPaymentsFiltered()
+
+            assertEquals(1, result.size)
+            assertEquals("abc123def456", result[0].paymentHash)
+        }
+
+    @Test
+    fun `getOrdersWithPaymentsFiltered returns null paymentHash when not a BTC payment`() =
+        runBlocking {
+            seedSale(paymentMethodName = "Cash")
+
+            val result = service.getOrdersWithPaymentsFiltered()
+
+            assertEquals(1, result.size)
+            assertNull(result[0].paymentHash)
+        }
 }


### PR DESCRIPTION
## Changes:

- Expose order items (products) and payment hash in the `/orders/with-payments` endpoint using GROUP_CONCAT aggregation
- Add shared `OrderProductsTable` component reused by both Reports and Orders modals
- Rewrite `OrderDetailsModal` in `/store/orders` to match Reports layout.

**Screenshots**:

<img width="938" height="1106" alt="imagen" src="https://github.com/user-attachments/assets/621ff676-c129-4089-a6f8-8367c204e648" />

 