### PR TITLE
Feature/refunds shifts

### DIFF
--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -83,6 +83,7 @@ const componentsEn = {
     printCorteZError: "Error printing Z Report",
     shiftPeriod: "Shift period",
     totalSales: "Total sales",
+    cashSales: "Cash sales",
     totalTickets: "Total tickets",
     byPaymentMethod: "By payment method",
     expectedTotal: "Expected total",

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -84,6 +84,7 @@ const componentsEn = {
     shiftPeriod: "Shift period",
     totalSales: "Total sales",
     cashSales: "Cash sales",
+    cashRefunds: "Cash refunds",
     totalTickets: "Total tickets",
     byPaymentMethod: "By payment method",
     expectedTotal: "Expected total",

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -83,6 +83,7 @@ const componentsEs = {
     printCorteZError: "Error al imprimir el Corte Z",
     shiftPeriod: "Período del turno",
     totalSales: "Total de ventas",
+    cashSales: "Ventas en efectivo",
     totalTickets: "Total de tickets",
     byPaymentMethod: "Por método de pago",
     expectedTotal: "Total esperado",

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -84,6 +84,7 @@ const componentsEs = {
     shiftPeriod: "Período del turno",
     totalSales: "Total de ventas",
     cashSales: "Ventas en efectivo",
+    cashRefunds: "Reembolsos en efectivo",
     totalTickets: "Total de tickets",
     byPaymentMethod: "Por método de pago",
     expectedTotal: "Total esperado",

--- a/client/src/components/pages/Store/Cart/utils/__tests__/cartTotals.test.js
+++ b/client/src/components/pages/Store/Cart/utils/__tests__/cartTotals.test.js
@@ -58,4 +58,21 @@ describe("calculateCartTotals", () => {
       total: 2000,
     });
   });
+
+  it("rounds a percentage discount that would leave a fraction of a cent", () => {
+    const fractionalItems = [{ id: 1, subtotal: 999 }];
+    expect(calculateCartTotals(fractionalItems, 15)).toEqual({
+      subtotal: 999,
+      discountAmount: 150,
+      total: 849,
+    });
+  });
+
+  it("rounds a fixed discount that would leave a fraction of a cent", () => {
+    expect(calculateCartTotals(items, 19.995, "fixed")).toEqual({
+      subtotal: 2000,
+      discountAmount: 2000,
+      total: 0,
+    });
+  });
 });

--- a/client/src/components/pages/Store/Cart/utils/cartTotals.js
+++ b/client/src/components/pages/Store/Cart/utils/cartTotals.js
@@ -1,8 +1,9 @@
 export function calculateCartTotals(items, discountValue, discountType = "percentage") {
   const subtotal = items.reduce((sum, item) => sum + item.subtotal, 0);
-  const discountAmount =
+  const discountAmount = Math.round(
     discountType === "fixed"
       ? (Number(discountValue) || 0) * 100
-      : (subtotal * (Number(discountValue) || 0)) / 100;
+      : (subtotal * (Number(discountValue) || 0)) / 100,
+  );
   return { subtotal, discountAmount, total: subtotal - discountAmount };
 }

--- a/client/src/components/turn/CloseTurnModal.jsx
+++ b/client/src/components/turn/CloseTurnModal.jsx
@@ -32,7 +32,9 @@ export function CloseTurnModal({
   const reportsTranslations = useTranslations("reports");
   const shiftTranslations = useTranslations("shifts");
 
-  const { totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading } = useTurn();
+  const {
+    totalBalance, cashTotal, refundedCashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
+  } = useTurn();
 
   const { printTicket, printerConfigs, loadingConfigs } = usePrinters();
 
@@ -78,7 +80,7 @@ export function CloseTurnModal({
     : "—";
 
   const initialAmount = shiftData?.initialAmount ?? 0;
-  const expectedTotal = initialAmount + cashTotal;
+  const expectedTotal = initialAmount + cashTotal - refundedCashTotal;
   const difference = finalAmount - expectedTotal;
 
   return (
@@ -135,6 +137,10 @@ export function CloseTurnModal({
                   <div className="flex justify-between text-sm">
                     <span className="text-default-500">{shiftTranslations("cashSales")}</span>
                     <span>+ {formatCurrency(cashTotal)}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-default-500">{shiftTranslations("cashRefunds")}</span>
+                    <span>- {formatCurrency(refundedCashTotal)}</span>
                   </div>
                   <div className="flex justify-between text-sm font-semibold border-t border-default-200 pt-1 mt-1">
                     <span>{shiftTranslations("expectedTotal")}</span>

--- a/client/src/components/turn/CloseTurnModal.jsx
+++ b/client/src/components/turn/CloseTurnModal.jsx
@@ -81,7 +81,7 @@ export function CloseTurnModal({
 
   const initialAmount = shiftData?.initialAmount ?? 0;
   const expectedTotal = initialAmount + cashTotal - refundedCashTotal;
-  const difference = finalAmount - expectedTotal;
+  const difference = Math.round((finalAmount - expectedTotal) * 100) / 100;
 
   return (
     <Modal

--- a/client/src/components/turn/CloseTurnModal.jsx
+++ b/client/src/components/turn/CloseTurnModal.jsx
@@ -32,7 +32,7 @@ export function CloseTurnModal({
   const reportsTranslations = useTranslations("reports");
   const shiftTranslations = useTranslations("shifts");
 
-  const { totalBalance, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading } = useTurn();
+  const { totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading } = useTurn();
 
   const { printTicket, printerConfigs, loadingConfigs } = usePrinters();
 
@@ -78,7 +78,7 @@ export function CloseTurnModal({
     : "—";
 
   const initialAmount = shiftData?.initialAmount ?? 0;
-  const expectedTotal = initialAmount + totalBalance;
+  const expectedTotal = initialAmount + cashTotal;
   const difference = finalAmount - expectedTotal;
 
   return (
@@ -121,7 +121,7 @@ export function CloseTurnModal({
               classNames={{ inputWrapper: "shadow-none" }}
             />
 
-            {!ticketsLoading && (
+            {!ticketsLoading && !breakdownLoading && (
               <Card className="border">
                 <CardBody className="p-3 space-y-1">
                   <div className="flex justify-between text-sm">
@@ -131,6 +131,10 @@ export function CloseTurnModal({
                   <div className="flex justify-between text-sm">
                     <span className="text-default-500">{shiftTranslations("totalSales")}</span>
                     <span>+ {formatCurrency(totalBalance)}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-default-500">{shiftTranslations("cashSales")}</span>
+                    <span>+ {formatCurrency(cashTotal)}</span>
                   </div>
                   <div className="flex justify-between text-sm font-semibold border-t border-default-200 pt-1 mt-1">
                     <span>{shiftTranslations("expectedTotal")}</span>

--- a/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
+++ b/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
@@ -146,6 +146,14 @@ describe("CloseTurnModal", () => {
       expect(screen.queryByText("$280.00")).not.toBeInTheDocument();
     });
 
+    it("rounds the difference to the nearest cent so floating-point residue doesn't show as a discrepancy", () => {
+      setupMocks({ cashTotal: 0.001, refundedCashTotal: 0, ticketsLoading: false });
+      renderModal({ shiftData: { ...SHIFT_DATA, initialAmount: 0 } });
+      const differenceRow = screen.getByText("difference").closest("div");
+      expect(differenceRow.className).toContain("text-green-600");
+      expect(differenceRow.className).not.toContain("text-red-600");
+    });
+
     it("hides summary card while breakdown is loading even if tickets finished loading", () => {
       setupMocks({ ticketsLoading: false, breakdownLoading: true });
       renderModal();

--- a/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
+++ b/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
@@ -32,6 +32,7 @@ const SHIFT_DATA = {
 function setupMocks({
   totalBalance = 250,
   cashTotal = totalBalance,
+  refundedCashTotal = 0,
   totalTickets = 5,
   byPaymentMethod = [],
   ticketsLoading = false,
@@ -39,7 +40,9 @@ function setupMocks({
   printerConfigs = [],
   loadingConfigs = false,
 } = {}) {
-  useTurn.mockReturnValue({ totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading });
+  useTurn.mockReturnValue({
+    totalBalance, cashTotal, refundedCashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
+  });
   usePrinters.mockReturnValue({ printTicket: jest.fn(), printerConfigs, loadingConfigs });
 }
 
@@ -132,6 +135,15 @@ describe("CloseTurnModal", () => {
       renderModal();
       expect(screen.getByText("cashSales")).toBeInTheDocument();
       expect(screen.getByText("+ $180.00")).toBeInTheDocument();
+    });
+
+    it("shows cashRefunds line and subtracts it from expectedTotal", () => {
+      setupMocks({ totalBalance: 300, cashTotal: 180, refundedCashTotal: 30, ticketsLoading: false });
+      renderModal();
+      expect(screen.getByText("cashRefunds")).toBeInTheDocument();
+      expect(screen.getByText("- $30.00")).toBeInTheDocument();
+      expect(screen.getByText("$250.00")).toBeInTheDocument();
+      expect(screen.queryByText("$280.00")).not.toBeInTheDocument();
     });
 
     it("hides summary card while breakdown is loading even if tickets finished loading", () => {

--- a/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
+++ b/client/src/components/turn/__tests__/CloseTurnModal.test.jsx
@@ -31,13 +31,15 @@ const SHIFT_DATA = {
 
 function setupMocks({
   totalBalance = 250,
+  cashTotal = totalBalance,
   totalTickets = 5,
   byPaymentMethod = [],
   ticketsLoading = false,
+  breakdownLoading = false,
   printerConfigs = [],
   loadingConfigs = false,
 } = {}) {
-  useTurn.mockReturnValue({ totalBalance, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading: false });
+  useTurn.mockReturnValue({ totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading });
   usePrinters.mockReturnValue({ printTicket: jest.fn(), printerConfigs, loadingConfigs });
 }
 
@@ -118,10 +120,24 @@ describe("CloseTurnModal", () => {
       expect(screen.getByText("$100.00")).toBeInTheDocument();
     });
 
-    it("shows expectedTotal = initialAmount + totalBalance", () => {
-      setupMocks({ totalBalance: 250, ticketsLoading: false });
+    it("shows expectedTotal = initialAmount + cashTotal, not totalBalance", () => {
+      setupMocks({ totalBalance: 250, cashTotal: 180, ticketsLoading: false });
       renderModal();
-      expect(screen.getByText("$350.00")).toBeInTheDocument();
+      expect(screen.getByText("$280.00")).toBeInTheDocument();
+      expect(screen.queryByText("$350.00")).not.toBeInTheDocument();
+    });
+
+    it("shows cashSales line with the cashTotal value", () => {
+      setupMocks({ totalBalance: 250, cashTotal: 180, ticketsLoading: false });
+      renderModal();
+      expect(screen.getByText("cashSales")).toBeInTheDocument();
+      expect(screen.getByText("+ $180.00")).toBeInTheDocument();
+    });
+
+    it("hides summary card while breakdown is loading even if tickets finished loading", () => {
+      setupMocks({ ticketsLoading: false, breakdownLoading: true });
+      renderModal();
+      expect(screen.queryByText("expectedTotal")).not.toBeInTheDocument();
     });
 
     it("shows payment method breakdown when available", () => {
@@ -157,10 +173,10 @@ describe("CloseTurnModal", () => {
     it("calls onConfirm with finalAmount=0 and computed difference", async () => {
       const user = userEvent.setup();
       const onConfirm = jest.fn();
-      setupMocks({ totalBalance: 250, ticketsLoading: false });
+      setupMocks({ totalBalance: 250, cashTotal: 180, ticketsLoading: false });
       renderModal({ onConfirm });
       await user.click(screen.getByText("close.confirm"));
-      expect(onConfirm).toHaveBeenCalledWith(0, -350);
+      expect(onConfirm).toHaveBeenCalledWith(0, -280);
     });
 
     it("disables confirm button while confirmLoading=true", () => {

--- a/client/src/hooks/turn/__tests__/useShiftTicketMetrics.test.js
+++ b/client/src/hooks/turn/__tests__/useShiftTicketMetrics.test.js
@@ -5,6 +5,7 @@ jest.mock("@/services/ticketsService", () => ({
   getPayments: jest.fn(),
   getPaymentMethods: jest.fn(),
   getPaymentByTicketId: jest.fn(),
+  getOrdersWithPayments: jest.fn(),
 }));
 
 import {
@@ -12,19 +13,20 @@ import {
   getPayments,
   getPaymentMethods,
   getPaymentByTicketId,
+  getOrdersWithPayments,
 } from "@/services/ticketsService";
 
 import { useShiftTicketMetrics } from "../useShiftTicketMetrics";
 
 const SHIFT_DATE = "2026-03-04";
 const START_TIME = "08:00:00";
-const shiftStartMs = new Date(`${SHIFT_DATE}T${START_TIME}`).getTime();
+const shiftStartMilliseconds = new Date(`${SHIFT_DATE}T${START_TIME}`).getTime();
 
 const toSqliteUtc = (epochMilliseconds) => new Date(epochMilliseconds).toISOString().replace("T", " ").slice(0, 19);
 
-const ticketAfter1 = { id: 1, ticketDate: toSqliteUtc(shiftStartMs + 1000), totalAmount: 5.0 };
-const ticketAfter2 = { id: 2, ticketDate: toSqliteUtc(shiftStartMs + 2000), totalAmount: 3.0 };
-const ticketBefore = { id: 3, ticketDate: toSqliteUtc(shiftStartMs - 5000), totalAmount: 10.0 };
+const ticketAfter1 = { id: 1, ticketDate: toSqliteUtc(shiftStartMilliseconds + 1000), totalAmount: 5.0 };
+const ticketAfter2 = { id: 2, ticketDate: toSqliteUtc(shiftStartMilliseconds + 2000), totalAmount: 3.0 };
+const ticketBefore = { id: 3, ticketDate: toSqliteUtc(shiftStartMilliseconds - 5000), totalAmount: 10.0 };
 
 const SHIFT_DATA = { shiftDate: SHIFT_DATE, startTime: START_TIME };
 
@@ -33,6 +35,7 @@ beforeEach(() => {
   getPayments.mockResolvedValue([]);
   getPaymentMethods.mockResolvedValue([]);
   getPaymentByTicketId.mockResolvedValue([]);
+  getOrdersWithPayments.mockResolvedValue([]);
 });
 
 describe("useShiftTicketMetrics", () => {
@@ -41,6 +44,7 @@ describe("useShiftTicketMetrics", () => {
       const { result } = renderHook(() => useShiftTicketMetrics(null));
       expect(result.current.totalBalance).toBe(0);
       expect(result.current.cashTotal).toBe(0);
+      expect(result.current.refundedCashTotal).toBe(0);
       expect(result.current.totalTickets).toBe(0);
       expect(result.current.byPaymentMethod).toEqual([]);
       expect(result.current.ticketsLoading).toBe(false);
@@ -82,7 +86,7 @@ describe("useShiftTicketMetrics", () => {
     });
 
     it("counts ticket at exact shift start boundary", async () => {
-      const ticketAtBoundary = { id: 4, ticketDate: toSqliteUtc(shiftStartMs), totalAmount: 7.0 };
+      const ticketAtBoundary = { id: 4, ticketDate: toSqliteUtc(shiftStartMilliseconds), totalAmount: 7.0 };
       getTickets.mockResolvedValue([ticketAtBoundary]);
 
       const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
@@ -93,8 +97,8 @@ describe("useShiftTicketMetrics", () => {
     });
 
     it("filters ticket from previous shift that would appear in new shift due to UTC offset", async () => {
-      const oldShiftTicket = { id: 5, ticketDate: toSqliteUtc(shiftStartMs - 240000), totalAmount: 3.0 };
-      const newShiftTicket = { id: 6, ticketDate: toSqliteUtc(shiftStartMs + 60000), totalAmount: 1.0 };
+      const oldShiftTicket = { id: 5, ticketDate: toSqliteUtc(shiftStartMilliseconds - 240000), totalAmount: 3.0 };
+      const newShiftTicket = { id: 6, ticketDate: toSqliteUtc(shiftStartMilliseconds + 60000), totalAmount: 1.0 };
 
       getTickets.mockResolvedValue([oldShiftTicket, newShiftTicket]);
 
@@ -172,6 +176,91 @@ describe("useShiftTicketMetrics", () => {
       expect(result.current.cashTotal).toBe(0);
     });
 
+    it("computes refundedCashTotal summing only cash orders refunded during the shift", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Cash", total: 15.0, discountAmount: 0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 1000) } },
+        { paymentMethod: "Cash", total: 8.0, discountAmount: 0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 2000) } },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(23.0);
+    });
+
+    it("subtracts the discount from the order total when computing refundedCashTotal", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Cash", total: 15.0, discountAmount: 5.0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 1000) } },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(10.0);
+    });
+
+    it("excludes refunds on non-cash orders from refundedCashTotal", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Card", total: 8.0, discountAmount: 0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 1000) } },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(0);
+    });
+
+    it("excludes refunds that happened before the shift started", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Cash", total: 15.0, discountAmount: 0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds - 5000) } },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(0);
+    });
+
+    it("counts a refund processed this shift even when the original order was sold in a previous shift", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        {
+          paymentMethod: "Cash",
+          total: 15.0,
+          discountAmount: 0,
+          createdAt: toSqliteUtc(shiftStartMilliseconds - 86400000),
+          refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 1000) },
+        },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(15.0);
+    });
+
+    it("refundedCashTotal is 0 when no orders were refunded", async () => {
+      getTickets.mockResolvedValue([]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Cash", total: 15.0, discountAmount: 0, refund: null },
+      ]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.ticketsLoading).toBe(false));
+      await waitFor(() => expect(result.current.breakdownLoading).toBe(false));
+
+      expect(result.current.refundedCashTotal).toBe(0);
+    });
+
     it("uses 'other' translation key for unknown payment method", async () => {
       getTickets.mockResolvedValue([ticketAfter1]);
       getPayments.mockResolvedValue([{ id: 10, methodId: 99 }]);
@@ -228,6 +317,7 @@ describe("useShiftTicketMetrics", () => {
       expect(result.current.totalBalance).toBe(5.0);
       expect(result.current.totalTickets).toBe(1);
       expect(result.current.cashTotal).toBe(0);
+      expect(result.current.refundedCashTotal).toBe(0);
     });
 
     it("reset clears all metrics to initial state", async () => {
@@ -235,9 +325,12 @@ describe("useShiftTicketMetrics", () => {
       getPayments.mockResolvedValue([{ id: 10, methodId: 20 }]);
       getPaymentMethods.mockResolvedValue([{ id: 20, name: "Cash" }]);
       getPaymentByTicketId.mockResolvedValueOnce([{ paymentId: 10 }]);
+      getOrdersWithPayments.mockResolvedValue([
+        { paymentMethod: "Cash", total: 15.0, discountAmount: 0, refund: { refundedAt: toSqliteUtc(shiftStartMilliseconds + 1000) } },
+      ]);
 
       const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
-      await waitFor(() => expect(result.current.cashTotal).toBe(5.0));
+      await waitFor(() => expect(result.current.refundedCashTotal).toBe(15.0));
 
       act(() => {
         result.current.reset();
@@ -246,6 +339,7 @@ describe("useShiftTicketMetrics", () => {
       await waitFor(() => {
         expect(result.current.totalBalance).toBe(0);
         expect(result.current.cashTotal).toBe(0);
+        expect(result.current.refundedCashTotal).toBe(0);
         expect(result.current.totalTickets).toBe(0);
         expect(result.current.byPaymentMethod).toEqual([]);
       });

--- a/client/src/hooks/turn/__tests__/useShiftTicketMetrics.test.js
+++ b/client/src/hooks/turn/__tests__/useShiftTicketMetrics.test.js
@@ -40,6 +40,7 @@ describe("useShiftTicketMetrics", () => {
     it("returns initial state without fetching", () => {
       const { result } = renderHook(() => useShiftTicketMetrics(null));
       expect(result.current.totalBalance).toBe(0);
+      expect(result.current.cashTotal).toBe(0);
       expect(result.current.totalTickets).toBe(0);
       expect(result.current.byPaymentMethod).toEqual([]);
       expect(result.current.ticketsLoading).toBe(false);
@@ -139,6 +140,38 @@ describe("useShiftTicketMetrics", () => {
       );
     });
 
+    it("computes cashTotal summing only tickets paid in cash", async () => {
+      getTickets.mockResolvedValue([ticketAfter1, ticketAfter2]);
+      getPayments.mockResolvedValue([
+        { id: 10, methodId: 20 },
+        { id: 11, methodId: 21 },
+      ]);
+      getPaymentMethods.mockResolvedValue([
+        { id: 20, name: "Cash" },
+        { id: 21, name: "Card" },
+      ]);
+      getPaymentByTicketId
+        .mockResolvedValueOnce([{ paymentId: 10 }])
+        .mockResolvedValueOnce([{ paymentId: 11 }]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.byPaymentMethod).toHaveLength(2));
+
+      expect(result.current.cashTotal).toBe(5.0);
+    });
+
+    it("cashTotal is 0 when no tickets were paid in cash", async () => {
+      getTickets.mockResolvedValue([ticketAfter1]);
+      getPayments.mockResolvedValue([{ id: 10, methodId: 21 }]);
+      getPaymentMethods.mockResolvedValue([{ id: 21, name: "Card" }]);
+      getPaymentByTicketId.mockResolvedValueOnce([{ paymentId: 10 }]);
+
+      const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
+      await waitFor(() => expect(result.current.byPaymentMethod).toHaveLength(1));
+
+      expect(result.current.cashTotal).toBe(0);
+    });
+
     it("uses 'other' translation key for unknown payment method", async () => {
       getTickets.mockResolvedValue([ticketAfter1]);
       getPayments.mockResolvedValue([{ id: 10, methodId: 99 }]);
@@ -194,13 +227,17 @@ describe("useShiftTicketMetrics", () => {
 
       expect(result.current.totalBalance).toBe(5.0);
       expect(result.current.totalTickets).toBe(1);
+      expect(result.current.cashTotal).toBe(0);
     });
 
     it("reset clears all metrics to initial state", async () => {
       getTickets.mockResolvedValue([ticketAfter1, ticketAfter2]);
+      getPayments.mockResolvedValue([{ id: 10, methodId: 20 }]);
+      getPaymentMethods.mockResolvedValue([{ id: 20, name: "Cash" }]);
+      getPaymentByTicketId.mockResolvedValueOnce([{ paymentId: 10 }]);
 
       const { result } = renderHook(() => useShiftTicketMetrics(SHIFT_DATA));
-      await waitFor(() => expect(result.current.totalTickets).toBe(2));
+      await waitFor(() => expect(result.current.cashTotal).toBe(5.0));
 
       act(() => {
         result.current.reset();
@@ -208,6 +245,7 @@ describe("useShiftTicketMetrics", () => {
 
       await waitFor(() => {
         expect(result.current.totalBalance).toBe(0);
+        expect(result.current.cashTotal).toBe(0);
         expect(result.current.totalTickets).toBe(0);
         expect(result.current.byPaymentMethod).toEqual([]);
       });

--- a/client/src/hooks/turn/useShiftTicketMetrics.js
+++ b/client/src/hooks/turn/useShiftTicketMetrics.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useTranslations } from "next-intl";
 
+import { classifyPaymentMethod, PAYMENT_METHODS } from "@/components/pages/Store/Cart/utils/paymentMethods";
 import {
   getTickets,
   getPayments,
@@ -14,6 +15,7 @@ export function useShiftTicketMetrics(openShiftData) {
   const shiftTranslations = useTranslations("shifts");
 
   const [totalBalance, setTotalBalance] = useState(0);
+  const [cashTotal, setCashTotal] = useState(0);
   const [totalTickets, setTotalTickets] = useState(0);
   const [byPaymentMethod, setByPaymentMethod] = useState([]);
   const [ticketsLoading, setTicketsLoading] = useState(false);
@@ -28,6 +30,7 @@ export function useShiftTicketMetrics(openShiftData) {
       ]);
 
       const methodTotals = {};
+      let cashRunningTotal = 0;
       for (const ticket of shiftTickets) {
         const ticketPayments = await getPaymentByTicketId(ticket.id);
         if (!ticketPayments?.length) continue;
@@ -39,11 +42,16 @@ export function useShiftTicketMetrics(openShiftData) {
         const methodName = method?.name ?? shiftTranslations("other");
 
         methodTotals[methodName] = (methodTotals[methodName] ?? 0) + ticket.totalAmount;
+
+        if (classifyPaymentMethod(method?.name) === PAYMENT_METHODS.CASH) {
+          cashRunningTotal += ticket.totalAmount;
+        }
       }
 
       setByPaymentMethod(
         Object.entries(methodTotals).map(([name, total]) => ({ name, total })),
       );
+      setCashTotal(cashRunningTotal);
     } finally {
       setBreakdownLoading(false);
     }
@@ -79,6 +87,7 @@ export function useShiftTicketMetrics(openShiftData) {
 
   const reset = useCallback(() => {
     setTotalBalance(0);
+    setCashTotal(0);
     setTotalTickets(0);
     setByPaymentMethod([]);
     setTicketsLoading(false);
@@ -87,6 +96,7 @@ export function useShiftTicketMetrics(openShiftData) {
 
   return {
     totalBalance,
+    cashTotal,
     totalTickets,
     byPaymentMethod,
     ticketsLoading,

--- a/client/src/hooks/turn/useShiftTicketMetrics.js
+++ b/client/src/hooks/turn/useShiftTicketMetrics.js
@@ -9,6 +9,7 @@ import {
   getPayments,
   getPaymentMethods,
   getPaymentByTicketId,
+  getOrdersWithPayments,
 } from "@/services/ticketsService";
 
 export function useShiftTicketMetrics(openShiftData) {
@@ -16,17 +17,19 @@ export function useShiftTicketMetrics(openShiftData) {
 
   const [totalBalance, setTotalBalance] = useState(0);
   const [cashTotal, setCashTotal] = useState(0);
+  const [refundedCashTotal, setRefundedCashTotal] = useState(0);
   const [totalTickets, setTotalTickets] = useState(0);
   const [byPaymentMethod, setByPaymentMethod] = useState([]);
   const [ticketsLoading, setTicketsLoading] = useState(false);
   const [breakdownLoading, setBreakdownLoading] = useState(false);
 
-  const fetchTicketBreakdown = useCallback(async (shiftTickets) => {
+  const fetchTicketBreakdown = useCallback(async (shiftTickets, shiftStartMilliseconds) => {
     setBreakdownLoading(true);
     try {
-      const [payments, methods] = await Promise.all([
+      const [payments, methods, orders] = await Promise.all([
         getPayments(),
         getPaymentMethods(),
+        getOrdersWithPayments(),
       ]);
 
       const methodTotals = {};
@@ -48,10 +51,17 @@ export function useShiftTicketMetrics(openShiftData) {
         }
       }
 
+      const refundedCashRunningTotal = orders
+        .filter((order) => order.refund?.refundedAt)
+        .filter((order) => new Date(`${order.refund.refundedAt.replace(" ", "T")}Z`).getTime() >= shiftStartMilliseconds)
+        .filter((order) => classifyPaymentMethod(order.paymentMethod) === PAYMENT_METHODS.CASH)
+        .reduce((runningTotal, order) => runningTotal + (order.total - order.discountAmount), 0);
+
       setByPaymentMethod(
         Object.entries(methodTotals).map(([name, total]) => ({ name, total })),
       );
       setCashTotal(cashRunningTotal);
+      setRefundedCashTotal(refundedCashRunningTotal);
     } finally {
       setBreakdownLoading(false);
     }
@@ -62,19 +72,19 @@ export function useShiftTicketMetrics(openShiftData) {
 
     setTicketsLoading(true);
     try {
-      const shiftStartMs = new Date(
+      const shiftStartMilliseconds = new Date(
         `${openShiftData.shiftDate}T${openShiftData.startTime}`,
       ).getTime();
 
       const tickets = await getTickets();
       const shiftTickets = tickets.filter(
-        (ticket) => new Date(`${ticket.ticketDate.replace(" ", "T")}Z`).getTime() >= shiftStartMs,
+        (ticket) => new Date(`${ticket.ticketDate.replace(" ", "T")}Z`).getTime() >= shiftStartMilliseconds,
       );
 
       setTotalBalance(shiftTickets.reduce((runningTotal, ticket) => runningTotal + ticket.totalAmount, 0));
       setTotalTickets(shiftTickets.length);
 
-      fetchTicketBreakdown(shiftTickets).catch(() => {});
+      fetchTicketBreakdown(shiftTickets, shiftStartMilliseconds).catch(() => {});
     } catch {
     } finally {
       setTicketsLoading(false);
@@ -88,6 +98,7 @@ export function useShiftTicketMetrics(openShiftData) {
   const reset = useCallback(() => {
     setTotalBalance(0);
     setCashTotal(0);
+    setRefundedCashTotal(0);
     setTotalTickets(0);
     setByPaymentMethod([]);
     setTicketsLoading(false);
@@ -97,6 +108,7 @@ export function useShiftTicketMetrics(openShiftData) {
   return {
     totalBalance,
     cashTotal,
+    refundedCashTotal,
     totalTickets,
     byPaymentMethod,
     ticketsLoading,

--- a/client/src/providers/turn/TurnProvider.jsx
+++ b/client/src/providers/turn/TurnProvider.jsx
@@ -17,6 +17,7 @@ export function TurnProvider({ children }) {
 
   const {
     totalBalance,
+    cashTotal,
     totalTickets,
     byPaymentMethod,
     ticketsLoading,
@@ -88,6 +89,7 @@ export function TurnProvider({ children }) {
       openShift,
       closeShift,
       totalBalance,
+      cashTotal,
       totalTickets,
       byPaymentMethod,
       ticketsLoading,
@@ -97,7 +99,7 @@ export function TurnProvider({ children }) {
     [
       openTurnId, openShiftData, loading, error,
       updateTurn, refreshTurn, loadOpenTurn, openShift, closeShift,
-      totalBalance, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
+      totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
       refreshShiftTickets,
     ],
   );

--- a/client/src/providers/turn/TurnProvider.jsx
+++ b/client/src/providers/turn/TurnProvider.jsx
@@ -18,6 +18,7 @@ export function TurnProvider({ children }) {
   const {
     totalBalance,
     cashTotal,
+    refundedCashTotal,
     totalTickets,
     byPaymentMethod,
     ticketsLoading,
@@ -90,6 +91,7 @@ export function TurnProvider({ children }) {
       closeShift,
       totalBalance,
       cashTotal,
+      refundedCashTotal,
       totalTickets,
       byPaymentMethod,
       ticketsLoading,
@@ -99,7 +101,7 @@ export function TurnProvider({ children }) {
     [
       openTurnId, openShiftData, loading, error,
       updateTurn, refreshTurn, loadOpenTurn, openShift, closeShift,
-      totalBalance, cashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
+      totalBalance, cashTotal, refundedCashTotal, totalTickets, byPaymentMethod, ticketsLoading, breakdownLoading,
       refreshShiftTickets,
     ],
   );

--- a/client/src/providers/turn/__tests__/TurnProvider.test.jsx
+++ b/client/src/providers/turn/__tests__/TurnProvider.test.jsx
@@ -59,6 +59,7 @@ describe("TurnProvider", () => {
     useShiftTicketMetrics.mockReturnValue({
       totalBalance: 130,
       cashTotal: 60,
+      refundedCashTotal: 0,
       totalTickets: 11,
       byPaymentMethod: [{ name: "Cash", total: 60 }],
       ticketsLoading: false,
@@ -79,6 +80,7 @@ describe("TurnProvider", () => {
     useShiftTicketMetrics.mockReturnValue({
       totalBalance: 130,
       cashTotal: 60,
+      refundedCashTotal: 0,
       totalTickets: 11,
       byPaymentMethod: [],
       ticketsLoading: false,
@@ -91,5 +93,25 @@ describe("TurnProvider", () => {
 
     await waitFor(() => expect(screen.getByText("+ $60.00")).toBeInTheDocument());
     expect(screen.queryByText("$230.00")).not.toBeInTheDocument();
+  });
+
+  it("forwards refundedCashTotal from useShiftTicketMetrics and subtracts it from expectedTotal", async () => {
+    useShiftTicketMetrics.mockReturnValue({
+      totalBalance: 130,
+      cashTotal: 60,
+      refundedCashTotal: 20,
+      totalTickets: 11,
+      byPaymentMethod: [],
+      ticketsLoading: false,
+      breakdownLoading: false,
+      refresh: jest.fn(),
+      reset: jest.fn(),
+    });
+
+    renderCloseTurnModal();
+
+    await waitFor(() => expect(screen.getByText("- $20.00")).toBeInTheDocument());
+    expect(screen.getByText("$140.00")).toBeInTheDocument();
+    expect(screen.queryByText("$160.00")).not.toBeInTheDocument();
   });
 });

--- a/client/src/providers/turn/__tests__/TurnProvider.test.jsx
+++ b/client/src/providers/turn/__tests__/TurnProvider.test.jsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@/hooks/auth/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1", userId: "user-1" } }),
+}));
+
+jest.mock("@/hooks/turn/useShiftTicketMetrics", () => ({
+  useShiftTicketMetrics: jest.fn(),
+}));
+
+jest.mock("@/services/shiftsService", () => ({
+  getTurnOpen: jest.fn(),
+  openTurn: jest.fn(),
+  closeTurn: jest.fn(),
+}));
+
+jest.mock("@/components/pages/Store/hooks/usePrinter", () => ({
+  usePrinters: () => ({ printTicket: jest.fn(), printerConfigs: [], loadingConfigs: false }),
+}));
+
+jest.mock("@/hooks/turn/useTurn", () => jest.requireActual("../../../hooks/turn/useTurn"));
+
+import { CloseTurnModal } from "@/components/turn/CloseTurnModal";
+import { useShiftTicketMetrics } from "@/hooks/turn/useShiftTicketMetrics";
+import { getTurnOpen } from "@/services/shiftsService";
+
+import { TurnProvider } from "../TurnProvider";
+
+const formatCurrency = (amount) => `$${Number(amount).toFixed(2)}`;
+
+const SHIFT_DATA = {
+  id: "shift-1",
+  shiftDate: "2026-03-04",
+  startTime: "09:00:00",
+  initialAmount: 100,
+};
+
+function renderCloseTurnModal() {
+  return render(
+    <TurnProvider>
+      <CloseTurnModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        shiftData={SHIFT_DATA}
+        formatCurrency={formatCurrency}
+      />
+    </TurnProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getTurnOpen.mockResolvedValue(SHIFT_DATA);
+});
+
+describe("TurnProvider", () => {
+  it("forwards totalBalance, cashTotal and byPaymentMethod from useShiftTicketMetrics to a real consumer", async () => {
+    useShiftTicketMetrics.mockReturnValue({
+      totalBalance: 130,
+      cashTotal: 60,
+      totalTickets: 11,
+      byPaymentMethod: [{ name: "Cash", total: 60 }],
+      ticketsLoading: false,
+      breakdownLoading: false,
+      refresh: jest.fn(),
+      reset: jest.fn(),
+    });
+
+    renderCloseTurnModal();
+
+    await waitFor(() => expect(screen.getByText("$160.00")).toBeInTheDocument());
+    expect(screen.getByText("+ $130.00")).toBeInTheDocument();
+    expect(screen.getByText("+ $60.00")).toBeInTheDocument();
+    expect(screen.getByText("Cash")).toBeInTheDocument();
+  });
+
+  it("does not fall back to totalBalance when cashTotal differs from it", async () => {
+    useShiftTicketMetrics.mockReturnValue({
+      totalBalance: 130,
+      cashTotal: 60,
+      totalTickets: 11,
+      byPaymentMethod: [],
+      ticketsLoading: false,
+      breakdownLoading: false,
+      refresh: jest.fn(),
+      reset: jest.fn(),
+    });
+
+    renderCloseTurnModal();
+
+    await waitFor(() => expect(screen.getByText("+ $60.00")).toBeInTheDocument());
+    expect(screen.queryByText("$230.00")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/services/ticketsService.js
+++ b/client/src/services/ticketsService.js
@@ -22,3 +22,9 @@ export async function getPaymentByTicketId(id) {
   const response = await httpClient(`/payments/ticket-payments/by-ticket/${id}`);
   return await parseJsonResponse(response, null);
 }
+
+export async function getOrdersWithPayments() {
+  const response = await httpClient("/orders/with-payments");
+  const orders = await parseJsonResponse(response, []);
+  return orders ?? [];
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/CheckoutService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/CheckoutService.kt
@@ -29,6 +29,7 @@ import pos.ambrosia.logger
 import pos.ambrosia.models.StoreCheckoutRequest
 import pos.ambrosia.models.StoreCheckoutResponse
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 private class InsufficientStockException : Exception()
@@ -187,7 +188,7 @@ class CheckoutService(
 
         return try {
             transaction {
-                val now = LocalDateTime.now().toString()
+                val now = LocalDateTime.now(ZoneOffset.UTC).toString()
                 val order =
                     OrderEntity.new(UUID.randomUUID()) {
                         this.userId = EntityID(UUID.fromString(request.userId), UsersTable)

--- a/server/app/src/main/kotlin/pos/ambrosia/services/RefundService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/RefundService.kt
@@ -32,6 +32,7 @@ import pos.ambrosia.utils.OrderAlreadyRefundedException
 import pos.ambrosia.utils.OrderNotRefundableException
 import pos.ambrosia.utils.ResourceNotFoundException
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 class RefundService(
@@ -149,7 +150,7 @@ class RefundService(
 
                 order.status = "refunded"
 
-                val refundedAt = LocalDateTime.now().toString()
+                val refundedAt = LocalDateTime.now(ZoneOffset.UTC).toString()
                 val refundEntity =
                     RefundEntity.new(UUID.randomUUID()) {
                         this.orderId = order.id


### PR DESCRIPTION
## Changes:

- Reconcile the shift close "expected cash" total against cash sales only, instead of summing every payment method — card and Lightning sales were inflating the expected cash figure.
- Discount cash refunds processed during the shift from the expected cash total, so cash paid back to customers no longer shows up as an unexplained register shortage.
- Write checkout and refund timestamps in UTC instead of the server's local time, fixing a mismatch that caused tickets and refunds to be silently excluded from the current shift's totals.
- Round the cart discount amount and the shift close difference to the nearest cent, eliminating fractional-cent and floating-point residue that could flag a perfectly balanced register as a discrepancy.

**Related Issues**:

https://github.com/olympus-btc/ambrosia/issues/499
https://github.com/olympus-btc/ambrosia/issues/646

**Screenshots**:

<img width="479" height="693" alt="Screenshot 2026-07-28 at 11 41 26 p m" src="https://github.com/user-attachments/assets/34e0bcfc-bfad-4bd0-9ea7-9c35c5087411" />

