### PR TITLE
Feature/refunds reports

### DIFF
--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersDetailData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersDetailData.test.js
@@ -19,9 +19,15 @@ const makeOrders = (count) => (
 const formatCurrency = (cents) => `$${cents}`;
 
 describe("useOrdersDetailData", () => {
+  const OriginalBlob = global.Blob;
+
   beforeEach(() => {
     global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
     global.URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    global.Blob = OriginalBlob;
   });
 
   it("starts at page 1 with rowsPerPage 10", () => {
@@ -87,5 +93,43 @@ describe("useOrdersDetailData", () => {
     const { result } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
     act(() => result.current.exportToCsv());
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("exportToCsv includes a status column with the row's status", () => {
+    let capturedCsv;
+    global.Blob = jest.fn((parts) => {
+      capturedCsv = parts[0];
+      return {};
+    });
+    const orders = [
+      { shortId: "SH0", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 1000, itemCount: 1, items: [{ productName: "Widget", quantity: 1 }], refunded: true },
+      { shortId: "SH1", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 2000, itemCount: 1, items: [{ productName: "Gadget", quantity: 1 }], refunded: false },
+    ];
+    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => result.current.exportToCsv());
+
+    expect(capturedCsv).toContain("status.refunded");
+    expect(capturedCsv).toContain("status.paid");
+  });
+
+  it("exportToCsv appends a summary section with revenue and refund totals", () => {
+    let capturedCsv;
+    global.Blob = jest.fn((parts) => {
+      capturedCsv = parts[0];
+      return {};
+    });
+    const orders = [
+      { shortId: "SH0", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 1000, itemCount: 1, items: [{ productName: "Widget", quantity: 1 }], refunded: true },
+      { shortId: "SH1", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 2000, itemCount: 1, items: [{ productName: "Gadget", quantity: 1 }], refunded: false },
+    ];
+    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => result.current.exportToCsv());
+
+    expect(capturedCsv).toContain("summary.revenue");
+    expect(capturedCsv).toContain("$3000");
+    expect(capturedCsv).toContain("summary.netRevenue");
+    expect(capturedCsv).toContain("$2000");
+    expect(capturedCsv).toContain("summary.totalRefunded");
+    expect(capturedCsv).toContain("$1000");
   });
 });

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useSalesData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useSalesData.test.js
@@ -18,9 +18,15 @@ const makeSales = (count) => (
 const formatCurrency = (cents) => `$${cents}`;
 
 describe("useSalesData", () => {
+  const OriginalBlob = global.Blob;
+
   beforeEach(() => {
     global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
     global.URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    global.Blob = OriginalBlob;
   });
 
   it("starts at page 1 with rowsPerPage 10", () => {
@@ -86,5 +92,43 @@ describe("useSalesData", () => {
     const { result } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
     act(() => result.current.exportToCsv());
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("exportToCsv includes a status column with the row's status", () => {
+    let capturedCsv;
+    global.Blob = jest.fn((parts) => {
+      capturedCsv = parts[0];
+      return {};
+    });
+    const sales = [
+      { productName: "Widget", userName: "alice", quantity: 1, priceAtOrder: 1000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: true },
+      { productName: "Gadget", userName: "alice", quantity: 1, priceAtOrder: 2000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: false },
+    ];
+    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => result.current.exportToCsv());
+
+    expect(capturedCsv).toContain("status.refunded");
+    expect(capturedCsv).toContain("status.paid");
+  });
+
+  it("exportToCsv appends a summary section with revenue and refund totals", () => {
+    let capturedCsv;
+    global.Blob = jest.fn((parts) => {
+      capturedCsv = parts[0];
+      return {};
+    });
+    const sales = [
+      { productName: "Widget", userName: "alice", quantity: 1, priceAtOrder: 1000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: true },
+      { productName: "Gadget", userName: "alice", quantity: 1, priceAtOrder: 2000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: false },
+    ];
+    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => result.current.exportToCsv());
+
+    expect(capturedCsv).toContain("summary.revenue");
+    expect(capturedCsv).toContain("$3000");
+    expect(capturedCsv).toContain("summary.netRevenue");
+    expect(capturedCsv).toContain("$2000");
+    expect(capturedCsv).toContain("summary.totalRefunded");
+    expect(capturedCsv).toContain("$1000");
   });
 });

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl";
 
 import formatDate from "@lib/formatDate";
 
+import { refundedToStatus } from "../utils/refundedToStatus";
+
 const DEFAULT_ROWS_PER_PAGE = 10;
 
 export function useOrdersDetailData(orders, formatCurrency) {
@@ -34,6 +36,7 @@ export function useOrdersDetailData(orders, formatCurrency) {
     const headers = [
       reportsTranslations("orders.shortId"), reportsTranslations("sales.date"), reportsTranslations("sales.user"),
       reportsTranslations("orders.products"), reportsTranslations("sales.quantity"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"),
+      reportsTranslations("orders.statusLabel"),
     ];
     const rows = orders.map((order) => [
       order.shortId,
@@ -43,8 +46,19 @@ export function useOrdersDetailData(orders, formatCurrency) {
       order.itemCount,
       formatCurrency(order.total),
       order.paymentMethod ?? "",
+      reportsTranslations(`status.${refundedToStatus(order.refunded)}`),
     ]);
-    const csv = [headers, ...rows]
+
+    const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
+    const totalRefunded = orders.filter((order) => order.refunded).reduce((sum, order) => sum + order.total, 0);
+    const summaryRows = [
+      [],
+      [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
+      [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
+      [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
+    ];
+
+    const csv = [headers, ...rows, ...summaryRows]
       .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
       .join("\n");
     const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
@@ -11,6 +11,7 @@ const DEFAULT_ROWS_PER_PAGE = 10;
 
 export function useOrdersDetailData(orders, formatCurrency) {
   const reportsTranslations = useTranslations("reports");
+  const statusTranslations = useTranslations();
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const [prevOrders, setPrevOrders] = useState(orders);
@@ -46,7 +47,7 @@ export function useOrdersDetailData(orders, formatCurrency) {
       order.itemCount,
       formatCurrency(order.total),
       order.paymentMethod ?? "",
-      reportsTranslations(`status.${refundedToStatus(order.refunded)}`),
+      statusTranslations(`status.${refundedToStatus(order.refunded)}`),
     ]);
 
     const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
@@ -67,7 +68,7 @@ export function useOrdersDetailData(orders, formatCurrency) {
     link.download = `orders-report-${new Date().toISOString().slice(0, 10)}.csv`;
     link.click();
     URL.revokeObjectURL(url);
-  }, [orders, formatCurrency, reportsTranslations]);
+  }, [orders, formatCurrency, reportsTranslations, statusTranslations]);
 
   return { paginatedOrders, totalPages, page, setPage, rowsPerPage, handleRowsPerPageChange, exportToCsv };
 }

--- a/client/src/components/pages/Store/Reports/hooks/useSalesData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useSalesData.js
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl";
 
 import formatDate from "@lib/formatDate";
 
+import { refundedToStatus } from "../utils/refundedToStatus";
+
 const DEFAULT_ROWS_PER_PAGE = 10;
 
 export function useSalesData(sales, formatCurrency) {
@@ -34,6 +36,7 @@ export function useSalesData(sales, formatCurrency) {
     const headers = [
       reportsTranslations("sales.product"), reportsTranslations("sales.user"), reportsTranslations("sales.quantity"),
       reportsTranslations("sales.price"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"), reportsTranslations("sales.date"),
+      reportsTranslations("orders.statusLabel"),
     ];
     const rows = sales.map((sale) => [
       sale.productName,
@@ -43,8 +46,21 @@ export function useSalesData(sales, formatCurrency) {
       formatCurrency(sale.priceAtOrder * sale.quantity),
       sale.paymentMethod ?? "",
       sale.saleDate ? formatDate(sale.saleDate) : "",
+      reportsTranslations(`status.${refundedToStatus(sale.refunded)}`),
     ]);
-    const csv = [headers, ...rows]
+
+    const totalRevenue = sales.reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
+    const totalRefunded = sales
+      .filter((sale) => sale.refunded)
+      .reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
+    const summaryRows = [
+      [],
+      [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
+      [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
+      [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
+    ];
+
+    const csv = [headers, ...rows, ...summaryRows]
       .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
       .join("\n");
     const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));

--- a/client/src/components/pages/Store/Reports/hooks/useSalesData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useSalesData.js
@@ -11,6 +11,7 @@ const DEFAULT_ROWS_PER_PAGE = 10;
 
 export function useSalesData(sales, formatCurrency) {
   const reportsTranslations = useTranslations("reports");
+  const statusTranslations = useTranslations();
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const [prevSales, setPrevSales] = useState(sales);
@@ -46,7 +47,7 @@ export function useSalesData(sales, formatCurrency) {
       formatCurrency(sale.priceAtOrder * sale.quantity),
       sale.paymentMethod ?? "",
       sale.saleDate ? formatDate(sale.saleDate) : "",
-      reportsTranslations(`status.${refundedToStatus(sale.refunded)}`),
+      statusTranslations(`status.${refundedToStatus(sale.refunded)}`),
     ]);
 
     const totalRevenue = sales.reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
@@ -69,7 +70,7 @@ export function useSalesData(sales, formatCurrency) {
     link.download = `sales-report-${new Date().toISOString().slice(0, 10)}.csv`;
     link.click();
     URL.revokeObjectURL(url);
-  }, [sales, formatCurrency, reportsTranslations]);
+  }, [sales, formatCurrency, reportsTranslations, statusTranslations]);
 
   return { paginatedSales, totalPages, page, setPage, rowsPerPage, handleRowsPerPageChange, exportToCsv };
 }

--- a/client/src/components/pages/Store/Reports/locales/en.js
+++ b/client/src/components/pages/Store/Reports/locales/en.js
@@ -109,7 +109,6 @@ const reportsEn = {
       ofLabel: "of",
       paginationAria: "Sales pagination",
       tableAriaLabel: "Sales detail",
-      refundedBadge: "Refunded",
     },
     close: {
       modalTitle: "Confirm Shift Close",

--- a/client/src/components/pages/Store/Reports/locales/es.js
+++ b/client/src/components/pages/Store/Reports/locales/es.js
@@ -109,7 +109,6 @@ const reportsEs = {
       ofLabel: "de",
       paginationAria: "Paginación de ventas",
       tableAriaLabel: "Detalle de ventas",
-      refundedBadge: "Reembolsada",
     },
     close: {
       modalTitle: "Confirmar Cierre de Turno",

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
@@ -285,7 +285,7 @@ class ReportService {
                     .sumOf { it.satoshiAmount!! }
 
             val (totalRefundedCents, totalRefundedSatoshis, refundCount) =
-                getRefundTotals(dateRange, userId, paymentMethod)
+                getRefundTotals(dateRange, productName, userId, paymentMethod)
 
             ProductSalesReport(
                 totalRevenueCents = sales.sumOf { it.priceAtOrder.toLong() * it.quantity },
@@ -306,12 +306,15 @@ class ReportService {
 
     private fun getRefundTotals(
         dateRange: Pair<String, String>?,
+        productName: String?,
         userId: String?,
         paymentMethod: String?,
     ): Triple<Long, Long, Int> {
         val join =
             RefundsTable
                 .join(OrdersTable, JoinType.INNER, RefundsTable.orderId, OrdersTable.id)
+                .join(OrderProductsTable, JoinType.INNER, OrderProductsTable.orderId, OrdersTable.id)
+                .join(ProductsTable, JoinType.INNER, OrderProductsTable.productId, ProductsTable.id)
                 .join(TicketsTable, JoinType.INNER, TicketsTable.orderId, OrdersTable.id)
                 .join(TicketPaymentsTable, JoinType.INNER, TicketPaymentsTable.ticketId, TicketsTable.id)
                 .join(PaymentsTable, JoinType.INNER, PaymentsTable.id, TicketPaymentsTable.paymentId)
@@ -322,6 +325,7 @@ class ReportService {
             query = query.andWhere { dateFunc(RefundsTable.refundedAt) greaterEq start }
             query = query.andWhere { dateFunc(RefundsTable.refundedAt) lessEq end }
         }
+        productName?.let { name -> query = query.andWhere { ProductsTable.name like "%$name%" } }
         userId?.let { uid -> query = query.andWhere { OrdersTable.userId eq EntityID(UUID.fromString(uid), UsersTable) } }
         paymentMethod?.let { method -> query = query.andWhere { lowerFunc(PaymentMethodsTable.name) eq method.lowercase() } }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
@@ -612,22 +612,25 @@ class ReportServiceTest {
     }
 
     @Test
-    fun `productName filter does not affect refund totals`() {
-        val sale = seedSale(orderStatus = "refunded", total = 15.0, createdAt = "2024-06-10T12:00:00")
-        addOrderProduct(sale.orderId, productName = "Widget")
-        ExposedTestDb.seedRefund(sale.orderId, refundedAt = "2024-06-11T09:00:00")
+    fun `refund totals include refunds of orders with the matching product name`() {
+        val widget = seedSale(orderStatus = "refunded", total = 15.0, createdAt = "2024-06-10T12:00:00")
+        addOrderProduct(widget.orderId, productName = "Widget")
+        ExposedTestDb.seedRefund(widget.orderId, refundedAt = "2024-06-11T09:00:00")
+
+        val gadget = seedSale(orderStatus = "refunded", total = 25.0, createdAt = "2024-06-10T12:00:00")
+        addOrderProduct(gadget.orderId, productName = "Gadget")
+        ExposedTestDb.seedRefund(gadget.orderId, refundedAt = "2024-06-11T09:00:00")
 
         val report =
             service.getProductSalesReport(
                 period = null,
                 startDate = "2024-06-01",
                 endDate = "2024-06-30",
-                productName = "NonMatchingProduct",
+                productName = "Widget",
                 userId = null,
                 paymentMethod = null,
             )
 
-        assertTrue(report.sales.isEmpty())
         assertEquals(1, report.refundCount)
         assertEquals(1500L, report.totalRefundedCents)
     }


### PR DESCRIPTION
## Changes:

- Include the `productName` filter when computing aggregate refund totals in the product sales report, so a report filtered by product no longer counts refunds from unrelated products.
- Add a Status column and revenue/net revenue/refund summary totals to the Sales and Orders CSV exports, resolving the status label through the shared translations namespace.

**Screenshots**:

<img width="677" height="163" alt="Screenshot 2026-07-27 at 4 23 45 p m" src="https://github.com/user-attachments/assets/427ad326-59a3-4e16-998e-cb9a9ea43b39" />

<img width="668" height="167" alt="Screenshot 2026-07-27 at 4 25 02 p m" src="https://github.com/user-attachments/assets/d808dc9f-15e7-4d56-9759-5962f9a68508" />
