### PR TITLE
Feature/refunds permissions

### DIFF
--- a/client/src/components/pages/Store/Orders/OrderDetailsModal/OrderDetailsModal.jsx
+++ b/client/src/components/pages/Store/Orders/OrderDetailsModal/OrderDetailsModal.jsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 
 import { AmountDisplay } from "@/components/shared/AmountDisplay";
 import { OrderProductsTable } from "@/components/shared/OrderProductsTable";
+import { usePermission } from "@/hooks/usePermission";
 import formatDate from "@lib/formatDate";
 
 import { StatusChip } from "../OrdersList/StatusChip";
@@ -18,6 +19,7 @@ import { RefundInfo } from "./RefundInfo";
 
 export function OrderDetailsModal({ order, isOpen, onClose, onRefunded, formatAmount, currentRate }) {
   const ordersTranslations = useTranslations("orders");
+  const canRefund = usePermission({ allOf: ["orders_refund"] });
   const [isRefundOpen, setIsRefundOpen] = useState(false);
   const {
     id,
@@ -135,7 +137,7 @@ export function OrderDetailsModal({ order, isOpen, onClose, onRefunded, formatAm
             )}
           </ModalBody>
           <ModalFooter className="flex justify-between">
-            {status === "paid" && (
+            {status === "paid" && canRefund && (
               <Button color="danger" onPress={() => setIsRefundOpen(true)}>
                 {ordersTranslations("details.refund")}
               </Button>

--- a/client/src/components/pages/Store/Orders/OrderDetailsModal/__tests__/OrderDetailsModal.test.jsx
+++ b/client/src/components/pages/Store/Orders/OrderDetailsModal/__tests__/OrderDetailsModal.test.jsx
@@ -23,6 +23,11 @@ jest.mock("@/lib/formatDate", () => ({
   default: jest.fn(() => "formatted-date"),
 }));
 
+let mockCanRefund = true;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanRefund,
+}));
+
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   const Modal = ({ isOpen, children }) => (isOpen ? <div>{children}</div> : null);
@@ -48,6 +53,10 @@ jest.mock("@heroui/react", () => {
 });
 
 describe("OrderDetailsModal", () => {
+  beforeEach(() => {
+    mockCanRefund = true;
+  });
+
   it("renders order details and handles close", () => {
     const onClose = jest.fn();
     const formatAmount = jest.fn((value) => `fmt-${value}`);
@@ -183,6 +192,22 @@ describe("OrderDetailsModal", () => {
         formatAmount={formatAmount}
       />,
     );
+    expect(screen.queryByText("details.refund")).not.toBeInTheDocument();
+  });
+
+  it("hides the refund button for a paid order when the user lacks orders_refund", () => {
+    mockCanRefund = false;
+    const formatAmount = jest.fn((value) => `fmt-${value}`);
+
+    render(
+      <OrderDetailsModal
+        order={{ id: "order-1", status: "paid", total: 10 }}
+        isOpen
+        onClose={jest.fn()}
+        formatAmount={formatAmount}
+      />,
+    );
+
     expect(screen.queryByText("details.refund")).not.toBeInTheDocument();
   });
 

--- a/client/src/components/pages/Store/Users/Roles/CreateRoleModal.jsx
+++ b/client/src/components/pages/Store/Users/Roles/CreateRoleModal.jsx
@@ -36,8 +36,8 @@ export function CreateRoleModal({
 
   const handleSelectTemplate = (template) => {
     setSelectedTemplate(template.key);
-    setForm((prev) => ({
-      ...prev,
+    setForm((previousForm) => ({
+      ...previousForm,
       name: template.key,
       isAdmin: template.isAdmin ?? false,
       permissions: template.permissions,
@@ -126,7 +126,7 @@ export function CreateRoleModal({
                   label={roleTranslations("roles.create.roleName")}
                   placeholder={roleTranslations("roles.create.roleNamePlaceholder")}
                   value={resolveRoleName(form.name, roleTranslations)}
-                  onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                  onChange={(event) => setForm((previousForm) => ({ ...previousForm, name: event.target.value }))}
                   isRequired
                 />
                 <Input
@@ -134,17 +134,18 @@ export function CreateRoleModal({
                   placeholder={roleTranslations("roles.create.passwordPlaceholder")}
                   type="password"
                   value={form.password}
-                  onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                  onChange={(event) => setForm((previousForm) => ({ ...previousForm, password: event.target.value }))}
                 />
-                <Checkbox
-                  isSelected={form.isAdmin}
-                  onValueChange={(isSelected) => setForm((prev) => ({ ...prev, isAdmin: isSelected }))}
-                >
-                  {roleTranslations("roles.create.isAdmin")}
-                </Checkbox>
               </div>
 
-              <div className="mt-4 space-y-4">
+              <Checkbox
+                isSelected={form.isAdmin}
+                onValueChange={(isSelected) => setForm((previousForm) => ({ ...previousForm, isAdmin: isSelected }))}
+              >
+                {roleTranslations("roles.create.isAdmin")}
+              </Checkbox>
+
+              <div className="space-y-4">
                 <p className="text-sm text-default-600">
                   {roleTranslations("roles.permissions.legend")}
                 </p>
@@ -153,6 +154,7 @@ export function CreateRoleModal({
                   selected={form.permissions}
                   togglePermission={togglePermission}
                   businessType={businessType}
+                  isAdmin={form.isAdmin}
                 />
               </div>
             </>

--- a/client/src/components/pages/Store/Users/Roles/EditRoleModal.jsx
+++ b/client/src/components/pages/Store/Users/Roles/EditRoleModal.jsx
@@ -52,7 +52,7 @@ export function EditRoleModal({
               label={roleTranslations("roles.edit.roleName")}
               placeholder={roleTranslations("roles.edit.roleNamePlaceholder")}
               value={form.name}
-              onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              onChange={(event) => setForm((previousForm) => ({ ...previousForm, name: event.target.value }))}
               isRequired
             />
             <Input
@@ -60,17 +60,18 @@ export function EditRoleModal({
               placeholder={roleTranslations("roles.edit.passwordPlaceholder")}
               type="password"
               value={form.password}
-              onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+              onChange={(event) => setForm((previousForm) => ({ ...previousForm, password: event.target.value }))}
             />
-            <Checkbox
-              isSelected={form.isAdmin}
-              onValueChange={(isSelected) => setForm((prev) => ({ ...prev, isAdmin: isSelected }))}
-            >
-              {roleTranslations("roles.edit.isAdmin")}
-            </Checkbox>
           </div>
 
-          <div className="mt-4 space-y-4">
+          <Checkbox
+            isSelected={form.isAdmin}
+            onValueChange={(isSelected) => setForm((previousForm) => ({ ...previousForm, isAdmin: isSelected }))}
+          >
+            {roleTranslations("roles.edit.isAdmin")}
+          </Checkbox>
+
+          <div className="space-y-4">
             <p className="text-sm text-default-600">
               {roleTranslations("roles.permissions.legend")}
             </p>
@@ -79,6 +80,7 @@ export function EditRoleModal({
               selected={form.permissions}
               togglePermission={togglePermission}
               businessType={businessType}
+              isAdmin={form.isAdmin}
             />
           </div>
         </ModalBody>

--- a/client/src/components/pages/Store/Users/Roles/PermissionSelector.jsx
+++ b/client/src/components/pages/Store/Users/Roles/PermissionSelector.jsx
@@ -9,6 +9,7 @@ export function PermissionSelector({
   selected = [],
   togglePermission,
   businessType,
+  isAdmin = false,
 }) {
   const roleTranslations = useTranslations();
   const selectedSet = useMemo(() => new Set(selected), [selected]);
@@ -22,13 +23,20 @@ export function PermissionSelector({
 
   return (
     <div className="space-y-4">
-      {businessType && (
-        <div className="flex justify-end">
-          <Chip size="sm" variant="flat">
-            {businessType === "store"
-              ? roleTranslations("roles.permissions.scope.store")
-              : roleTranslations("roles.permissions.scope.restaurant")}
-          </Chip>
+      {(businessType || isAdmin) && (
+        <div className="space-y-2">
+          <p className={`text-xs text-primary-600 ${isAdmin ? "" : "invisible"}`}>
+            {roleTranslations("roles.permissions.adminNotice")}
+          </p>
+          {businessType && (
+            <div className="flex justify-end">
+              <Chip size="sm" variant="flat">
+                {businessType === "store"
+                  ? roleTranslations("roles.permissions.scope.store")
+                  : roleTranslations("roles.permissions.scope.restaurant")}
+              </Chip>
+            </div>
+          )}
         </div>
       )}
       {Object.entries(groupedPermissions).map(([groupKey, permissions]) => (
@@ -43,7 +51,8 @@ export function PermissionSelector({
             {permissions.map((permission) => (
               <div key={permission.key} className="flex flex-col gap-1">
                 <Checkbox
-                  isSelected={selectedSet.has(permission.key)}
+                  isSelected={isAdmin || selectedSet.has(permission.key)}
+                  isDisabled={isAdmin}
                   onValueChange={() => togglePermission(permission.key)}
                 >
                   {roleTranslations(`roles.permissions.items.${permission.key}.label`, { defaultValue: permission.key })}

--- a/client/src/components/pages/Store/Users/Roles/__tests__/PermissionSelector.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/PermissionSelector.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+
+import { I18nProvider } from "@/i18n/I18nProvider";
+
+import { PermissionSelector } from "../PermissionSelector";
+
+const catalog = [
+  { key: "orders_read", group: "sales" },
+  { key: "orders_refund", group: "sales" },
+];
+
+const renderSelector = (props = {}) => render(
+  <I18nProvider>
+    <PermissionSelector
+      catalog={catalog}
+      selected={[]}
+      togglePermission={jest.fn()}
+      businessType="store"
+      {...props}
+    />
+  </I18nProvider>,
+);
+
+describe("PermissionSelector", () => {
+  it("keeps the admin notice space reserved but invisible when isAdmin is false", () => {
+    renderSelector({ isAdmin: false });
+    expect(screen.getByText("roles.permissions.adminNotice")).toHaveClass("invisible");
+  });
+
+  it("leaves checkboxes enabled and unchecked when isAdmin is false and nothing is selected", () => {
+    const { container } = renderSelector({ isAdmin: false });
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox).not.toBeDisabled();
+    });
+  });
+
+  it("shows the admin notice and forces every checkbox checked and disabled when isAdmin is true", () => {
+    const { container } = renderSelector({ isAdmin: true });
+    expect(screen.getByText("roles.permissions.adminNotice")).not.toHaveClass("invisible");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+      expect(checkbox).toBeDisabled();
+    });
+  });
+});

--- a/client/src/components/pages/Store/Users/Roles/locales/en.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/en.js
@@ -30,7 +30,7 @@ const rolesEn = {
       title: "Create role",
       roleName: "Role name",
       roleNamePlaceholder: "e.g. Cashier",
-      password: "Password for critical actions (optional)",
+      password: "Password for critical actions",
       passwordPlaceholder: "Optional",
       isAdmin: "With admin privileges",
       templateLegend: "Choose a role template to get started, or use advanced mode to configure it manually.",
@@ -74,6 +74,7 @@ const rolesEn = {
       title: "Visible permissions",
       subtitle: "Catalog filtered by business type",
       legend: "Select the permissions for this role. Only those that apply to the current business type are shown.",
+      adminNotice: "Admin roles automatically get every permission.",
       affects: "Affects:",
       related: {
         Users: "Users",

--- a/client/src/components/pages/Store/Users/Roles/locales/es.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/es.js
@@ -30,7 +30,7 @@ const rolesEs = {
       title: "Crear rol",
       roleName: "Nombre del rol",
       roleNamePlaceholder: "Ej. Cajero",
-      password: "Contraseña para acciones críticas (opcional)",
+      password: "Contraseña para acciones críticas",
       passwordPlaceholder: "Opcional",
       isAdmin: "Con privilegios de administrador",
       templateLegend: "Elige una plantilla de rol para comenzar, o usa el modo avanzado para configurarlo manualmente.",
@@ -74,6 +74,7 @@ const rolesEs = {
       title: "Permisos visibles",
       subtitle: "Catálogo filtrado según el tipo de negocio",
       legend: "Selecciona los permisos que tendrá este rol. Solo se muestran los que aplican al tipo de negocio actual.",
+      adminNotice: "Los roles admin reciben automáticamente todos los permisos.",
       affects: "Afecta a:",
       related: {
         Users: "Usuarios",

--- a/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
+++ b/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
@@ -37,7 +37,7 @@ export const permissionCatalog = [
   { key: "wallet_read", group: "payments", business: "store" },
 
   { key: "settings_update", group: "settings", business: "both", related: ["Settings"] },
-  { key: "printer_update", group: "settings", business: "restaurant" },
+  { key: "printer_update", group: "settings", business: "store" },
 
   { key: "dish_read", group: "menu", business: "restaurant", related: ["Dishes"] },
   { key: "dish_create", group: "menu", business: "restaurant" },
@@ -72,6 +72,6 @@ export const permissionCatalog = [
   { key: "tickets_create", group: "tickets", business: "both" },
   { key: "tickets_update", group: "tickets", business: "both" },
 
-  { key: "reports_read", group: "reports", business: "restaurant" },
-  { key: "reports_export", group: "reports", business: "restaurant" },
+  { key: "reports_read", group: "reports", business: "store" },
+  { key: "reports_export", group: "reports", business: "store" },
 ];

--- a/client/src/lib/__tests__/features.test.js
+++ b/client/src/lib/__tests__/features.test.js
@@ -1,0 +1,17 @@
+import { getAvailableFeatures } from "../features";
+
+const findRoute = (available, path) => Object.values(available)
+  .flatMap((feature) => feature.routes)
+  .find((route) => route.path === path);
+
+describe("getAvailableFeatures", () => {
+  it("includes /store/reports for a non-admin user with reports_read", () => {
+    const available = getAvailableFeatures(true, false, [{ name: "reports_read" }], "store");
+    expect(findRoute(available, "/store/reports")).toBeDefined();
+  });
+
+  it("excludes /store/reports for a user without reports_read, even with wallet_read", () => {
+    const available = getAvailableFeatures(true, false, [{ name: "wallet_read" }], "store");
+    expect(findRoute(available, "/store/reports")).toBeUndefined();
+  });
+});

--- a/client/src/lib/features.js
+++ b/client/src/lib/features.js
@@ -26,7 +26,7 @@ export const features = {
       { path: "/store/cart", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["orders_create"] },
       { path: "/store/orders", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["orders_read"] },
       { path: "/store/wallet", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["wallet_read"] },
-      { path: "/store/reports", requiresAuth: true, requiresAdmin: true, types: ["store"], permissions: ["wallet_read"] },
+      { path: "/store/reports", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["reports_read"] },
       { path: "/store/settings", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["settings_update"] },
     ],
     navItems: [

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PermissionsService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PermissionsService.kt
@@ -27,6 +27,8 @@ class PermissionsService {
             enabled = entity.enabled,
         )
 
+    private fun enabledPermissionIds() = PermissionEntity.find { PermissionsTable.enabled eq true }.map { it.id }
+
     fun getAll(): List<Permission> =
         transaction {
             PermissionEntity
@@ -77,16 +79,20 @@ class PermissionsService {
                     return@transaction 0
                 }
             val roleEntityId = EntityID(roleUUID, RolesTable)
-            if (RoleEntity.findById(roleUUID)?.takeIf { !it.isDeleted } == null) return@transaction 0
+            val role = RoleEntity.findById(roleUUID)?.takeIf { !it.isDeleted } ?: return@transaction 0
 
             RolePermissionsTable.deleteWhere { RolePermissionsTable.roleId eq roleEntityId }
 
-            if (permissionKeys.isEmpty()) return@transaction 0
+            if (!role.isAdmin && permissionKeys.isEmpty()) return@transaction 0
 
             val permissionIds =
-                PermissionEntity
-                    .find { (PermissionsTable.name inList permissionKeys) and (PermissionsTable.enabled eq true) }
-                    .map { it.id }
+                if (role.isAdmin) {
+                    enabledPermissionIds()
+                } else {
+                    PermissionEntity
+                        .find { (PermissionsTable.name inList permissionKeys) and (PermissionsTable.enabled eq true) }
+                        .map { it.id }
+                }
 
             permissionIds.sumOf { permissionId ->
                 RolePermissionsTable
@@ -108,9 +114,7 @@ class PermissionsService {
             val roleEntityId = EntityID(roleUUID, RolesTable)
             if (RoleEntity.findById(roleUUID)?.takeIf { !it.isDeleted } == null) return@transaction 0
 
-            val permissionIds = PermissionEntity.find { PermissionsTable.enabled eq true }.map { it.id }
-
-            permissionIds.sumOf { permissionId ->
+            enabledPermissionIds().sumOf { permissionId ->
                 RolePermissionsTable
                     .insertIgnore {
                         it[RolePermissionsTable.roleId] = roleEntityId

--- a/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
@@ -21,6 +21,7 @@ class RolesService(
     private val env: ApplicationEnvironment,
 ) {
     private val adminGuard = AdminGuardService()
+    private val permissionsService = PermissionsService()
 
     fun addRole(role: Role): String? =
         transaction {
@@ -38,14 +39,18 @@ class RolesService(
                     env = env,
                 )
 
+            val isAdmin = role.isAdmin ?: false
             val generatedId =
                 RoleEntity
                     .new(id) {
                         this.role = role.role
                         this.password = SecurePinProcessor.byteArrayToBase64(encryptedPin)
-                        this.isAdmin = role.isAdmin ?: false
+                        this.isAdmin = isAdmin
                     }.id.value
                     .toString()
+
+            grantAllPermissionsIfAdmin(generatedId, isAdmin)
+
             logger.info("Role created successfully with ID: $generatedId")
             generatedId
         }
@@ -111,7 +116,8 @@ class RolesService(
                 logger.error("Role name already exists: ${role.role}")
                 return@transaction false
             }
-            ensureRoleAdminInvariant(id, role.isAdmin ?: false)
+            val isAdmin = role.isAdmin ?: false
+            ensureRoleAdminInvariant(id, isAdmin)
 
             val entity = RoleEntity.findById(UUID.fromString(id))?.takeIf { !it.isDeleted }
             if (entity == null) {
@@ -119,15 +125,23 @@ class RolesService(
                 false
             } else {
                 entity.role = role.role
-                entity.isAdmin = role.isAdmin ?: false
+                entity.isAdmin = isAdmin
                 if (role.password != null) {
                     val encryptedPin = SecurePinProcessor.hashPinForStorage(role.password.toCharArray(), id, env)
                     entity.password = SecurePinProcessor.byteArrayToBase64(encryptedPin)
                 }
+                grantAllPermissionsIfAdmin(id, isAdmin)
                 logger.info("Role updated successfully: ${role.id}")
                 true
             }
         }
+
+    private fun grantAllPermissionsIfAdmin(
+        roleId: String,
+        isAdmin: Boolean,
+    ) {
+        if (isAdmin) permissionsService.assignAllEnabledToRole(roleId)
+    }
 
     fun deleteRole(id: String): Boolean =
         transaction {

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PermissionsServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PermissionsServiceTest.kt
@@ -125,6 +125,33 @@ class PermissionsServiceTest {
     }
 
     @Test
+    fun `replaceRolePermissions assigns all enabled permissions when role is admin`() {
+        val roleId = ExposedTestDb.seedRole("Admin", isAdmin = true)
+        ExposedTestDb.seedPermission("perm.read", "Read")
+        ExposedTestDb.seedPermission("perm.write", "Write")
+        ExposedTestDb.seedPermission("perm.disabled", "Disabled", enabled = false)
+
+        val count = service.replaceRolePermissions(roleId, emptyList())
+
+        assertEquals(2, count)
+        val names = service.getByRole(roleId)!!.map { it.name }
+        assertEquals(listOf("perm.read", "perm.write"), names)
+    }
+
+    @Test
+    fun `replaceRolePermissions ignores partial list and assigns all enabled permissions when role is admin`() {
+        val roleId = ExposedTestDb.seedRole("Admin", isAdmin = true)
+        ExposedTestDb.seedPermission("perm.read", "Read")
+        ExposedTestDb.seedPermission("perm.write", "Write")
+
+        val count = service.replaceRolePermissions(roleId, listOf("perm.read"))
+
+        assertEquals(2, count)
+        val names = service.getByRole(roleId)!!.map { it.name }
+        assertEquals(listOf("perm.read", "perm.write"), names)
+    }
+
+    @Test
     fun `assignAllEnabledToRole returns 0 when role does not exist`() {
         val count = service.assignAllEnabledToRole(UUID.randomUUID().toString())
         assertEquals(0, count)

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.After
 import org.junit.Before
 import pos.ambrosia.db.tables.UserEntity
 import pos.ambrosia.models.Role
+import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.RolesService
 import pos.ambrosia.utils.ExposedTestDb
 import pos.ambrosia.utils.LastAdminRemovalException
@@ -24,6 +25,7 @@ import kotlin.test.assertTrue
 class RoleServiceTest {
     private val env = applicationEnvironment { config = MapApplicationConfig("secret" to "test-secret") }
     private val service = RolesService(env)
+    private val permissionsService = PermissionsService()
     private lateinit var dbFile: File
 
     @Before
@@ -58,6 +60,32 @@ class RoleServiceTest {
         runBlocking {
             val result = service.addRole(Role(role = "Cashier", password = "1234", isAdmin = false))
             assertNotNull(result)
+        }
+    }
+
+    @Test
+    fun `addRole assigns all enabled permissions when isAdmin is true`() {
+        runBlocking {
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            ExposedTestDb.seedPermission("perm.write", "Write")
+
+            val roleId = service.addRole(Role(role = "Admin", password = "1234", isAdmin = true))
+
+            assertNotNull(roleId)
+            val names = permissionsService.getByRole(roleId!!)!!.map { it.name }
+            assertEquals(listOf("perm.read", "perm.write"), names)
+        }
+    }
+
+    @Test
+    fun `addRole does not assign permissions when isAdmin is false`() {
+        runBlocking {
+            ExposedTestDb.seedPermission("perm.read", "Read")
+
+            val roleId = service.addRole(Role(role = "Cashier", password = "1234", isAdmin = false))
+
+            assertNotNull(roleId)
+            assertTrue(permissionsService.getByRole(roleId!!)!!.isEmpty())
         }
     }
 
@@ -104,6 +132,21 @@ class RoleServiceTest {
 
             val updated = service.getRoleById(roleId)
             assertEquals("Manager", updated?.role)
+        }
+    }
+
+    @Test
+    fun `updateRole assigns all enabled permissions when isAdmin becomes true`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            ExposedTestDb.seedPermission("perm.write", "Write")
+
+            val result = service.updateRole(roleId, Role(role = "Manager", isAdmin = true))
+
+            assertTrue(result)
+            val names = permissionsService.getByRole(roleId)!!.map { it.name }
+            assertEquals(listOf("perm.read", "perm.write"), names)
         }
     }
 


### PR DESCRIPTION
 ## Changes:

- Auto-assign every enabled permission to admin roles on create/update, so a role marked `isAdmin` can never end up with zero permissions and be locked out of login.
- Correct the `business` tag for `reports_read`, `reports_export`, and `printer_update` in the permission catalog so they're assignable to Store roles, not just Restaurant.
- Disable and clarify the permission checklist in the Create/Edit role modals when a role is marked admin, since the backend now grants every permission automatically.
- Hide the refund button in the order details modal when the user lacks the `orders_refund` permission.
- Gate the Reports nav item by `reports_read` instead of the incorrect `wallet_read`, and drop the admin-only requirement.

**Screenshots**:

<img width="801" height="532" alt="Screenshot 2026-07-17 at 4 56 47 p m" src="https://github.com/user-attachments/assets/912baff9-c697-42bd-8ba3-267a3fe91e5f" />

<img width="329" height="576" alt="Screenshot 2026-07-17 at 4 57 33 p m" src="https://github.com/user-attachments/assets/f3d42500-f67a-4736-bb6d-1fc323da854c" />

<img width="483" height="460" alt="Screenshot 2026-07-17 at 5 01 47 p m" src="https://github.com/user-attachments/assets/06611072-2156-4c89-863f-a8468941f0ed" />
