### PR TITLE
Fix(settings): Use specific default printer toast messages

### DIFF
--- a/client/src/components/pages/Store/Settings/Printers/Printers.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/Printers.jsx
@@ -108,9 +108,9 @@ export function Printers() {
   const handleSetDefault = async (id) => {
     try {
       await setDefaultPrinterConfig(id);
-      addToast({ description: settingsTranslations("cardPrinters.updateSuccess"), color: "success" });
+      addToast({ description: settingsTranslations("cardPrinters.setDefaultSuccess"), color: "success" });
     } catch {
-      addToast({ description: settingsTranslations("cardPrinters.updateError"), color: "danger" });
+      addToast({ description: settingsTranslations("cardPrinters.setDefaultError"), color: "danger" });
     }
   };
 

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/Printers.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/Printers.test.jsx
@@ -4,6 +4,10 @@ import * as usePrintersHook from "../../../hooks/usePrinter";
 import * as useTemplatesHook from "../../../hooks/useTemplates";
 import { Printers } from "../Printers";
 
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
 jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
@@ -41,6 +45,8 @@ const defaultTemplates = {
   error: null,
   refetch: jest.fn(),
 };
+
+const { addToast } = require("@heroui/react");
 
 beforeEach(() => {
   capturedProps = null;
@@ -134,6 +140,44 @@ describe("Printers", () => {
         "Alpha",
         "Zebra",
       ]);
+    });
+  });
+
+  describe("handleSetDefault", () => {
+    it("shows specific success toast when default printer is updated", async () => {
+      const setDefaultPrinterConfig = jest.fn().mockResolvedValue({});
+      usePrintersHook.usePrinters.mockReturnValue({
+        ...defaultPrinters,
+        setDefaultPrinterConfig,
+      });
+
+      render(<Printers />);
+
+      await capturedProps.state.onSetDefaultConfig("cfg-1");
+
+      expect(setDefaultPrinterConfig).toHaveBeenCalledWith("cfg-1");
+      expect(addToast).toHaveBeenCalledWith({
+        description: "cardPrinters.setDefaultSuccess",
+        color: "success",
+      });
+    });
+
+    it("shows specific error toast when default printer update fails", async () => {
+      const setDefaultPrinterConfig = jest.fn().mockRejectedValue(new Error("failed"));
+      usePrintersHook.usePrinters.mockReturnValue({
+        ...defaultPrinters,
+        setDefaultPrinterConfig,
+      });
+
+      render(<Printers />);
+
+      await capturedProps.state.onSetDefaultConfig("cfg-1");
+
+      expect(setDefaultPrinterConfig).toHaveBeenCalledWith("cfg-1");
+      expect(addToast).toHaveBeenCalledWith({
+        description: "cardPrinters.setDefaultError",
+        color: "danger",
+      });
     });
   });
 });

--- a/client/src/components/pages/Store/Settings/Printers/locales/en.js
+++ b/client/src/components/pages/Store/Settings/Printers/locales/en.js
@@ -33,6 +33,8 @@ const printersEn = {
     saveError: "Failed to add printer",
     updateSuccess: "Printer updated successfully",
     updateError: "Failed to update printer",
+    setDefaultSuccess: "Default printer updated successfully",
+    setDefaultError: "Failed to update default printer",
     deleteSuccess: "Printer removed successfully",
     deleteError: "Failed to remove printer",
   },

--- a/client/src/components/pages/Store/Settings/Printers/locales/es.js
+++ b/client/src/components/pages/Store/Settings/Printers/locales/es.js
@@ -33,6 +33,8 @@ const printersEs = {
     saveError: "Error al agregar impresora",
     updateSuccess: "Impresora actualizada con éxito",
     updateError: "Error al actualizar impresora",
+    setDefaultSuccess: "Impresora predeterminada actualizada con éxito",
+    setDefaultError: "Error al actualizar impresora predeterminada",
     deleteSuccess: "Impresora eliminada con éxito",
     deleteError: "Error al eliminar impresora",
   },


### PR DESCRIPTION
  - Updated `handleSetDefault` in `Printers.jsx` so setting a default printer no longer reuses the generic printer update toast.
  - Added dedicated locale keys in `Printers/locales/en.js` and `Printers/locales/es.js`:
    - `cardPrinters.setDefaultSuccess`
    - `cardPrinters.setDefaultError`
  - Added focused coverage in `Printers.test.jsx` for both successful and failed default-printer updates.