### PR TITLE
Fix(Installer): Retry transient phoenixd download failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,11 @@ install-phoenixd:
 	TMP=$$(mktemp -d); \
 	trap 'rm -rf "$$TMP"' EXIT; \
 	echo "Downloading phoenixd $(PHOENIXD_TAG) ($$ZIP)..."; \
-	curl -fL --retry 3 \
+	curl -fL \
+	  --retry 5 \
+	  --retry-delay 5 \
+	  --retry-all-errors \
+	  --connect-timeout 30 \
 	  -o "$$TMP/$$ZIP" \
 	  "https://github.com/ACINQ/phoenixd/releases/download/v$(PHOENIXD_TAG)/$$ZIP" && \
 	sudo unzip -j -o "$$TMP/$$ZIP" -d "$(PHOENIXD_INSTALL_DIR)" && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,8 +60,13 @@ check_dependencies() {
 download_file() {
   local url="$1"
   local dest="$2"
-  # Retry 3 times, fail on error, follow redirects, silent unless error
-  if ! curl -fL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+  if ! curl -fL \
+    --retry 5 \
+    --retry-delay 5 \
+    --retry-all-errors \
+    --connect-timeout 30 \
+    -o "$dest" \
+    "$url"; then
     log_error "Failed to download $url"
     exit 1
   fi


### PR DESCRIPTION
  ## Summary

  - Harden phoenixd downloads against transient GitHub/network failures.
  - Increase curl retries from 3 to 5.
  - Add retry delay, retry-all-errors, and connection timeout options.
  - Apply the same retry behavior to both installer paths:
    - `scripts/install.sh`
    - `Makefile install-phoenixd`

  ## Context

  The installer CI failed on macOS ARM64 while downloading the phoenixd release asset from GitHub with a temporary `504` error.
  This change makes the installer more resilient to those transient failures without changing successful install behavior.
