### PR TITLE
Fix(CI): Pin uv setup action for E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,9 +27,9 @@ jobs:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "latest"
+        version: "0.11.28"
 
     - name: Cache Gradle dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
  ## Summary

  Fixes the E2E workflow setup failure by updating the uv setup action and pinning the uv version used in CI.

  ## Changes

  - Updates `astral-sh/setup-uv` from `v4` to `v8.1.0`.
  - Replaces `version: "latest"` with pinned `version: "0.11.28"`.

  ## Context

  The E2E workflow was failing before tests started, during the `Install uv` step. GitHub returned an HTML “Unicorn” error page
  while the action was resolving/downloading uv, so no Ambrosia E2E tests actually ran.

  Pinning the action and uv version avoids relying on the fragile `latest` lookup path during CI setup.
