### PR TITLE
Fix: Improve user toast feedback

### DIFF
--- a/client/src/components/pages/Store/Users/AddUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/AddUsersModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { addToast, Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
 import { Eye, EyeOff } from "lucide-react";
@@ -11,6 +11,39 @@ import { resolveRoleName } from "@/components/pages/Store/Users/Roles/utils/role
 export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModal, setAddUsersShowModal, addUser }) {
   const userTranslations = useTranslations();
   const [showPin, setShowPin] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
+
+  const handleSubmitAddUser = async (event) => {
+    event.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+
+    try {
+      await addUser(data);
+    } catch {
+      return;
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+    }
+
+    addToast({ description: userTranslations("users.toasts.createSuccess"), color: "success" });
+    setData({
+      userName: "",
+      userPin: "",
+      userPhone: "",
+      userEmail: "",
+      userRole: "Vendedor",
+    });
+    setAddUsersShowModal(false);
+  };
+
   return (
     <Modal
       isOpen={addUsersShowModal}
@@ -32,23 +65,7 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
         <ModalBody>
           <form
             className="space-y-4"
-            onSubmit={async (event) => {
-              event.preventDefault();
-              try {
-                await addUser(data);
-              } catch {
-                return;
-              }
-              addToast({ description: userTranslations("users.toasts.createSuccess"), color: "success" });
-              setData({
-                userName: "",
-                userPin: "",
-                userPhone: "",
-                userEmail: "",
-                userRole: "Vendedor",
-              });
-              setAddUsersShowModal(false);
-            }}
+            onSubmit={handleSubmitAddUser}
           >
             <Input
               label={userTranslations("users.modal.userNameLabel")}
@@ -129,7 +146,8 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
                 color="primary"
                 className="bg-green-800"
                 type="submit"
-                isDisabled={!data.userRole}
+                isDisabled={!data.userRole || isSubmitting}
+                isLoading={isSubmitting}
               >
                 {userTranslations("users.modal.submitButton")}
               </Button>

--- a/client/src/components/pages/Store/Users/AddUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/AddUsersModal.jsx
@@ -34,7 +34,11 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
             className="space-y-4"
             onSubmit={async (event) => {
               event.preventDefault();
-              await addUser(data);
+              try {
+                await addUser(data);
+              } catch {
+                return;
+              }
               addToast({ description: userTranslations("users.toasts.createSuccess"), color: "success" });
               setData({
                 userName: "",

--- a/client/src/components/pages/Store/Users/AddUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/AddUsersModal.jsx
@@ -2,14 +2,14 @@
 
 import { useState } from "react";
 
-import { Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
+import { addToast, Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
 import { Eye, EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { resolveRoleName } from "@/components/pages/Store/Users/Roles/utils/roleTemplates";
 
 export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModal, setAddUsersShowModal, addUser }) {
-  const t = useTranslations();
+  const userTranslations = useTranslations();
   const [showPin, setShowPin] = useState(false);
   return (
     <Modal
@@ -27,14 +27,15 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
     >
       <ModalContent>
         <ModalHeader>
-          {t("users.modal.titleAdd")}
+          {userTranslations("users.modal.titleAdd")}
         </ModalHeader>
         <ModalBody>
           <form
             className="space-y-4"
-            onSubmit={async (e) => {
-              e.preventDefault();
+            onSubmit={async (event) => {
+              event.preventDefault();
               await addUser(data);
+              addToast({ description: userTranslations("users.toasts.createSuccess"), color: "success" });
               setData({
                 userName: "",
                 userPin: "",
@@ -46,43 +47,43 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
             }}
           >
             <Input
-              label={t("users.modal.userNameLabel")}
+              label={userTranslations("users.modal.userNameLabel")}
               type="text"
-              placeholder={t("users.modal.userNamePlaceholder")}
+              placeholder={userTranslations("users.modal.userNamePlaceholder")}
               isRequired
-              errorMessage={t("users.modal.userNameError")}
+              errorMessage={userTranslations("users.modal.userNameError")}
               value={data.userName ?? ""}
-              onChange={(e) => onChange({ ...data, userName: e.target.value })}
+              onChange={(event) => onChange({ ...data, userName: event.target.value })}
             />
             <Input
-              label={t("users.modal.userEmailLabel")}
+              label={userTranslations("users.modal.userEmailLabel")}
               type="email"
-              placeholder={t("users.modal.userEmailPlaceholder")}
+              placeholder={userTranslations("users.modal.userEmailPlaceholder")}
               value={data.userEmail ?? ""}
-              onChange={(e) => onChange({ ...data, userEmail: e.target.value })}
+              onChange={(event) => onChange({ ...data, userEmail: event.target.value })}
             />
             <Input
-              label={t("users.modal.userPhoneLabel")}
+              label={userTranslations("users.modal.userPhoneLabel")}
               type="tel"
-              placeholder={t("users.modal.userPhonePlaceholder")}
+              placeholder={userTranslations("users.modal.userPhonePlaceholder")}
               maxLength={10}
               value={data.userPhone ?? ""}
-              onChange={(e) => {
-                const onlyNumbers = e.target.value.replace(/\D/g, "");
+              onChange={(event) => {
+                const onlyNumbers = event.target.value.replace(/\D/g, "");
                 onChange({ ...data, userPhone: onlyNumbers });
               }}
             />
             <Input
-              label={t("users.modal.userPinLabel")}
+              label={userTranslations("users.modal.userPinLabel")}
               type={showPin ? "text" : "password"}
-              placeholder={t("users.modal.userPinPlaceholder")}
+              placeholder={userTranslations("users.modal.userPinPlaceholder")}
               isRequired
               minLength={4}
               maxLength={4}
-              errorMessage={t("users.modal.userPinError")}
+              errorMessage={userTranslations("users.modal.userPinError")}
               value={data.userPin ?? ""}
-              onChange={(e) => {
-                const onlyNumbers = e.target.value.replace(/\D/g, "");
+              onChange={(event) => {
+                const onlyNumbers = event.target.value.replace(/\D/g, "");
                 onChange({ ...data, userPin: onlyNumbers });
               }}
               endContent={
@@ -99,15 +100,15 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
               }
             />
             <Select
-              label={t("users.modal.userRoleLabel")}
+              label={userTranslations("users.modal.userRoleLabel")}
               isRequired
               defaultSelectedKeys={[data.userRole || roles?.[0]?.id || ""]}
               value={data.userRole || roles?.[0]?.id || ""}
-              onChange={(e) => onChange({ ...data, userRole: e.target.value })}
+              onChange={(event) => onChange({ ...data, userRole: event.target.value })}
             >
               {roles.map((role) => (
                 <SelectItem key={role.id} value={role.id}>
-                  {resolveRoleName(role.role, t)}
+                  {resolveRoleName(role.role, userTranslations)}
                 </SelectItem>
               ))}
             </Select>
@@ -118,7 +119,7 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
                 className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 onPress={() => setAddUsersShowModal(false)}
               >
-                {t("users.modal.cancelButton")}
+                {userTranslations("users.modal.cancelButton")}
               </Button>
               <Button
                 color="primary"
@@ -126,7 +127,7 @@ export function AddUsersModal({ data, setData, roles, onChange, addUsersShowModa
                 type="submit"
                 isDisabled={!data.userRole}
               >
-                {t("users.modal.submitButton")}
+                {userTranslations("users.modal.submitButton")}
               </Button>
             </ModalFooter>
           </form>

--- a/client/src/components/pages/Store/Users/DeleteUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/DeleteUsersModal.jsx
@@ -1,10 +1,31 @@
 "use client";
 
+import { useRef, useState } from "react";
+
 import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 export function DeleteUsersModal({ user, deleteUsersShowModal, setDeleteUsersShowModal, onConfirm }) {
-  const t = useTranslations("users");
+  const userTranslations = useTranslations("users");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isDeletingRef = useRef(false);
+
+  const handleConfirmDeleteUser = async () => {
+    if (isDeletingRef.current) {
+      return;
+    }
+
+    isDeletingRef.current = true;
+    setIsDeleting(true);
+
+    try {
+      await onConfirm?.();
+    } finally {
+      isDeletingRef.current = false;
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <Modal
       isOpen={deleteUsersShowModal}
@@ -16,10 +37,10 @@ export function DeleteUsersModal({ user, deleteUsersShowModal, setDeleteUsersSho
       }}
     >
       <ModalContent>
-        <ModalHeader>{t("modal.titleDelete")}</ModalHeader>
+        <ModalHeader>{userTranslations("modal.titleDelete")}</ModalHeader>
         <ModalBody>
-          <p>{t("modal.subtitleDelete")}<b> {user?.name}</b>?</p>
-          <p className="text-red-500 text-sm">{t("modal.warningDelete")}</p>
+          <p>{userTranslations("modal.subtitleDelete")}<b> {user?.name}</b>?</p>
+          <p className="text-red-500 text-sm">{userTranslations("modal.warningDelete")}</p>
         </ModalBody>
         <ModalFooter>
           <Button
@@ -28,10 +49,15 @@ export function DeleteUsersModal({ user, deleteUsersShowModal, setDeleteUsersSho
             className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             onPress={() => setDeleteUsersShowModal(false)}
           >
-            {t("modal.cancelButton")}
+            {userTranslations("modal.cancelButton")}
           </Button>
-          <Button color="danger" onPress={onConfirm}>
-            {t("modal.deleteButton")}
+          <Button
+            color="danger"
+            onPress={handleConfirmDeleteUser}
+            isDisabled={isDeleting}
+            isLoading={isDeleting}
+          >
+            {userTranslations("modal.deleteButton")}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/client/src/components/pages/Store/Users/EditUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/EditUsersModal.jsx
@@ -47,7 +47,11 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
             className="space-y-4"
             onSubmit={async (event) => {
               event.preventDefault();
-              await updateUser(data);
+              try {
+                await updateUser(data);
+              } catch {
+                return;
+              }
               addToast({ description: userTranslations("users.toasts.updateSuccess"), color: "success" });
               setData({
                 userId: "",

--- a/client/src/components/pages/Store/Users/EditUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/EditUsersModal.jsx
@@ -2,14 +2,14 @@
 
 import { useState } from "react";
 
-import { Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
+import { addToast, Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
 import { Eye, EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { resolveRoleName } from "@/components/pages/Store/Users/Roles/utils/roleTemplates";
 
 export function EditUsersModal({ data, setData, roles, onChange, editUsersShowModal, setEditUsersShowModal, updateUser }) {
-  const t = useTranslations();
+  const userTranslations = useTranslations();
   const [showPin, setShowPin] = useState(false);
   const handleOnCloseModal = () => {
     setData({
@@ -40,13 +40,15 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
     >
       <ModalContent>
         <ModalHeader>
-          {t("users.modal.titleEdit")}
+          {userTranslations("users.modal.titleEdit")}
         </ModalHeader>
         <ModalBody>
           <form
             className="space-y-4"
-            onSubmit={(e) => {
-              e.preventDefault();
+            onSubmit={async (event) => {
+              event.preventDefault();
+              await updateUser(data);
+              addToast({ description: userTranslations("users.toasts.updateSuccess"), color: "success" });
               setData({
                 userId: "",
                 userName: "",
@@ -55,47 +57,46 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
                 userEmail: "",
                 userRole: "Vendedor",
               });
-              updateUser(data);
               setEditUsersShowModal(false);
             }}
           >
             <Input
-              label={t("users.modal.userNameLabel")}
+              label={userTranslations("users.modal.userNameLabel")}
               type="text"
-              placeholder={t("users.modal.userNamePlaceholder")}
+              placeholder={userTranslations("users.modal.userNamePlaceholder")}
               isRequired
-              errorMessage={t("users.modal.userNameError")}
+              errorMessage={userTranslations("users.modal.userNameError")}
               value={data.userName ?? ""}
-              onChange={(e) => onChange({ ...data, userName: e.target.value })}
+              onChange={(event) => onChange({ ...data, userName: event.target.value })}
             />
             <Input
-              label={t("users.modal.userEmailLabel")}
+              label={userTranslations("users.modal.userEmailLabel")}
               type="email"
-              placeholder={t("users.modal.userEmailPlaceholder")}
+              placeholder={userTranslations("users.modal.userEmailPlaceholder")}
               value={data?.userEmail ?? ""}
-              onChange={(e) => onChange({ ...data, userEmail: e.target.value })}
+              onChange={(event) => onChange({ ...data, userEmail: event.target.value })}
             />
             <Input
-              label={t("users.modal.userPhoneLabel")}
+              label={userTranslations("users.modal.userPhoneLabel")}
               type="tel"
-              placeholder={t("users.modal.userPhonePlaceholder")}
+              placeholder={userTranslations("users.modal.userPhonePlaceholder")}
               maxLength={10}
               value={data.userPhone ?? ""}
-              onChange={(e) => {
-                const onlyNumbers = e.target.value.replace(/\D/g, "");
+              onChange={(event) => {
+                const onlyNumbers = event.target.value.replace(/\D/g, "");
                 onChange({ ...data, userPhone: onlyNumbers });
               }}
             />
             <Input
-              label={t("users.modal.userPinLabel")}
+              label={userTranslations("users.modal.userPinLabel")}
               type={showPin ? "text" : "password"}
-              placeholder={t("users.modal.userPinPlaceholder")}
+              placeholder={userTranslations("users.modal.userPinPlaceholder")}
               minLength={4}
               maxLength={4}
-              errorMessage={t("users.modal.userPinError")}
+              errorMessage={userTranslations("users.modal.userPinError")}
               value={data.userPin ?? ""}
-              onChange={(e) => {
-                const onlyNumbers = e.target.value.replace(/\D/g, "");
+              onChange={(event) => {
+                const onlyNumbers = event.target.value.replace(/\D/g, "");
                 onChange({ ...data, userPin: onlyNumbers });
               }}
               endContent={
@@ -112,15 +113,15 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
               }
             />
             <Select
-              label={t("users.modal.userRoleLabel")}
+              label={userTranslations("users.modal.userRoleLabel")}
               isRequired
               defaultSelectedKeys={[data.userRole]}
               value={data.userRole}
-              onChange={(e) => onChange({ ...data, userRole: e.target.value })}
+              onChange={(event) => onChange({ ...data, userRole: event.target.value })}
             >
               {roles.map((role) => (
                 <SelectItem key={role.id}>
-                  {resolveRoleName(role.role, t)}
+                  {resolveRoleName(role.role, userTranslations)}
                 </SelectItem>
               ))}
             </Select>
@@ -132,7 +133,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
                 className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 onPress={() => handleOnCloseModal()}
               >
-                {t("users.modal.cancelButton")}
+                {userTranslations("users.modal.cancelButton")}
               </Button>
               <Button
                 color="primary"
@@ -140,7 +141,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
                 type="submit"
                 isDisabled={!data.userRole}
               >
-                {t("users.modal.editButton")}
+                {userTranslations("users.modal.editButton")}
               </Button>
             </ModalFooter>
           </form>

--- a/client/src/components/pages/Store/Users/EditUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/EditUsersModal.jsx
@@ -11,6 +11,7 @@ import { resolveRoleName } from "@/components/pages/Store/Users/Roles/utils/role
 export function EditUsersModal({ data, setData, roles, onChange, editUsersShowModal, setEditUsersShowModal, updateUser }) {
   const userTranslations = useTranslations();
   const [showPin, setShowPin] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const handleOnCloseModal = () => {
     setData({
       userId: "",
@@ -21,6 +22,35 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
       userRole: roles?.[0]?.id || "",
     });
 
+    setEditUsersShowModal(false);
+  };
+
+  const handleSubmitEditUser = async (event) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await updateUser(data);
+    } catch {
+      return;
+    } finally {
+      setIsSubmitting(false);
+    }
+
+    addToast({ description: userTranslations("users.toasts.updateSuccess"), color: "success" });
+    setData({
+      userId: "",
+      userName: "",
+      userPin: "",
+      userPhone: "",
+      userEmail: "",
+      userRole: "Vendedor",
+    });
     setEditUsersShowModal(false);
   };
 
@@ -45,24 +75,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
         <ModalBody>
           <form
             className="space-y-4"
-            onSubmit={async (event) => {
-              event.preventDefault();
-              try {
-                await updateUser(data);
-              } catch {
-                return;
-              }
-              addToast({ description: userTranslations("users.toasts.updateSuccess"), color: "success" });
-              setData({
-                userId: "",
-                userName: "",
-                userPin: "",
-                userPhone: "",
-                userEmail: "",
-                userRole: "Vendedor",
-              });
-              setEditUsersShowModal(false);
-            }}
+            onSubmit={handleSubmitEditUser}
           >
             <Input
               label={userTranslations("users.modal.userNameLabel")}
@@ -143,7 +156,8 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
                 color="primary"
                 className="bg-green-800"
                 type="submit"
-                isDisabled={!data.userRole}
+                isDisabled={!data.userRole || isSubmitting}
+                isLoading={isSubmitting}
               >
                 {userTranslations("users.modal.editButton")}
               </Button>

--- a/client/src/components/pages/Store/Users/EditUsersModal.jsx
+++ b/client/src/components/pages/Store/Users/EditUsersModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { addToast, Button, Input, Select, SelectItem, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/react";
 import { Eye, EyeOff } from "lucide-react";
@@ -12,6 +12,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
   const userTranslations = useTranslations();
   const [showPin, setShowPin] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
   const handleOnCloseModal = () => {
     setData({
       userId: "",
@@ -28,10 +29,11 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
   const handleSubmitEditUser = async (event) => {
     event.preventDefault();
 
-    if (isSubmitting) {
+    if (isSubmittingRef.current) {
       return;
     }
 
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
 
     try {
@@ -39,6 +41,7 @@ export function EditUsersModal({ data, setData, roles, onChange, editUsersShowMo
     } catch {
       return;
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
 

--- a/client/src/components/pages/Store/Users/Users.jsx
+++ b/client/src/components/pages/Store/Users/Users.jsx
@@ -138,11 +138,14 @@ export function Users() {
         deleteUsersShowModal={deleteUsersShowModal}
         setDeleteUsersShowModal={setDeleteUsersShowModal}
         onConfirm={async () => {
-          if (userToDelete?.id) {
-            await deleteUser(userToDelete.id);
-            addToast({ description: userTranslations("toasts.deleteSuccess"), color: "success" });
+          try {
+            if (userToDelete?.id) {
+              await deleteUser(userToDelete.id);
+              addToast({ description: userTranslations("toasts.deleteSuccess"), color: "success" });
+            }
+            setDeleteUsersShowModal(false);
+          } catch {
           }
-          setDeleteUsersShowModal(false);
         }}
       />
     </>

--- a/client/src/components/pages/Store/Users/Users.jsx
+++ b/client/src/components/pages/Store/Users/Users.jsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 
-import { Button } from "@heroui/react";
+import { addToast, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { PageHeader } from "@/components/shared/PageHeader";
@@ -63,13 +63,13 @@ export function Users() {
     setData((prev) => ({ ...prev, ...newData }));
   };
 
-  const t = useTranslations("users");
+  const userTranslations = useTranslations("users");
 
   return (
     <>
       <PageHeader
-        title={t("title")}
-        subtitle={t("subtitle")}
+        title={userTranslations("title")}
+        subtitle={userTranslations("subtitle")}
         actions={(
           <RequirePermission allOf={["users_create"]}>
             <Button
@@ -87,7 +87,7 @@ export function Users() {
                 setAddUsersShowModal(true);
               }}
             >
-              {t("addUser")}
+              {userTranslations("addUser")}
             </Button>
           </RequirePermission>
         )}
@@ -140,6 +140,7 @@ export function Users() {
         onConfirm={async () => {
           if (userToDelete?.id) {
             await deleteUser(userToDelete.id);
+            addToast({ description: userTranslations("toasts.deleteSuccess"), color: "success" });
           }
           setDeleteUsersShowModal(false);
         }}

--- a/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
@@ -172,6 +172,28 @@ describe("AddUsersModal", () => {
     expect(setAddUsersShowModal).toHaveBeenCalledWith(false);
   });
 
+  it("does not reset or close when addUser fails", async () => {
+    const addUser = jest.fn(() => Promise.reject(new Error("add failed")));
+    const setData = jest.fn();
+    const setAddUsersShowModal = jest.fn();
+
+    renderModal({
+      addUser,
+      setData,
+      setAddUsersShowModal,
+    });
+
+    fireEvent.click(screen.getByText("users.modal.submitButton"));
+
+    await waitFor(() => expect(addUser).toHaveBeenCalledWith(baseData));
+    expect(addToast).not.toHaveBeenCalledWith({
+      description: "users.toasts.createSuccess",
+      color: "success",
+    });
+    expect(setData).not.toHaveBeenCalled();
+    expect(setAddUsersShowModal).not.toHaveBeenCalledWith(false);
+  });
+
   it("requires name and pin fields", () => {
     renderModal();
 

--- a/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
@@ -22,6 +22,11 @@ jest.mock("framer-motion", () => {
   };
 });
 
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return { ...actual, addToast: jest.fn() };
+});
+
 const roles = [
   { id: "seller", role: "Seller" },
   { id: "admin", role: "Admin" },
@@ -41,6 +46,8 @@ const localStorageMock = {
   clear: jest.fn(),
 };
 global.localStorage = localStorageMock;
+
+const { addToast } = require("@heroui/react");
 
 const renderModal = (props = {}) => render(
   <I18nProvider>
@@ -151,6 +158,10 @@ describe("AddUsersModal", () => {
     fireEvent.click(screen.getByText("users.modal.submitButton"));
 
     await waitFor(() => expect(addUser).toHaveBeenCalledWith(baseData));
+    expect(addToast).toHaveBeenCalledWith({
+      description: "users.toasts.createSuccess",
+      color: "success",
+    });
     expect(setData).toHaveBeenCalledWith({
       userName: "",
       userPin: "",

--- a/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/AddUsersModal.test.jsx
@@ -194,6 +194,31 @@ describe("AddUsersModal", () => {
     expect(setAddUsersShowModal).not.toHaveBeenCalledWith(false);
   });
 
+  it("does not submit twice while add is pending", async () => {
+    let resolveAddUser;
+    const addUser = jest.fn(() => new Promise((resolve) => {
+      resolveAddUser = resolve;
+    }));
+    const setAddUsersShowModal = jest.fn();
+
+    renderModal({
+      addUser,
+      setAddUsersShowModal,
+    });
+
+    const submitButton = screen.getByText("users.modal.submitButton");
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(addUser).toHaveBeenCalledTimes(1));
+
+    resolveAddUser();
+
+    await waitFor(() => {
+      expect(setAddUsersShowModal).toHaveBeenCalledWith(false);
+    });
+  });
+
   it("requires name and pin fields", () => {
     renderModal();
 

--- a/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { I18nProvider } from "@/i18n/I18nProvider";
 
@@ -22,6 +22,11 @@ jest.mock("framer-motion", () => {
   };
 });
 
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return { ...actual, addToast: jest.fn() };
+});
+
 const roles = [
   { id: "seller", role: "Seller" },
   { id: "admin", role: "Admin" },
@@ -42,6 +47,8 @@ const localStorageMock = {
   clear: jest.fn(),
 };
 global.localStorage = localStorageMock;
+
+const { addToast } = require("@heroui/react");
 
 const renderModal = (props = {}) => render(
   <I18nProvider>
@@ -100,16 +107,20 @@ describe("EditUsersModal", () => {
     expect(setEditUsersShowModal).toHaveBeenCalledWith(false);
   });
 
-  it("saves changes and closes on submit", () => {
+  it("saves changes and closes on submit", async () => {
     const setData = jest.fn();
     const setEditUsersShowModal = jest.fn();
-    const updateUser = jest.fn();
+    const updateUser = jest.fn(() => Promise.resolve());
 
     renderModal({ setData, setEditUsersShowModal, updateUser });
 
     fireEvent.click(screen.getByText("users.modal.editButton"));
 
-    expect(updateUser).toHaveBeenCalledWith(baseData);
+    await waitFor(() => expect(updateUser).toHaveBeenCalledWith(baseData));
+    expect(addToast).toHaveBeenCalledWith({
+      description: "users.toasts.updateSuccess",
+      color: "success",
+    });
     expect(setData).toHaveBeenCalledWith({
       userId: "",
       userName: "",

--- a/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
@@ -150,6 +150,29 @@ describe("EditUsersModal", () => {
     expect(setEditUsersShowModal).not.toHaveBeenCalledWith(false);
   });
 
+  it("does not submit twice while update is pending", async () => {
+    const setData = jest.fn();
+    const setEditUsersShowModal = jest.fn();
+    let resolveUpdateUser;
+    const updateUser = jest.fn(() => new Promise((resolve) => {
+      resolveUpdateUser = resolve;
+    }));
+
+    renderModal({ setData, setEditUsersShowModal, updateUser });
+
+    const submitButton = screen.getByText("users.modal.editButton");
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(updateUser).toHaveBeenCalledTimes(1));
+
+    resolveUpdateUser();
+
+    await waitFor(() => {
+      expect(setEditUsersShowModal).toHaveBeenCalledWith(false);
+    });
+  });
+
   it("normalizes phone and pin to digits and toggles pin visibility", () => {
     const onChange = jest.fn();
 

--- a/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/EditUsersModal.test.jsx
@@ -132,6 +132,24 @@ describe("EditUsersModal", () => {
     expect(setEditUsersShowModal).toHaveBeenCalledWith(false);
   });
 
+  it("does not reset or close when updateUser fails", async () => {
+    const setData = jest.fn();
+    const setEditUsersShowModal = jest.fn();
+    const updateUser = jest.fn(() => Promise.reject(new Error("update failed")));
+
+    renderModal({ setData, setEditUsersShowModal, updateUser });
+
+    fireEvent.click(screen.getByText("users.modal.editButton"));
+
+    await waitFor(() => expect(updateUser).toHaveBeenCalledWith(baseData));
+    expect(addToast).not.toHaveBeenCalledWith({
+      description: "users.toasts.updateSuccess",
+      color: "success",
+    });
+    expect(setData).not.toHaveBeenCalled();
+    expect(setEditUsersShowModal).not.toHaveBeenCalledWith(false);
+  });
+
   it("normalizes phone and pin to digits and toggles pin visibility", () => {
     const onChange = jest.fn();
 

--- a/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
@@ -83,14 +83,34 @@ jest.mock("../EditUsersModal", () => ({
 }));
 
 jest.mock("../DeleteUsersModal", () => ({
-  DeleteUsersModal: ({ deleteUsersShowModal, onConfirm }) => (
-    deleteUsersShowModal ? (
+  DeleteUsersModal: ({ deleteUsersShowModal, onConfirm }) => {
+    const React = require("react");
+    const [isDeleting, setIsDeleting] = React.useState(false);
+    const isDeletingRef = React.useRef(false);
+
+    const handleConfirmDeleteUser = async () => {
+      if (isDeletingRef.current) {
+        return;
+      }
+
+      isDeletingRef.current = true;
+      setIsDeleting(true);
+
+      try {
+        await onConfirm?.();
+      } finally {
+        isDeletingRef.current = false;
+        setIsDeleting(false);
+      }
+    };
+
+    return deleteUsersShowModal ? (
       <div>
         modal.titleDelete
-        <button onClick={() => onConfirm?.()}>modal.deleteButton</button>
+        <button disabled={isDeleting} onClick={handleConfirmDeleteUser}>modal.deleteButton</button>
       </div>
-    ) : null
-  ),
+    ) : null;
+  },
 }));
 
 jest.mock("../../hooks/useUsers", () => ({
@@ -334,6 +354,36 @@ describe("Users page", () => {
       color: "success",
     });
     expect(screen.getByText("modal.titleDelete")).toBeInTheDocument();
+  });
+
+  it("does not confirm delete twice while delete is pending", async () => {
+    let resolveDeleteUser;
+    mockDeleteUser.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveDeleteUser = resolve;
+    }));
+
+    await act(async () => {
+      renderUsers();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", {
+      name: "Delete User",
+    });
+
+    await act(async () => {
+      fireEvent.click(deleteButtons[0]);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("modal.deleteButton"));
+      fireEvent.click(screen.getByText("modal.deleteButton"));
+    });
+
+    expect(mockDeleteUser).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDeleteUser();
+    });
   });
 
   it("does not delete when user id is missing", async () => {

--- a/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
@@ -309,6 +309,33 @@ describe("Users page", () => {
     });
   });
 
+  it("keeps delete modal open when deleteUser fails", async () => {
+    mockDeleteUser.mockRejectedValueOnce(new Error("delete failed"));
+
+    await act(async () => {
+      renderUsers();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", {
+      name: "Delete User",
+    });
+
+    await act(async () => {
+      fireEvent.click(deleteButtons[0]);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("modal.deleteButton"));
+    });
+
+    expect(mockDeleteUser).toHaveBeenCalledWith(1);
+    expect(addToast).not.toHaveBeenCalledWith({
+      description: "toasts.deleteSuccess",
+      color: "success",
+    });
+    expect(screen.getByText("modal.titleDelete")).toBeInTheDocument();
+  });
+
   it("does not delete when user id is missing", async () => {
     await act(async () => {
       renderUsers();

--- a/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
@@ -14,6 +14,11 @@ let mockRoles = [
   { id: "seller", role: "Seller" },
 ];
 
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return { ...actual, addToast: jest.fn() };
+});
+
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(() => "/store/users"),
 }));
@@ -47,7 +52,7 @@ jest.mock("../AddUsersModal", () => ({
           <input
             aria-label="modal.userNameLabel"
             value={data?.userName || ""}
-            onChange={(e) => onChange?.({ userName: e.target.value })}
+            onChange={(event) => onChange?.({ userName: event.target.value })}
           />
         </label>
         <button onClick={() => addUser?.(data)}>modal.submitButton</button>
@@ -64,12 +69,12 @@ jest.mock("../EditUsersModal", () => ({
         <input
           aria-label="modal.userNameLabel"
           value={data?.userName || user?.name || ""}
-          onChange={(e) => onChange?.({ userName: e.target.value })}
+          onChange={(event) => onChange?.({ userName: event.target.value })}
         />
         <input
           aria-label="modal.userPhoneLabel"
           value={data?.userPhone || user?.phone || ""}
-          onChange={(e) => onChange?.({ userPhone: e.target.value })}
+          onChange={(event) => onChange?.({ userPhone: event.target.value })}
         />
         <button onClick={() => updateUser?.(data)}>modal.editButton</button>
       </div>
@@ -129,6 +134,8 @@ const localStorageMock = {
   clear: jest.fn(),
 };
 global.localStorage = localStorageMock;
+
+const { addToast } = require("@heroui/react");
 
 function renderUsers() {
   return render(
@@ -296,6 +303,10 @@ describe("Users page", () => {
     });
 
     expect(mockDeleteUser).toHaveBeenCalledWith(1);
+    expect(addToast).toHaveBeenCalledWith({
+      description: "toasts.deleteSuccess",
+      color: "success",
+    });
   });
 
   it("does not delete when user id is missing", async () => {

--- a/client/src/components/pages/Store/Users/locales/en.js
+++ b/client/src/components/pages/Store/Users/locales/en.js
@@ -38,6 +38,9 @@ const usersEn = {
       deleteButton: "Delete",
     },
     toasts: {
+      createSuccess: "User created successfully",
+      updateSuccess: "User updated successfully",
+      deleteSuccess: "User deleted successfully",
       duplicateNameTitle: "Duplicate name",
       duplicateNameDescription: "A user with that name already exists.",
       genericErrorTitle: "Error",

--- a/client/src/components/pages/Store/Users/locales/es.js
+++ b/client/src/components/pages/Store/Users/locales/es.js
@@ -38,6 +38,9 @@ const usersEs = {
       deleteButton: "Eliminar",
     },
     toasts: {
+      createSuccess: "Usuario creado con éxito",
+      updateSuccess: "Usuario actualizado con éxito",
+      deleteSuccess: "Usuario eliminado con éxito",
       duplicateNameTitle: "Nombre duplicado",
       duplicateNameDescription: "Ya existe un usuario con ese nombre.",
       genericErrorTitle: "Error",

--- a/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
@@ -17,8 +17,8 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
+  const usersTranslations = (key) => key;
+  return { useTranslations: () => usersTranslations };
 });
 
 const handlers = {};
@@ -75,9 +75,9 @@ describe("useUsers", () => {
 
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
 
-    let response;
+    let addUserResponse;
     await act(async () => {
-      response = await handlers.addUser({
+      addUserResponse = await handlers.addUser({
         userName: "Luis",
         userPin: "1234",
         userRole: 2,
@@ -86,7 +86,7 @@ describe("useUsers", () => {
       });
     });
 
-    expect(response).toEqual({ ok: true });
+    expect(addUserResponse).toEqual({ ok: true });
     expect(httpClient).toHaveBeenCalledWith("/users", {
       method: "POST",
       headers: {
@@ -203,14 +203,63 @@ describe("useUsers", () => {
 
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
 
-    await act(async () => {
-      await handlers.deleteUser(6);
-    });
+    await expect(handlers.deleteUser(6)).rejects.toMatchObject({ status: 409 });
 
     expect(addToast).toHaveBeenCalledWith({
       title: "toasts.lastAdminTitle",
       description: "toasts.lastAdminDescription",
       color: "warning",
+    });
+  });
+
+  it("shows duplicate name toast and rejects when adding user returns conflict", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 409 });
+    parseJsonResponse.mockResolvedValueOnce({ message: "Duplicate user" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
+
+    await expect(handlers.addUser({
+      userName: "Luis",
+      userPin: "1234",
+      userRole: 2,
+      userEmail: "luis@example.com",
+      userPhone: "555-0101",
+    })).rejects.toMatchObject({ status: 409 });
+
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.duplicateNameTitle",
+      description: "toasts.duplicateNameDescription",
+      color: "danger",
+    });
+  });
+
+  it("shows generic error toast and rejects when updating user fails", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: 3, name: "Paula" }]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 500 });
+    parseJsonResponse.mockResolvedValueOnce({ message: "Server error" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await expect(handlers.updateUser({
+      userId: 3,
+      userName: "Paula",
+      userRole: 1,
+      userEmail: "paula@example.com",
+      userPhone: "555-0202",
+      userPin: "",
+    })).rejects.toMatchObject({ status: 500 });
+
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.genericErrorTitle",
+      description: "toasts.genericErrorDescription",
+      color: "danger",
     });
   });
 });

--- a/client/src/components/pages/Store/hooks/useUsers.jsx
+++ b/client/src/components/pages/Store/hooks/useUsers.jsx
@@ -8,10 +8,10 @@ import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
-async function buildHttpRequestError(response, fallbackMessage) {
-  const responsePayload = await parseJsonResponse(response, null);
+async function buildHttpRequestError(httpResponse, fallbackMessage) {
+  const responsePayload = await parseJsonResponse(httpResponse, null);
   const requestError = new Error(fallbackMessage);
-  requestError.status = response.status;
+  requestError.status = httpResponse.status;
   requestError.responseMessage = responsePayload?.message;
   return requestError;
 }
@@ -21,7 +21,7 @@ function isLastAdminConflict(requestError) {
 }
 
 export function useUsers() {
-  const t = useTranslations("users");
+  const usersTranslations = useTranslations("users");
   const { fetchList } = useFetchList();
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -29,24 +29,24 @@ export function useUsers() {
 
   const showGenericMutationErrorToast = useCallback(() => {
     addToast({
-      title: t("toasts.genericErrorTitle"),
-      description: t("toasts.genericErrorDescription"),
+      title: usersTranslations("toasts.genericErrorTitle"),
+      description: usersTranslations("toasts.genericErrorDescription"),
       color: "danger",
     });
-  }, [t]);
+  }, [usersTranslations]);
 
   const showUserConflictToast = useCallback((requestError, fallbackConflictToast) => {
     if (isLastAdminConflict(requestError)) {
       addToast({
-        title: t("toasts.lastAdminTitle"),
-        description: t("toasts.lastAdminDescription"),
+        title: usersTranslations("toasts.lastAdminTitle"),
+        description: usersTranslations("toasts.lastAdminDescription"),
         color: "warning",
       });
       return;
     }
 
     addToast(fallbackConflictToast);
-  }, [t]);
+  }, [usersTranslations]);
 
   const fetchUsers = useCallback(async () => {
     setLoading(true);
@@ -94,14 +94,15 @@ export function useUsers() {
     } catch (requestError) {
       if (requestError?.status === 409) {
         showUserConflictToast(requestError, {
-          title: t("toasts.duplicateNameTitle"),
-          description: t("toasts.duplicateNameDescription"),
+          title: usersTranslations("toasts.duplicateNameTitle"),
+          description: usersTranslations("toasts.duplicateNameDescription"),
           color: "danger",
         });
-        return;
+        throw requestError;
       }
 
       showGenericMutationErrorToast();
+      throw requestError;
     }
   };
 
@@ -130,14 +131,15 @@ export function useUsers() {
     } catch (requestError) {
       if (requestError?.status === 409) {
         showUserConflictToast(requestError, {
-          title: t("toasts.duplicateNameTitle"),
-          description: t("toasts.duplicateNameDescription"),
+          title: usersTranslations("toasts.duplicateNameTitle"),
+          description: usersTranslations("toasts.duplicateNameDescription"),
           color: "danger",
         });
-        return;
+        throw requestError;
       }
 
       showGenericMutationErrorToast();
+      throw requestError;
     }
   };
 
@@ -156,14 +158,15 @@ export function useUsers() {
     } catch (requestError) {
       if (requestError?.status === 409) {
         showUserConflictToast(requestError, {
-          title: t("toasts.lastUserTitle"),
-          description: t("toasts.lastUserDescription"),
+          title: usersTranslations("toasts.lastUserTitle"),
+          description: usersTranslations("toasts.lastUserDescription"),
           color: "warning",
         });
-        return;
+        throw requestError;
       }
 
       showGenericMutationErrorToast();
+      throw requestError;
     }
   };
 


### PR DESCRIPTION
## Summary

  - Add success toast notifications when users are created, updated, or deleted.
  - Keep existing error toast handling in `useUsers`.
  - Rethrow failed create/update/delete requests so modals can react correctly.
  - Keep add, edit, and delete modals open when user mutations fail.
  - Prevent success toasts, form resets, and modal closes on failed user actions.

  ## Files touched

  - `client/src/components/pages/Store/Users/AddUsersModal.jsx`
  - `client/src/components/pages/Store/Users/EditUsersModal.jsx`
  - `client/src/components/pages/Store/Users/Users.jsx`
  - `client/src/components/pages/Store/hooks/useUsers.jsx`
  - Users modal/hook tests

<img width="370" height="130" alt="Screenshot From 2026-07-03 18-33-47" src="https://github.com/user-attachments/assets/2dbd707f-d1f6-48d5-acc0-31c455d9d659" />

<img width="1012" height="127" alt="Screenshot From 2026-07-03 18-35-03" src="https://github.com/user-attachments/assets/f7187186-5bfb-4cf7-bb13-a676ec2ecdff" />

<img width="1012" height="127" alt="Screenshot From 2026-07-03 18-35-13" src="https://github.com/user-attachments/assets/d3c05b3a-e932-4d25-ab09-00af0f6883da" />