### PR TITLE
Feature/refunds payments

### DIFF
--- a/client/src/components/pages/Store/Orders/RefundModal.jsx
+++ b/client/src/components/pages/Store/Orders/RefundModal.jsx
@@ -10,6 +10,7 @@ import {
   ModalFooter,
   Button,
   Textarea,
+  Checkbox,
   addToast,
 } from "@heroui/react";
 import { useTranslations } from "next-intl";
@@ -37,15 +38,25 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
   const [invoice, setInvoice] = useState("");
   const [invoiceError, setInvoiceError] = useState("");
   const [cashGiven, setCashGiven] = useState(0);
+  const [cardRefundAcknowledged, setCardRefundAcknowledged] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const isBtcOrder = order?.satoshiAmount != null;
   const isCashOrder = !isBtcOrder && order?.paymentMethod?.toLowerCase() === "cash";
+  const isCardOrder = !isBtcOrder && !isCashOrder;
   const orderTotalCents = Math.round((order?.total ?? 0) * 100);
   const cashGivenCents = Math.round((cashGiven || 0) * 100);
   const cashDifferenceCents = cashGivenCents - orderTotalCents;
   const isCashAmountExact = cashDifferenceCents === 0;
-  const isConfirmDisabled = isBtcOrder ? !invoice.trim() : isCashOrder ? !isCashAmountExact : false;
+
+  let isConfirmDisabled = false;
+  if (isBtcOrder) {
+    isConfirmDisabled = !invoice.trim();
+  } else if (isCashOrder) {
+    isConfirmDisabled = !isCashAmountExact;
+  } else if (isCardOrder) {
+    isConfirmDisabled = !cardRefundAcknowledged;
+  }
 
   function handleInvoiceChange(value) {
     setInvoice(value);
@@ -93,6 +104,7 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
     setInvoice("");
     setInvoiceError("");
     setCashGiven(0);
+    setCardRefundAcknowledged(false);
     onClose();
   }
 
@@ -139,6 +151,16 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
               isCashAmountExact={isCashAmountExact}
               formatAmount={formatAmount}
             />
+          )}
+          {isCardOrder && (
+            <div className="space-y-3">
+              <p className="text-sm text-gray-600">
+                {ordersTranslations("details.refundCardNotice")}
+              </p>
+              <Checkbox isSelected={cardRefundAcknowledged} onValueChange={setCardRefundAcknowledged}>
+                {ordersTranslations("details.refundCardAcknowledge")}
+              </Checkbox>
+            </div>
           )}
         </ModalBody>
         <ModalFooter className="flex justify-between">

--- a/client/src/components/pages/Store/Orders/__tests__/RefundModal.test.jsx
+++ b/client/src/components/pages/Store/Orders/__tests__/RefundModal.test.jsx
@@ -40,11 +40,27 @@ jest.mock("@heroui/react", () => ({
       />
     </label>
   ),
+  Checkbox: ({ children, isSelected, onValueChange }) => (
+    <label>
+      <input
+        type="checkbox"
+        aria-label={children}
+        checked={isSelected}
+        onChange={(e) => onValueChange(e.target.checked)}
+      />
+      {children}
+    </label>
+  ),
 }));
 
 jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
+
+function acknowledgeCardRefundAndConfirm() {
+  fireEvent.click(screen.getByLabelText("details.refundCardAcknowledge"));
+  fireEvent.click(screen.getByText("details.refundConfirm"));
+}
 
 describe("RefundModal", () => {
   beforeEach(() => {
@@ -60,7 +76,7 @@ describe("RefundModal", () => {
 
     expect(screen.queryByLabelText("details.refundInvoiceLabel")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("details.refundConfirm"));
+    acknowledgeCardRefundAndConfirm();
 
     await waitFor(() => expect(httpClient).toHaveBeenCalledWith("/store/orders/order-1/refund", {
       method: "POST",
@@ -82,6 +98,7 @@ describe("RefundModal", () => {
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
 
     expect(screen.getByText(/5000\s+details\.sats/)).toBeInTheDocument();
+    expect(screen.queryByText("details.refundCardNotice")).not.toBeInTheDocument();
     expect(screen.getByText("details.refundConfirm")).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("details.refundInvoiceLabel"), {
@@ -159,7 +176,7 @@ describe("RefundModal", () => {
 
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
 
-    fireEvent.click(screen.getByText("details.refundConfirm"));
+    acknowledgeCardRefundAndConfirm();
 
     await waitFor(() => expect(addToast).toHaveBeenCalledWith(
       expect.objectContaining({ color: "danger", description: "Network request failed" }),
@@ -175,7 +192,7 @@ describe("RefundModal", () => {
 
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
 
-    fireEvent.click(screen.getByText("details.refundConfirm"));
+    acknowledgeCardRefundAndConfirm();
 
     await waitFor(() => expect(addToast).toHaveBeenCalledWith(
       expect.objectContaining({ color: "danger", description: "Order has already been refunded" }),
@@ -191,7 +208,7 @@ describe("RefundModal", () => {
 
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
 
-    fireEvent.click(screen.getByText("details.refundConfirm"));
+    acknowledgeCardRefundAndConfirm();
 
     await waitFor(() => expect(addToast).toHaveBeenCalledWith(
       expect.objectContaining({ color: "danger", description: "details.refundError" }),
@@ -206,6 +223,7 @@ describe("RefundModal", () => {
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={jest.fn()} formatAmount={formatAmount} />);
 
     expect(screen.getByText("$10.00")).toBeInTheDocument();
+    expect(screen.queryByText("details.refundCardNotice")).not.toBeInTheDocument();
     expect(screen.getByText("details.refundConfirm")).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("details.cashGivenLabel"), { target: { value: "8" } });
@@ -236,13 +254,35 @@ describe("RefundModal", () => {
     expect(onRefunded).toHaveBeenCalled();
   });
 
-  it("does not show the cash-given input for a non-cash, non-BTC order", () => {
+  it("shows the card refund notice and disables confirm until acknowledged for a non-cash, non-BTC order", () => {
     const order = { id: "order-card", total: 10, paymentMethod: "Credit Card" };
 
     render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={jest.fn()} />);
 
     expect(screen.queryByLabelText("details.cashGivenLabel")).not.toBeInTheDocument();
+    expect(screen.getByText("details.refundCardNotice")).toBeInTheDocument();
+    expect(screen.getByText("details.refundConfirm")).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText("details.refundCardAcknowledge"));
+
     expect(screen.getByText("details.refundConfirm")).not.toBeDisabled();
+  });
+
+  it("refunds a card order once the refund is acknowledged", async () => {
+    httpClient.mockResolvedValue({ ok: true });
+    const onRefunded = jest.fn();
+    const order = { id: "order-card", total: 10, paymentMethod: "Credit Card" };
+
+    render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
+
+    acknowledgeCardRefundAndConfirm();
+
+    await waitFor(() => expect(httpClient).toHaveBeenCalledWith("/store/orders/order-card/refund", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoice: "" }),
+    }));
+    expect(onRefunded).toHaveBeenCalled();
   });
 
   it("resets the invoice and calls onClose when cancelled", () => {

--- a/client/src/components/pages/Store/Orders/locales/en.js
+++ b/client/src/components/pages/Store/Orders/locales/en.js
@@ -85,6 +85,8 @@ const ordersEn = {
       refundAmountLabel: "Amount to refund",
       cashGivenLabel: "Cash given to customer",
       differenceLabel: "Difference",
+      refundCardNotice: "This will only mark the order as refunded in Ambrosia. Process the actual refund on your card payment platform.",
+      refundCardAcknowledge: "I already processed this refund on my card payment platform",
       sats: "sats",
       refundInvoice: "Refund invoice",
       refundedAt: "Refunded at",

--- a/client/src/components/pages/Store/Orders/locales/es.js
+++ b/client/src/components/pages/Store/Orders/locales/es.js
@@ -85,6 +85,8 @@ const ordersEs = {
       refundAmountLabel: "Monto a reembolsar",
       cashGivenLabel: "Efectivo entregado al cliente",
       differenceLabel: "Diferencia",
+      refundCardNotice: "Esto solo marcará la orden como reembolsada en Ambrosia. El reembolso real se hace en tu plataforma de pagos de tarjeta.",
+      refundCardAcknowledge: "Ya procesé este reembolso en mi plataforma de pagos de tarjeta",
       sats: "sats",
       refundInvoice: "Invoice de reembolso",
       refundedAt: "Reembolsada el",

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -358,9 +358,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1683,14 +1683,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -1746,9 +1772,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1908,9 +1934,9 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3623,9 +3649,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4874,9 +4900,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -5180,9 +5206,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6903,9 +6929,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/RefundsTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/RefundsTable.kt
@@ -11,6 +11,7 @@ object RefundsTable : SQLiteUUIDTable("refunds") {
     val refundInvoice = text("refund_invoice")
     val satoshiAmount = long("satoshi_amount").default(0L)
     val refundedAt = varchar("refunded_at", 50)
+    val paymentHash = text("payment_hash").nullable()
 }
 
 class RefundEntity(
@@ -22,4 +23,5 @@ class RefundEntity(
     var refundInvoice by RefundsTable.refundInvoice
     var satoshiAmount by RefundsTable.satoshiAmount
     var refundedAt by RefundsTable.refundedAt
+    var paymentHash by RefundsTable.paymentHash
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/services/RefundService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/RefundService.kt
@@ -18,9 +18,12 @@ import pos.ambrosia.db.tables.ProductVariantsTable
 import pos.ambrosia.db.tables.RefundEntity
 import pos.ambrosia.db.tables.TicketPaymentsTable
 import pos.ambrosia.db.tables.TicketsTable
+import pos.ambrosia.logger
 import pos.ambrosia.models.RefundRequest
 import pos.ambrosia.models.StoreRefund
+import pos.ambrosia.models.phoenix.OutgoingPayment
 import pos.ambrosia.models.phoenix.PayInvoiceRequest
+import pos.ambrosia.utils.Bolt11Decoder
 import pos.ambrosia.utils.OrderAlreadyRefundedException
 import pos.ambrosia.utils.OrderNotRefundableException
 import pos.ambrosia.utils.ResourceNotFoundException
@@ -130,14 +133,12 @@ class RefundService(
                 throw OrderNotRefundableException("This order has no Bitcoin payment to refund via Lightning")
             }
 
-            var satoshiAmount = 0L
-            if (request.invoice.isNotBlank()) {
-                val paymentResponse =
-                    phoenixService.payInvoice(
-                        PayInvoiceRequest(invoice = request.invoice, amountSat = originalSatoshiAmount),
-                    )
-                satoshiAmount = paymentResponse.recipientAmountSat
-            }
+            val (satoshiAmount, paymentHash) =
+                if (request.invoice.isNotBlank()) {
+                    payRefundInvoice(orderId, request.invoice, originalSatoshiAmount)
+                } else {
+                    0L to null
+                }
 
             transaction {
                 items.forEach { restoreOrderLineStock(it) }
@@ -151,7 +152,10 @@ class RefundService(
                         this.refundInvoice = request.invoice
                         this.satoshiAmount = satoshiAmount
                         this.refundedAt = refundedAt
+                        this.paymentHash = paymentHash
                     }
+
+                logger.info("Refund persisted for order $orderId (refundId=${refundEntity.id.value})")
 
                 StoreRefund(
                     id = refundEntity.id.value.toString(),
@@ -162,4 +166,35 @@ class RefundService(
                 )
             }
         }
+
+    private suspend fun payRefundInvoice(
+        orderId: String,
+        invoice: String,
+        originalSatoshiAmount: Long?,
+    ): Pair<Long, String?> {
+        val paymentHash = Bolt11Decoder.decodeInvoice(invoice)?.paymentHash
+        val alreadyPaidPayment = findAlreadyPaidOutgoingPayment(paymentHash)
+
+        val satoshiAmount =
+            if (alreadyPaidPayment != null) {
+                logger.info("Refund invoice for order $orderId was already paid (hash=$paymentHash), skipping payInvoice")
+                alreadyPaidPayment.sent
+            } else {
+                val paymentResponse =
+                    phoenixService.payInvoice(
+                        PayInvoiceRequest(invoice = invoice, amountSat = originalSatoshiAmount),
+                    )
+                logger.info("Refund payment sent for order $orderId (hash=$paymentHash)")
+                paymentResponse.recipientAmountSat
+            }
+
+        return satoshiAmount to paymentHash
+    }
+
+    private suspend fun findAlreadyPaidOutgoingPayment(paymentHash: String?): OutgoingPayment? {
+        if (paymentHash == null) return null
+        return runCatching { phoenixService.getOutgoingPaymentByHash(paymentHash) }
+            .getOrNull()
+            ?.takeIf { it.isPaid }
+    }
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/Bolt11Decoder.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/Bolt11Decoder.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.payment.Bolt11Invoice
 data class DecodedInvoice(
     val amountSat: Long?,
     val description: String?,
+    val paymentHash: String?,
 )
 
 object Bolt11Decoder {
@@ -25,6 +26,7 @@ object Bolt11Decoder {
             DecodedInvoice(
                 amountSat = parsedInvoice.amount?.truncateToSatoshi()?.toLong(),
                 description = parsedInvoice.description,
+                paymentHash = parsedInvoice.paymentHash.toString(),
             )
         } catch (e: Exception) {
             null

--- a/server/app/src/main/resources/db/migration/V38__add_refunds_payment_hash.sql
+++ b/server/app/src/main/resources/db/migration/V38__add_refunds_payment_hash.sql
@@ -1,0 +1,3 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE refunds ADD COLUMN payment_hash TEXT;

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/Bolt11DecoderTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/Bolt11DecoderTest.kt
@@ -79,4 +79,12 @@ class Bolt11DecoderTest {
         assertEquals(2000000L, result!!.amountSat)
         assertNull(result.description)
     }
+
+    @Test
+    fun `decodeInvoice extracts a 64-character hex payment hash`() {
+        val result = Bolt11Decoder.decodeInvoice(invoiceWithDescription)
+        assert(result != null)
+        assertEquals(64, result!!.paymentHash?.length)
+        assert(result.paymentHash!!.matches(Regex("^[0-9a-fA-F]{64}$")))
+    }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/RefundServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/RefundServiceTest.kt
@@ -2,10 +2,13 @@ package pos.ambrosia.utest
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
@@ -15,6 +18,8 @@ import io.ktor.server.config.ApplicationConfigValue
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.After
 import org.junit.Before
@@ -22,6 +27,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import pos.ambrosia.db.tables.OrderEntity
+import pos.ambrosia.db.tables.OrdersTable
+import pos.ambrosia.db.tables.RefundEntity
+import pos.ambrosia.db.tables.RefundsTable
 import pos.ambrosia.models.RefundRequest
 import pos.ambrosia.models.UpsertVariantRequest
 import pos.ambrosia.services.PhoenixService
@@ -47,6 +55,12 @@ class RefundServiceTest {
             on { config } doReturn mockConfig
         }
 
+    private val decodableInvoice =
+        "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcy" +
+            "q5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0r" +
+            "l77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39" +
+            "tuven09sam30g4vgpfna3rh"
+
     @Before
     fun setUp() {
         dbFile = ExposedTestDb.connect()
@@ -63,25 +77,43 @@ class RefundServiceTest {
         ExposedTestDb.cleanup(dbFile)
     }
 
-    private fun refundServiceRespondingWithSats(recipientAmountSat: Long): RefundService {
-        val mockJsonResponse =
-            """
-            {
-                "recipientAmountSat": $recipientAmountSat,
-                "routingFeeSat": 0,
-                "paymentId": "refund-payment-id",
-                "paymentHash": "refund-payment-hash",
-                "paymentPreimage": "refund-payment-preimage"
-            }
-            """.trimIndent()
-        val mockEngine =
-            MockEngine { _ ->
-                respond(
-                    content = ByteReadChannel(mockJsonResponse.toByteArray(Charsets.UTF_8)),
-                    status = HttpStatusCode.OK,
-                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
-                )
-            }
+    private fun mockPayInvoiceJson(recipientAmountSat: Long) =
+        """
+        {
+            "recipientAmountSat": $recipientAmountSat,
+            "routingFeeSat": 0,
+            "paymentId": "refund-payment-id",
+            "paymentHash": "refund-payment-hash",
+            "paymentPreimage": "refund-payment-preimage"
+        }
+        """.trimIndent()
+
+    private fun mockOutgoingPaymentJson(
+        isPaid: Boolean,
+        sentSat: Long,
+    ) = """
+        {
+            "type": "outgoing_payment",
+            "subType": "lightning",
+            "paymentId": "existing-payment-id",
+            "paymentHash": "existing-payment-hash",
+            "isPaid": $isPaid,
+            "sent": $sentSat,
+            "fees": 0,
+            "createdAt": 0
+        }
+        """.trimIndent()
+
+    private fun isOutgoingByHashRequest(request: HttpRequestData) = request.method == HttpMethod.Get
+
+    private fun MockRequestHandleScope.respondJson(json: String) =
+        respond(
+            content = ByteReadChannel(json.toByteArray(Charsets.UTF_8)),
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+
+    private fun refundServiceWithHttpClient(mockEngine: MockEngine): RefundService {
         val mockHttpClient =
             HttpClient(mockEngine) {
                 install(ContentNegotiation) {
@@ -89,45 +121,57 @@ class RefundServiceTest {
                 }
             }
         return RefundService(PhoenixService(mockEnv, mockHttpClient))
+    }
+
+    private fun refundServiceRespondingWithSats(recipientAmountSat: Long): RefundService {
+        val mockEngine = MockEngine { _ -> respondJson(mockPayInvoiceJson(recipientAmountSat)) }
+        return refundServiceWithHttpClient(mockEngine)
     }
 
     private fun refundServiceCapturingAmountSat(
         recipientAmountSat: Long,
         onAmountSatSent: (Long?) -> Unit,
     ): RefundService {
-        val mockJsonResponse =
-            """
-            {
-                "recipientAmountSat": $recipientAmountSat,
-                "routingFeeSat": 0,
-                "paymentId": "refund-payment-id",
-                "paymentHash": "refund-payment-hash",
-                "paymentPreimage": "refund-payment-preimage"
-            }
-            """.trimIndent()
         val mockEngine =
             MockEngine { request ->
                 val sentAmountSat = (request.body as FormDataContent).formData["amountSat"]?.toLong()
                 onAmountSatSent(sentAmountSat)
-                respond(
-                    content = ByteReadChannel(mockJsonResponse.toByteArray(Charsets.UTF_8)),
-                    status = HttpStatusCode.OK,
-                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
-                )
+                respondJson(mockPayInvoiceJson(recipientAmountSat))
             }
-        val mockHttpClient =
-            HttpClient(mockEngine) {
-                install(ContentNegotiation) {
-                    json(Json { ignoreUnknownKeys = true })
-                }
-            }
-        return RefundService(PhoenixService(mockEnv, mockHttpClient))
+        return refundServiceWithHttpClient(mockEngine)
     }
 
     private fun refundServiceWithNoPhoenixCallExpected(): RefundService {
         val mockEngine = MockEngine { _ -> error("phoenixd should not be called for a non-BTC refund") }
         val mockHttpClient = HttpClient(mockEngine)
         return RefundService(PhoenixService(mockEnv, mockHttpClient))
+    }
+
+    private fun refundServiceWithOutgoingPaymentAlreadyPaid(sentSat: Long): RefundService {
+        val mockEngine =
+            MockEngine { request ->
+                if (isOutgoingByHashRequest(request)) {
+                    respondJson(mockOutgoingPaymentJson(isPaid = true, sentSat = sentSat))
+                } else {
+                    error("payInvoice should not be called when the invoice was already paid")
+                }
+            }
+        return refundServiceWithHttpClient(mockEngine)
+    }
+
+    private fun refundServiceWithOutgoingPaymentQueryFailing(
+        recipientAmountSat: Long,
+        failureStatus: HttpStatusCode,
+    ): RefundService {
+        val mockEngine =
+            MockEngine { request ->
+                if (isOutgoingByHashRequest(request)) {
+                    respond(content = "", status = failureStatus)
+                } else {
+                    respondJson(mockPayInvoiceJson(recipientAmountSat))
+                }
+            }
+        return refundServiceWithHttpClient(mockEngine)
     }
 
     private fun seedUser(): String {
@@ -143,6 +187,14 @@ class RefundServiceTest {
 
     private fun orderStatus(orderId: String): String =
         transaction { OrderEntity.findById(UUID.fromString(orderId))?.status ?: error("Order not found: $orderId") }
+
+    private fun refundPaymentHash(orderId: String): String? =
+        transaction {
+            RefundEntity
+                .find { RefundsTable.orderId eq EntityID(UUID.fromString(orderId), OrdersTable) }
+                .firstOrNull()
+                ?.paymentHash
+        }
 
     private fun seedPaidOrderWithLine(
         userId: String,
@@ -163,6 +215,17 @@ class RefundServiceTest {
         return orderId
     }
 
+    private fun seedPaidBtcOrderWithPayment(satoshiAmount: Long): String {
+        val userId = seedUser()
+        val productId = ExposedTestDb.seedProduct(name = "Widget", quantity = 5)
+        val variantId = defaultVariantId(productId)
+        val orderId = seedPaidOrderWithLine(userId, productId, variantId, quantity = 1, priceAtOrder = 500)
+        val paymentId = ExposedTestDb.seedPayment(satoshiAmount = satoshiAmount)
+        val ticketId = ExposedTestDb.seedTicket(orderId, userId)
+        ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+        return orderId
+    }
+
     @Test
     fun `processRefund on non-BTC order sets status refunded and satoshiAmount zero`() =
         runBlocking {
@@ -180,13 +243,7 @@ class RefundServiceTest {
     @Test
     fun `processRefund on BTC order calls payInvoice and stores recipientAmountSat`() =
         runBlocking {
-            val userId = seedUser()
-            val productId = ExposedTestDb.seedProduct(name = "Widget", quantity = 5)
-            val variantId = defaultVariantId(productId)
-            val orderId = seedPaidOrderWithLine(userId, productId, variantId, quantity = 1, priceAtOrder = 500)
-            val paymentId = ExposedTestDb.seedPayment(satoshiAmount = 1234)
-            val ticketId = ExposedTestDb.seedTicket(orderId, userId)
-            ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 1234)
 
             val refund = refundServiceRespondingWithSats(1234).processRefund(orderId, RefundRequest(invoice = "lnbc1..."))
 
@@ -197,13 +254,7 @@ class RefundServiceTest {
     @Test
     fun `processRefund forces amountSat to the order's original paid amount regardless of what the invoice itself requests`() =
         runBlocking {
-            val userId = seedUser()
-            val productId = ExposedTestDb.seedProduct(name = "Widget", quantity = 5)
-            val variantId = defaultVariantId(productId)
-            val orderId = seedPaidOrderWithLine(userId, productId, variantId, quantity = 1, priceAtOrder = 500)
-            val paymentId = ExposedTestDb.seedPayment(satoshiAmount = 895)
-            val ticketId = ExposedTestDb.seedTicket(orderId, userId)
-            ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 895)
 
             var sentAmountSat: Long? = null
             val refund =
@@ -350,5 +401,57 @@ class RefundServiceTest {
 
             assertEquals(8, variantQuantity(componentDefaultVariant))
             assertEquals(0, variantQuantity(bundleVariant))
+        }
+
+    @Test
+    fun `processRefund skips payInvoice and persists the already-paid amount when the invoice was paid in a previous attempt`() =
+        runBlocking {
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 1234)
+
+            val refund =
+                refundServiceWithOutgoingPaymentAlreadyPaid(sentSat = 1234)
+                    .processRefund(orderId, RefundRequest(invoice = decodableInvoice))
+
+            assertEquals(1234L, refund.satoshiAmount)
+            assertEquals("refunded", orderStatus(orderId))
+        }
+
+    @Test
+    fun `processRefund calls payInvoice normally when the outgoing payment lookup finds no prior payment`() =
+        runBlocking {
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 1234)
+
+            val refund =
+                refundServiceWithOutgoingPaymentQueryFailing(recipientAmountSat = 1234, failureStatus = HttpStatusCode.NotFound)
+                    .processRefund(orderId, RefundRequest(invoice = decodableInvoice))
+
+            assertEquals(1234L, refund.satoshiAmount)
+            assertEquals("refunded", orderStatus(orderId))
+        }
+
+    @Test
+    fun `processRefund calls payInvoice normally when the outgoing payment lookup fails unexpectedly`() =
+        runBlocking {
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 1234)
+
+            val refund =
+                refundServiceWithOutgoingPaymentQueryFailing(
+                    recipientAmountSat = 1234,
+                    failureStatus = HttpStatusCode.InternalServerError,
+                ).processRefund(orderId, RefundRequest(invoice = decodableInvoice))
+
+            assertEquals(1234L, refund.satoshiAmount)
+            assertEquals("refunded", orderStatus(orderId))
+        }
+
+    @Test
+    fun `processRefund persists the invoice's payment hash on the refund row`() =
+        runBlocking {
+            val orderId = seedPaidBtcOrderWithPayment(satoshiAmount = 1234)
+
+            refundServiceWithOutgoingPaymentQueryFailing(recipientAmountSat = 1234, failureStatus = HttpStatusCode.NotFound)
+                .processRefund(orderId, RefundRequest(invoice = decodableInvoice))
+
+            assertEquals(64, refundPaymentHash(orderId)?.length)
         }
 }


### PR DESCRIPTION
## Changes:

- Prevent duplicate Lightning payments when a refund is retried, by persisting the payment hash on the refund record and checking phoenixd for an already-paid outgoing payment before sending a new one.
- Require explicit acknowledgment before refunding card orders, since card refunds only update Ambrosia's record and don't move money — the modal now shows a notice and a checkbox before enabling confirm.

**Screenshots**:

<img width="418" height="359" alt="Screenshot 2026-07-22 at 6 54 26 p m" src="https://github.com/user-attachments/assets/76ce92cd-402a-4e55-a887-5e94ec2e6af7" />
