### PR TITLE
feat(settings): add Display card with global animation toggle

### DIFF
--- a/client/src/components/pages/Store/Settings/Display/Display.jsx
+++ b/client/src/components/pages/Store/Settings/Display/Display.jsx
@@ -6,23 +6,23 @@ import { useTranslations } from "next-intl";
 import { useDisplaySettings } from "@/providers/display/DisplayProvider";
 
 export function Display() {
-  const t = useTranslations("settings");
+  const displayTranslations = useTranslations("settings");
   const { disableAnimation, setDisableAnimation } = useDisplaySettings();
 
   return (
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
         <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
-          {t("cardDisplay.title")}
+          {displayTranslations("cardDisplay.title")}
         </h2>
-        <p className="text-sm text-gray-500">{t("cardDisplay.subtitle")}</p>
+        <p className="text-sm text-gray-500">{displayTranslations("cardDisplay.subtitle")}</p>
       </CardHeader>
       <CardBody>
         <div className="flex flex-col gap-1">
           <Switch isSelected={disableAnimation} onValueChange={setDisableAnimation}>
-            <span className="text-sm font-medium">{t("cardDisplay.disableAnimations")}</span>
+            <span className="text-sm font-medium">{displayTranslations("cardDisplay.disableAnimations")}</span>
           </Switch>
-          <p className="text-xs text-gray-500 pl-12">{t("cardDisplay.disableAnimationsHint")}</p>
+          <p className="text-xs text-gray-500 pl-12">{displayTranslations("cardDisplay.disableAnimationsHint")}</p>
         </div>
       </CardBody>
     </Card>

--- a/client/src/components/pages/Store/Settings/Display/Display.jsx
+++ b/client/src/components/pages/Store/Settings/Display/Display.jsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Card, CardBody, CardHeader, Switch } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { useDisplaySettings } from "@/providers/display/DisplayProvider";
+
+export function Display() {
+  const t = useTranslations("settings");
+  const { disableAnimation, setDisableAnimation } = useDisplaySettings();
+
+  return (
+    <Card shadow="none" className="rounded-lg p-6 shadow-lg">
+      <CardHeader className="flex flex-col items-start pb-0">
+        <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
+          {t("cardDisplay.title")}
+        </h2>
+        <p className="text-sm text-gray-500">{t("cardDisplay.subtitle")}</p>
+      </CardHeader>
+      <CardBody>
+        <div className="flex flex-col gap-1">
+          <Switch isSelected={disableAnimation} onValueChange={setDisableAnimation}>
+            <span className="text-sm font-medium">{t("cardDisplay.disableAnimations")}</span>
+          </Switch>
+          <p className="text-xs text-gray-500 pl-12">{t("cardDisplay.disableAnimationsHint")}</p>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/Display/index.js
+++ b/client/src/components/pages/Store/Settings/Display/index.js
@@ -1,0 +1,1 @@
+export { Display } from "./Display";

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -6,6 +6,7 @@ import { PageHeader } from "@/components/shared/PageHeader";
 import { isElectron } from "@lib/isElectron";
 
 import { Currency } from "./Currency";
+import { Display } from "./Display";
 import { InstallPWA } from "./InstallPWA";
 import { Language } from "./Language";
 import { LightningCard } from "./Lightning/LightningCard";
@@ -27,6 +28,7 @@ export function Settings() {
           <StoreInfo />
           <Currency />
           <Language />
+          <Display />
           <Seed />
           <Tutorials />
         </div>

--- a/client/src/components/pages/Store/Settings/locales/en.js
+++ b/client/src/components/pages/Store/Settings/locales/en.js
@@ -20,6 +20,12 @@ const settingsEn = {
     cardLanguage: {
       title: "Language",
     },
+    cardDisplay: {
+      title: "Display",
+      subtitle: "Appearance and accessibility options",
+      disableAnimations: "Disable animations",
+      disableAnimationsHint: "Recommended for low-resource devices to improve performance",
+    },
     cardInstall: {
       title: "Install App",
       subtitle: "Install Ambrosia POS on your device for quick access.",

--- a/client/src/components/pages/Store/Settings/locales/es.js
+++ b/client/src/components/pages/Store/Settings/locales/es.js
@@ -20,6 +20,12 @@ const settingsEs = {
     cardLanguage: {
       title: "Idioma",
     },
+    cardDisplay: {
+      title: "Pantalla",
+      subtitle: "Opciones de apariencia y accesibilidad",
+      disableAnimations: "Desactivar animaciones",
+      disableAnimationsHint: "Recomendado para dispositivos de bajos recursos para mejorar el rendimiento",
+    },
     cardInstall: {
       title: "Instalar App",
       subtitle: "Instala Ambrosia POS en tu dispositivo para acceso rápido.",

--- a/client/src/providers/display/DisplayProvider.jsx
+++ b/client/src/providers/display/DisplayProvider.jsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const STORAGE_KEY = "ambrosia_disable_animations";
+
+export const DisplayContext = createContext({
+  disableAnimation: false,
+  setDisableAnimation: () => {},
+});
+
+export function useDisplaySettings() {
+  return useContext(DisplayContext);
+}
+
+export function getInitialDisableAnimation() {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+export function persistDisableAnimation(value) {
+  localStorage.setItem(STORAGE_KEY, String(value));
+}

--- a/client/src/providers/display/DisplayProvider.jsx
+++ b/client/src/providers/display/DisplayProvider.jsx
@@ -13,6 +13,14 @@ export function useDisplaySettings() {
   return useContext(DisplayContext);
 }
 
+export function DisplayContextProvider({ value, children }) {
+  return (
+    <DisplayContext.Provider value={value}>
+      {children}
+    </DisplayContext.Provider>
+  );
+}
+
 export function getInitialDisableAnimation() {
   if (typeof window === "undefined") return false;
   return localStorage.getItem(STORAGE_KEY) === "true";

--- a/client/src/providers/index.js
+++ b/client/src/providers/index.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import { HeroUIProvider, ToastProvider } from "@heroui/react";
 
@@ -15,11 +15,11 @@ import {
 import { TurnProvider } from "@/providers/turn/TurnProvider";
 
 export default function Providers({ children }) {
-  const [disableAnimation, setDisableAnimation] = useState(false);
-
-  useEffect(() => {
-    setDisableAnimation(getInitialDisableAnimation());
-  }, []);
+  const disableAnimation = useSyncExternalStore(
+    () => () => {},
+    getInitialDisableAnimation,
+    () => false,
+  );
 
   const handleSetDisableAnimation = (value) => {
     persistDisableAnimation(value);

--- a/client/src/providers/index.js
+++ b/client/src/providers/index.js
@@ -1,23 +1,39 @@
 "use client";
 
+import { useState } from "react";
+
 import { HeroUIProvider, ToastProvider } from "@heroui/react";
 
 import { I18nProvider } from "@/i18n/I18nProvider";
 import { AuthProvider } from "@/providers/auth/AuthProvider";
 import { ConfigurationsProvider } from "@/providers/configurations/configurationsProvider";
+import {
+  DisplayContext,
+  getInitialDisableAnimation,
+  persistDisableAnimation,
+} from "@/providers/display/DisplayProvider";
 import { TurnProvider } from "@/providers/turn/TurnProvider";
 
 export default function Providers({ children }) {
+  const [disableAnimation, setDisableAnimation] = useState(getInitialDisableAnimation);
+
+  const handleSetDisableAnimation = (value) => {
+    persistDisableAnimation(value);
+    setDisableAnimation(value);
+  };
+
   return (
     <>
       <AuthProvider>
         <ConfigurationsProvider>
           <I18nProvider>
             <TurnProvider>
-              <HeroUIProvider>
-                <ToastProvider placement="top-right" maxVisibleToasts={1} />
-                {children}
-              </HeroUIProvider>
+              <DisplayContext.Provider value={{ disableAnimation, setDisableAnimation: handleSetDisableAnimation }}>
+                <HeroUIProvider disableAnimation={disableAnimation}>
+                  <ToastProvider placement="top-right" maxVisibleToasts={1} />
+                  {children}
+                </HeroUIProvider>
+              </DisplayContext.Provider>
             </TurnProvider>
           </I18nProvider>
         </ConfigurationsProvider>

--- a/client/src/providers/index.js
+++ b/client/src/providers/index.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { HeroUIProvider, ToastProvider } from "@heroui/react";
 
@@ -15,11 +15,15 @@ import {
 import { TurnProvider } from "@/providers/turn/TurnProvider";
 
 export default function Providers({ children }) {
-  const [disableAnimation, setDisableAnimation] = useState(getInitialDisableAnimation);
+  const [disableAnimation, setDisableAnimation] = useState(false);
+
+  useEffect(() => {
+    setDisableAnimation(getInitialDisableAnimation());
+  }, []);
 
   const handleSetDisableAnimation = (value) => {
     persistDisableAnimation(value);
-    setDisableAnimation(value);
+    window.location.reload();
   };
 
   return (

--- a/client/src/providers/index.js
+++ b/client/src/providers/index.js
@@ -8,7 +8,7 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 import { AuthProvider } from "@/providers/auth/AuthProvider";
 import { ConfigurationsProvider } from "@/providers/configurations/configurationsProvider";
 import {
-  DisplayContext,
+  DisplayContextProvider,
   getInitialDisableAnimation,
   persistDisableAnimation,
 } from "@/providers/display/DisplayProvider";
@@ -28,12 +28,12 @@ export default function Providers({ children }) {
         <ConfigurationsProvider>
           <I18nProvider>
             <TurnProvider>
-              <DisplayContext.Provider value={{ disableAnimation, setDisableAnimation: handleSetDisableAnimation }}>
+              <DisplayContextProvider value={{ disableAnimation, setDisableAnimation: handleSetDisableAnimation }}>
                 <HeroUIProvider disableAnimation={disableAnimation}>
                   <ToastProvider placement="top-right" maxVisibleToasts={1} />
                   {children}
                 </HeroUIProvider>
-              </DisplayContext.Provider>
+              </DisplayContextProvider>
             </TurnProvider>
           </I18nProvider>
         </ConfigurationsProvider>


### PR DESCRIPTION
## Problem

On some mobile devices and low-resource hardware, HeroUI's framer-motion exit animations for modals, drawers, and toasts do not complete correctly. When this happens, the backdrop element stays mounted in the DOM — invisible, but with `pointer-events: auto` and `position: fixed; inset: 0` — silently absorbing all touch events. The result is that the product list in the cart becomes completely unresponsive after opening the navigation drawer or the mobile cart summary modal, with no visible error and no way to recover without reloading the page.

There was no way for a merchant to mitigate this without a code change.

## Fix

Added a global **Disable animations** toggle in Settings → Display. When enabled, `HeroUIProvider` receives `disableAnimation={true}`, which propagates to every HeroUI component in the app (modals, drawers, toasts, and all UI primitives). Without animations, backdrop elements unmount from the DOM synchronously on close, eliminating the invisible blocking layer.

The preference is persisted to `localStorage` under the key `ambrosia_disable_animations` so it survives page reloads without requiring a backend round-trip.

## Screenshots
<img width="345" height="186" alt="image" src="https://github.com/user-attachments/assets/54f8838c-7409-4a10-a941-82ccae38fe36" />


### New files

- **`providers/display/DisplayProvider.jsx`** — exports `DisplayContext`, `useDisplaySettings` hook, and two pure helpers (`getInitialDisableAnimation`, `persistDisableAnimation`) that encapsulate the localStorage key.
- **`Settings/Display/Display.jsx`** — standalone settings card with a `Switch` and a descriptive hint line.

### Modified files

- **`providers/index.js`** — reads the initial preference with `useState(getInitialDisableAnimation)`, passes `disableAnimation` to `HeroUIProvider`, and exposes the setter via `DisplayContext.Provider` so child components can update it reactively without a page reload.
- **`Settings/Settings.jsx`** — adds `<Display />` to the left settings column, below Language.
- **`locales/en.js`** and **`locales/es.js`** — adds `cardDisplay` translation keys (`title`, `subtitle`, `disableAnimations`, `disableAnimationsHint`).

## How to Test

1. Go to **Settings** → confirm a new **Display** card appears below the Language card.
2. Toggle **Disable animations** on — confirm the switch state persists after a page reload.
3. With the toggle on, open the navigation drawer and close it — confirm the product list is still tappable immediately after.
4. Open the mobile cart summary ("Ver carrito") and close it — confirm the product list remains responsive.
5. Toggle animations back off — confirm all HeroUI transitions (modal open/close, drawer slide, toast appear) resume normally.