### PR TITLE
fix(client): share bitcoin price cache and drop stale-price fallback

### DIFF
--- a/client/src/services/__tests__/bitcoinPriceService.test.js
+++ b/client/src/services/__tests__/bitcoinPriceService.test.js
@@ -1,0 +1,81 @@
+import BitcoinPriceService from "../bitcoinPriceService";
+
+describe("BitcoinPriceService", () => {
+  let priceService;
+
+  beforeEach(() => {
+    priceService = new BitcoinPriceService();
+    priceService.clearCache();
+    global.fetch = jest.fn();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the price from the API on a successful fetch", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ bitcoin: { usd: 50000 } }),
+    });
+
+    const price = await priceService.getBitcoinPrice("usd");
+
+    expect(price).toBe(50000);
+  });
+
+  it("throws instead of returning a fallback price when the network request fails", async () => {
+    global.fetch.mockRejectedValue(new Error("network error"));
+
+    await expect(priceService.getBitcoinPrice("usd")).rejects.toThrow(
+      "Unable to get BTC price for usd",
+    );
+  });
+
+  it("throws instead of returning a fallback price when the response is not ok", async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(priceService.getBitcoinPrice("usd")).rejects.toThrow(
+      "Unable to get BTC price for usd",
+    );
+  });
+
+  it("throws instead of returning a fallback price when the currency is missing from the response", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ bitcoin: {} }),
+    });
+
+    await expect(priceService.getBitcoinPrice("mxn")).rejects.toThrow(
+      "Unable to get BTC price for mxn",
+    );
+  });
+
+  it("does not cache a price after a failed fetch", async () => {
+    global.fetch.mockRejectedValueOnce(new Error("network error"));
+    await expect(priceService.getBitcoinPrice("usd")).rejects.toThrow();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ bitcoin: { usd: 60000 } }),
+    });
+    const price = await priceService.getBitcoinPrice("usd");
+
+    expect(price).toBe(60000);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses the cached price within the cache window instead of refetching", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ bitcoin: { usd: 50000 } }),
+    });
+
+    await priceService.getBitcoinPrice("usd");
+    const secondPrice = await priceService.getBitcoinPrice("usd");
+
+    expect(secondPrice).toBe(50000);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/services/bitcoinPriceService.js
+++ b/client/src/services/bitcoinPriceService.js
@@ -1,14 +1,10 @@
+const sharedPriceCache = new Map();
+
 class BitcoinPriceService {
   constructor() {
-    this.cache = new Map();
-    this.CACHE_DURATION = 5 * 60 * 1000;
+    this.cache = sharedPriceCache;
+    this.CACHE_DURATION = 60 * 1000;
     this.SATOSHIS_PER_BTC = 100000000;
-    this.FALLBACK_PRICES = {
-      usd: 45000,
-      mxn: 900000,
-      eur: 42000,
-      btc: 1,
-    };
   }
 
   async getBitcoinPrice(currency = "usd") {
@@ -53,13 +49,6 @@ class BitcoinPriceService {
       return price;
     } catch (error) {
       console.warn(`Error fetching BTC price for ${currency}:`, error.message);
-
-      const fallbackPrice = this.FALLBACK_PRICES[currency.toLowerCase()];
-      if (fallbackPrice) {
-        console.warn(`Using fallback price for ${currency}: ${fallbackPrice}`);
-        return fallbackPrice;
-      }
-
       throw new Error(`Unable to get BTC price for ${currency}`);
     }
   }


### PR DESCRIPTION
## Summary
- Cart checkout (`useBitcoinInvoice`) and wallet manual invoices (`useWalletAmountInput`/`useSatsToFiatEstimate`) each created their own `BitcoinPriceService` instance with its own 5-minute cache, so the sats amount used to generate an invoice could reflect a BTC price fetched minutes apart between the two flows — the reported "desfase" in price.
- Moved the price cache to module scope (`sharedPriceCache`) so all consumers of `BitcoinPriceService` share the same cached quote, and shrank the cache window from 5 minutes to 1 minute so it refreshes more often.
- Removed the silent fallback to hardcoded `FALLBACK_PRICES` when the CoinGecko fetch fails — `getBitcoinPrice` now always throws on failure instead of quietly returning a stale, hardcoded price. Existing callers already handle the rejected promise (`useBitcoinInvoice`, `useBitcoinPrice`, `useWalletAmountInput`, `useSatsToFiatEstimate`), so this surfaces real failures instead of masking them.
- Added `src/services/__tests__/bitcoinPriceService.test.js` covering: successful fetch, cache reuse within the window, and that fetch/HTTP/missing-currency failures throw instead of returning a fallback price.

## Test plan
- [x] `npm test -- --testPathPatterns="bitcoinPrice|useBitcoinInvoice|useBitcoinPrice|PaymentTab|PaymentConfirmModal|PaymentSentModal|ReceiveTab"` — 113 tests passing
- [x] `npm run lint` — clean