### PR TITLE
feat(client): show wallet total balance in local currency

### DIFF
--- a/client/src/components/pages/Store/Wallet/NodeInfo/NodeInfo.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/NodeInfo.jsx
@@ -12,7 +12,7 @@ import { ChannelCard } from "./ChannelCard";
 import { NodeSummary } from "./NodeSummary";
 
 export function NodeInfo({ info, onRefresh, currentRate, currencyAcronym, locale }) {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
   const [selectedChannel, setSelectedChannel] = useState(null);
   const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
 
@@ -37,7 +37,7 @@ export function NodeInfo({ info, onRefresh, currentRate, currencyAcronym, locale
       <Card className="rounded-lg mb-6 p-6">
         <CardHeader>
           <h3 className="text-lg font-bold text-deep flex items-center">
-            {t("nodeInfo.title")}
+            {walletTranslations("nodeInfo.title")}
           </h3>
         </CardHeader>
         <CardBody>
@@ -51,11 +51,11 @@ export function NodeInfo({ info, onRefresh, currentRate, currencyAcronym, locale
           {!info.channels?.length ? (
             <div className="flex flex-col items-center py-8 text-forest opacity-60">
               <Zap className="w-8 h-8 mb-2" />
-              <p className="text-sm">{t("nodeInfo.noChannels")}</p>
+              <p className="text-sm">{walletTranslations("nodeInfo.noChannels")}</p>
             </div>
           ) : (
             <div className="space-y-3">
-              <h4 className="font-semibold text-deep">{t("nodeInfo.subtitle")}</h4>
+              <h4 className="font-semibold text-deep">{walletTranslations("nodeInfo.subtitle")}</h4>
               {(info.channels ?? []).map((channel, index) => (
                 <ChannelCard
                   key={channel.channelId}

--- a/client/src/components/pages/Store/Wallet/NodeInfo/NodeInfo.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/NodeInfo.jsx
@@ -11,7 +11,7 @@ import { CloseChannelModal } from "../CloseChannel/CloseChannelModal";
 import { ChannelCard } from "./ChannelCard";
 import { NodeSummary } from "./NodeSummary";
 
-export function NodeInfo({ info, onRefresh }) {
+export function NodeInfo({ info, onRefresh, currentRate, currencyAcronym, locale }) {
   const t = useTranslations("wallet");
   const [selectedChannel, setSelectedChannel] = useState(null);
   const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
@@ -41,7 +41,13 @@ export function NodeInfo({ info, onRefresh }) {
           </h3>
         </CardHeader>
         <CardBody>
-          <NodeSummary info={info} totalBalance={totalBalance} />
+          <NodeSummary
+            info={info}
+            totalBalance={totalBalance}
+            currentRate={currentRate}
+            currencyAcronym={currencyAcronym}
+            locale={locale}
+          />
           {!info.channels?.length ? (
             <div className="flex flex-col items-center py-8 text-forest opacity-60">
               <Zap className="w-8 h-8 mb-2" />

--- a/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
@@ -21,7 +21,7 @@ function StatCard({ icon: Icon, label, value, secondaryValue }) {
 }
 
 export function NodeSummary({ info, totalBalance, currentRate, currencyAcronym, locale }) {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
 
   const totalBalanceFiat = currentRate != null
     ? formatFiat({
@@ -35,23 +35,23 @@ export function NodeSummary({ info, totalBalance, currentRate, currencyAcronym, 
     <div className="grid grid-cols-2 gap-4 mb-6">
       <StatCard
         icon={Wallet}
-        label={t("nodeInfo.totalBalance")}
+        label={walletTranslations("nodeInfo.totalBalance")}
         value={`${formatSats(totalBalance)} sats`}
         secondaryValue={totalBalanceFiat}
       />
       <StatCard
         icon={Globe}
-        label={t("nodeInfo.network")}
+        label={walletTranslations("nodeInfo.network")}
         value={info.chain}
       />
       <StatCard
         icon={Zap}
-        label={t("nodeInfo.channels")}
+        label={walletTranslations("nodeInfo.channels")}
         value={info.channels?.filter((channel) => channel.state === "Normal").length ?? 0}
       />
       <StatCard
         icon={Layers}
-        label={t("nodeInfo.block")}
+        label={walletTranslations("nodeInfo.block")}
         value={info.blockHeight}
       />
     </div>

--- a/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
@@ -3,9 +3,9 @@
 import { Wallet, Layers, Globe, Zap } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { formatSats } from "../utils/formatters";
+import { formatFiat, formatSats } from "../utils/formatters";
 
-function StatCard({ icon: Icon, label, value }) {
+function StatCard({ icon: Icon, label, value, secondaryValue }) {
   return (
     <div className="border p-3 sm:p-4 lg:p-3 xl:p-4 rounded-lg">
       <div className="flex items-center space-x-2 mb-2">
@@ -13,12 +13,23 @@ function StatCard({ icon: Icon, label, value }) {
         <span className="text-xs sm:text-sm lg:text-xs xl:text-sm font-medium text-forest">{label}</span>
       </div>
       <p className="text-base sm:text-xl lg:text-base xl:text-xl font-bold text-deep">{value}</p>
+      {secondaryValue && (
+        <p className="text-xs sm:text-sm text-forest">{secondaryValue}</p>
+      )}
     </div>
   );
 }
 
-export function NodeSummary({ info, totalBalance }) {
+export function NodeSummary({ info, totalBalance, currentRate, currencyAcronym, locale }) {
   const t = useTranslations("wallet");
+
+  const totalBalanceFiat = currentRate != null
+    ? formatFiat({
+      value: (totalBalance / 100_000_000) * currentRate,
+      currencyAcronym,
+      locale,
+    })
+    : null;
 
   return (
     <div className="grid grid-cols-2 gap-4 mb-6">
@@ -26,6 +37,7 @@ export function NodeSummary({ info, totalBalance }) {
         icon={Wallet}
         label={t("nodeInfo.totalBalance")}
         value={`${formatSats(totalBalance)} sats`}
+        secondaryValue={totalBalanceFiat}
       />
       <StatCard
         icon={Globe}

--- a/client/src/components/pages/Store/Wallet/NodeInfo/__tests__/NodeInfo.test.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/__tests__/NodeInfo.test.jsx
@@ -4,10 +4,10 @@ import { I18nProvider } from "@i18n/I18nProvider";
 
 import { NodeInfo } from "../NodeInfo";
 
-function renderNodeInfo(info) {
+function renderNodeInfo(info, props = {}) {
   return render(
     <I18nProvider>
-      <NodeInfo info={info} />
+      <NodeInfo info={info} {...props} />
     </I18nProvider>,
   );
 }
@@ -282,6 +282,34 @@ describe("NodeInfo Component", () => {
 
       expect(screen.getByText("0 sats")).toBeInTheDocument();
       expect(screen.getByText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("Total Balance in Local Currency", () => {
+    it("does not show a fiat value when no exchange rate is available", () => {
+      renderNodeInfo(mockNodeInfo);
+
+      expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
+    });
+
+    it("shows the total balance converted to the configured local currency", () => {
+      renderNodeInfo(mockNodeInfo, {
+        currentRate: 45000,
+        currencyAcronym: "USD",
+        locale: "en-US",
+      });
+
+      expect(screen.getByText("$36.00")).toBeInTheDocument();
+    });
+
+    it("reflects a different configured currency", () => {
+      renderNodeInfo(mockNodeInfo, {
+        currentRate: 900000,
+        currencyAcronym: "MXN",
+        locale: "es-MX",
+      });
+
+      expect(screen.getByText(/720\.00/)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/pages/Store/Wallet/StoreWallet.jsx
+++ b/client/src/components/pages/Store/Wallet/StoreWallet.jsx
@@ -140,7 +140,13 @@ export function StoreWallet() {
       {nodeAvailable && (
         <>
           <div className="lg:grid lg:grid-cols-2 lg:gap-6">
-            <NodeInfo info={info} onRefresh={fetchInfo} />
+            <NodeInfo
+              info={info}
+              onRefresh={fetchInfo}
+              currentRate={currentRate}
+              currencyAcronym={currency.acronym}
+              locale={currency.locale}
+            />
 
             <Transactions
               transactions={transactions}


### PR DESCRIPTION
## Summary
- Show the fiat equivalent of the Lightning node's total sats balance under the existing "Total Balance" stat in the Wallet page, using the configured business currency and current BTC exchange rate.
- Rename `t` to `walletTranslations` in `NodeSummary.jsx` for Clean Code naming conventions.

<img width="270" height="149" alt="image" src="https://github.com/user-attachments/assets/44dbb1df-6b1d-469c-b3a2-4b2705f23dea" />

## Test plan
- [x] `npm test -- src/components/pages/Store/Wallet` (330 tests passing)
- [x] `npm run lint`
- [x] Manual check in `/store/wallet` with a running Lightning node to confirm the local-currency balance renders correctly