### PR TITLE
Chore/remove dead store orders routes

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/StoreOrders.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/StoreOrders.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.Application
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
-import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import pos.ambrosia.models.Message
@@ -18,22 +17,6 @@ fun Application.configureStoreOrders() {
 }
 
 fun Route.storeOrders(checkoutService: CheckoutService) {
-    authorizePermission("orders_read") {
-        get("") {
-            val orderStatus = call.request.queryParameters["status"]
-            val orders = checkoutService.getStoreOrders(orderStatus)
-            call.respond(HttpStatusCode.OK, orders)
-        }
-        get("/{id}") {
-            val id =
-                call.parameters["id"]
-                    ?: return@get call.respond(HttpStatusCode.BadRequest, Message("Missing order ID"))
-            val order =
-                checkoutService.getStoreOrderById(id)
-                    ?: return@get call.respond(HttpStatusCode.NotFound, Message("Order not found"))
-            call.respond(HttpStatusCode.OK, order)
-        }
-    }
     authorizePermission("orders_delete") {
         delete("/{id}") {
             val id =

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -501,25 +501,6 @@ data class CreateStoreOrderRequest(
 )
 
 @Serializable
-data class StoreOrderItem(
-    val productId: String,
-    val variantId: String? = null,
-    val quantity: Int,
-    val priceAtOrder: Int,
-)
-
-@Serializable
-data class StoreOrder(
-    val id: String,
-    val userId: String,
-    val userName: String? = null,
-    val status: String,
-    val total: Int,
-    val createdAt: String,
-    val items: List<StoreOrderItem>,
-)
-
-@Serializable
 data class StoreCheckoutItem(
     val productId: String,
     val variantId: String? = null,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/CheckoutService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/CheckoutService.kt
@@ -2,12 +2,10 @@ package pos.ambrosia.services
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greaterEq
-import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.minus
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -26,13 +24,10 @@ import pos.ambrosia.db.tables.ProductVariantsTable
 import pos.ambrosia.db.tables.ProductsTable
 import pos.ambrosia.db.tables.TicketEntity
 import pos.ambrosia.db.tables.TicketPaymentsTable
-import pos.ambrosia.db.tables.UserEntity
 import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.logger
 import pos.ambrosia.models.StoreCheckoutRequest
 import pos.ambrosia.models.StoreCheckoutResponse
-import pos.ambrosia.models.StoreOrder
-import pos.ambrosia.models.StoreOrderItem
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -54,30 +49,6 @@ class CheckoutService(
 ) {
     companion object {
         private val checkoutMutex = Mutex()
-    }
-
-    private fun toStoreOrder(entity: OrderEntity): StoreOrder {
-        val items =
-            OrderProductsTable
-                .selectAll()
-                .where { OrderProductsTable.orderId eq entity.id }
-                .map {
-                    StoreOrderItem(
-                        productId = it[OrderProductsTable.productId].value.toString(),
-                        variantId = it[OrderProductsTable.variantId],
-                        quantity = it[OrderProductsTable.quantity],
-                        priceAtOrder = it[OrderProductsTable.priceAtOrder],
-                    )
-                }
-        return StoreOrder(
-            id = entity.id.value.toString(),
-            userId = entity.userId.value.toString(),
-            userName = UserEntity.findById(entity.userId)?.name,
-            status = entity.status,
-            total = entity.total.toInt(),
-            createdAt = entity.createdAt.replace(" ", "T"),
-            items = items,
-        )
     }
 
     private fun firstActiveVariantId(productEntityId: EntityID<UUID>): UUID? =
@@ -138,30 +109,6 @@ class CheckoutService(
 
         return remainingQuantity == 0
     }
-
-    fun getStoreOrders(status: String? = null): List<StoreOrder> =
-        transaction {
-            val baseCondition = (OrdersTable.isDeleted eq false) and OrdersTable.tableId.isNull()
-            val condition = if (status != null) baseCondition and (OrdersTable.status eq status) else baseCondition
-            OrderEntity
-                .find { condition }
-                .orderBy(OrdersTable.createdAt to SortOrder.DESC)
-                .map { toStoreOrder(it) }
-        }
-
-    fun getStoreOrderById(id: String): StoreOrder? =
-        transaction {
-            val orderUuid =
-                try {
-                    UUID.fromString(id)
-                } catch (_: IllegalArgumentException) {
-                    return@transaction null
-                }
-            OrderEntity
-                .findById(orderUuid)
-                ?.takeIf { !it.isDeleted && it.tableId == null }
-                ?.let { toStoreOrder(it) }
-        }
 
     fun cancelStoreOrder(id: String): Boolean =
         transaction {

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutServiceTest.kt
@@ -314,7 +314,6 @@ class CheckoutServiceTest {
             assertEquals(first.response.ticketId, second.response.ticketId)
             assertEquals(first.response.paymentId, second.response.paymentId)
 
-            // Only one order persisted — the recovered checkout must not duplicate.
             assertEquals(1, transaction { OrderEntity.all().toList() }.size)
             assertEquals(9, productQuantity(productId))
         }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutServiceTest.kt
@@ -137,7 +137,7 @@ class CheckoutServiceTest {
             val result = service.checkout(validStoreRequest(userId, items = checkoutItems))
 
             assertTrue(result is CheckoutResult.Invalid)
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -223,7 +223,7 @@ class CheckoutServiceTest {
 
             assertTrue(result is CheckoutResult.Invalid)
             assertEquals(1, productQuantity(productId))
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -243,7 +243,7 @@ class CheckoutServiceTest {
             assertTrue(result is CheckoutResult.Invalid)
             assertEquals(10, productQuantity(productId1))
             assertEquals(1, productQuantity(productId2))
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -259,7 +259,7 @@ class CheckoutServiceTest {
 
             assertTrue(result is CheckoutResult.NotPaid)
             assertEquals(10, productQuantity(productId))
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -274,7 +274,7 @@ class CheckoutServiceTest {
             val result = service.checkout(validStoreRequest(userId, items = items, paymentHash = "hash-unknown"))
 
             assertTrue(result is CheckoutResult.NotPaid)
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -315,66 +315,8 @@ class CheckoutServiceTest {
             assertEquals(first.response.paymentId, second.response.paymentId)
 
             // Only one order persisted — the recovered checkout must not duplicate.
-            assertEquals(1, service.getStoreOrders().size)
+            assertEquals(1, transaction { OrderEntity.all().toList() }.size)
             assertEquals(9, productQuantity(productId))
-        }
-    }
-
-    @Test
-    fun `getStoreOrders returns empty list when no orders found`() {
-        runBlocking {
-            assertTrue(service.getStoreOrders().isEmpty())
-        }
-    }
-
-    @Test
-    fun `getStoreOrders returns store orders with items after checkout`() {
-        runBlocking {
-            val userId = seedUser()
-            val productId = ExposedTestDb.seedProduct(name = "Widget", quantity = 10)
-            val items = listOf(StoreCheckoutItem(productId = productId, quantity = 2, priceAtOrder = 500))
-            val checkout = service.checkout(validStoreRequest(userId, items = items))
-            assertTrue(checkout is CheckoutResult.Success)
-
-            val result = service.getStoreOrders()
-            assertEquals(1, result.size)
-            assertEquals(checkout.response.orderId, result[0].id)
-            assertEquals(1, result[0].items.size)
-            assertEquals(productId, result[0].items[0].productId)
-        }
-    }
-
-    @Test
-    fun `getStoreOrders filters by status`() {
-        runBlocking {
-            val userId = seedUser()
-            val productId = ExposedTestDb.seedProduct(quantity = 10)
-            val items = listOf(StoreCheckoutItem(productId = productId, quantity = 1, priceAtOrder = 100))
-            service.checkout(validStoreRequest(userId, items = items))
-
-            assertEquals(1, service.getStoreOrders(status = "paid").size)
-            assertTrue(service.getStoreOrders(status = "open").isEmpty())
-        }
-    }
-
-    @Test
-    fun `getStoreOrderById returns null when order not found`() {
-        runBlocking {
-            assertEquals(null, service.getStoreOrderById(UUID.randomUUID().toString()))
-        }
-    }
-
-    @Test
-    fun `getStoreOrderById returns order when found`() {
-        runBlocking {
-            val userId = seedUser()
-            val productId = ExposedTestDb.seedProduct(quantity = 10)
-            val items = listOf(StoreCheckoutItem(productId = productId, quantity = 1, priceAtOrder = 100))
-            val checkout = service.checkout(validStoreRequest(userId, items = items))
-            assertTrue(checkout is CheckoutResult.Success)
-
-            val result = service.getStoreOrderById(checkout.response.orderId)
-            assertEquals(checkout.response.orderId, result?.id)
         }
     }
 
@@ -384,7 +326,7 @@ class CheckoutServiceTest {
             val userId = seedUser()
             val orderId = ExposedTestDb.seedOrder(userId, status = "open")
             assertTrue(service.cancelStoreOrder(orderId))
-            assertEquals("closed", service.getStoreOrderById(orderId)?.status)
+            assertEquals("closed", transaction { OrderEntity.findById(UUID.fromString(orderId))?.status })
         }
     }
 
@@ -532,7 +474,7 @@ class CheckoutServiceTest {
 
             assertTrue(result is CheckoutResult.Invalid)
             assertEquals(1, productQuantity(componentId))
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 
@@ -555,7 +497,7 @@ class CheckoutServiceTest {
             assertTrue(result is CheckoutResult.Invalid)
             assertEquals(5, productQuantity(regularProductId))
             assertEquals(1, productQuantity(componentId))
-            assertTrue(service.getStoreOrders().isEmpty())
+            assertTrue(transaction { OrderEntity.all().toList() }.isEmpty())
         }
     }
 }


### PR DESCRIPTION
## Changes:

- Removed the dead `GET /store/orders` and `GET /store/orders/{id}` routes, since the client Orders page reads from `/orders/with-payments` (ReportService) instead; `DELETE /store/orders/{id}` (cancelStoreOrder) was kept
- Removed the now-unused `getStoreOrders`, `getStoreOrderById`, and `toStoreOrder` methods from `CheckoutService`
- Removed the unused `StoreOrder`/`StoreOrderItem` models from `AppModels`
- Dropped the `CheckoutServiceTest` coverage for the removed `StoreOrder` read path, replacing the assertions that relied on it with direct Exposed queries