### PR TITLE
Feature refunds dashboard

### DIFF
--- a/client/src/components/pages/Store/Store.jsx
+++ b/client/src/components/pages/Store/Store.jsx
@@ -4,6 +4,8 @@ import { Card, CardHeader, CardBody } from "@heroui/card";
 import { Users, Package, ShoppingCart } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
+import { usePermission } from "@/hooks/usePermission";
 import { PageHeader } from "@components/shared/PageHeader";
 
 import { useOrders } from "./hooks/useOrders";
@@ -15,8 +17,17 @@ export function Store() {
   const { users } = useUsers();
   const { products } = useProducts();
   const { orders } = useOrders();
+  const { formatAmount } = useCurrency();
+  const canSeeRevenue = usePermission({ allOf: ["reports_read"] });
 
-  const paidOrdersCount = orders?.filter((order) => order.status === "paid")?.length || 0;
+  const formatCurrency = (amount) => formatAmount(Math.round(amount * 100));
+
+  const paidOrders = orders?.filter((order) => order.status === "paid") ?? [];
+  const netRevenue = paidOrders.reduce((sum, order) => sum + (order.total ?? 0), 0);
+
+  const salesStat = canSeeRevenue
+    ? { name: t("stats.revenue"), quantity: formatCurrency(netRevenue) }
+    : { name: t("stats.sales"), quantity: paidOrders.length };
 
   const STATS = [
     {
@@ -33,8 +44,7 @@ export function Store() {
     },
     {
       id: 3,
-      name: t("stats.sales"),
-      quantity: paidOrdersCount,
+      ...salesStat,
       icon: ShoppingCart,
     },
   ];

--- a/client/src/components/pages/Store/__tests__/Store.test.jsx
+++ b/client/src/components/pages/Store/__tests__/Store.test.jsx
@@ -1,5 +1,6 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, within } from "@testing-library/react";
 
+import { useCurrency } from "@/components/hooks/useCurrency";
 import * as useNavigationHook from "@/hooks/useNavigation";
 import { I18nProvider } from "@/i18n/I18nProvider";
 import * as configurationsProvider from "@/providers/configurations/configurationsProvider";
@@ -29,6 +30,15 @@ jest.mock("lucide-react", () => ({
 
 jest.mock("@/lib/http", () => ({
   httpClient: jest.fn(() => Promise.resolve({})),
+}));
+
+let mockCanSeeRevenue = false;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanSeeRevenue,
+}));
+
+jest.mock("@/components/hooks/useCurrency", () => ({
+  useCurrency: jest.fn(),
 }));
 
 const localStorageMock = {
@@ -73,6 +83,11 @@ describe("Store Dashboard", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockCanSeeRevenue = false;
+    useCurrency.mockReturnValue({
+      formatAmount: (cents) => `$${(cents / 100).toFixed(2)}`,
+    });
 
     jest.spyOn(useNavigationHook, "useNavigation").mockReturnValue({
       availableFeatures: {},
@@ -233,5 +248,48 @@ describe("Store Dashboard", () => {
     expect(screen.getByText("stats.users")).toBeInTheDocument();
     expect(screen.getByText("stats.products")).toBeInTheDocument();
     expect(screen.getByText("stats.sales")).toBeInTheDocument();
+  });
+
+  const ordersWithRevenue = [
+    { id: 1, status: "paid", total: 100 },
+    { id: 2, status: "paid", total: 50 },
+    { id: 3, status: "refunded", total: 9999 },
+    { id: 4, status: "pending", total: 30 },
+  ];
+
+  it("shows the paid order count, not revenue, for a user without reports_read", async () => {
+    mockCanSeeRevenue = false;
+    jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: ordersWithRevenue,
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.queryByText("stats.revenue")).not.toBeInTheDocument();
+    const salesCard = screen.getByText("stats.sales").closest(".border");
+    expect(within(salesCard).getByText("2")).toBeInTheDocument();
+  });
+
+  it("shows net revenue instead of the count for a user with reports_read, excluding refunded orders", async () => {
+    mockCanSeeRevenue = true;
+    jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: ordersWithRevenue,
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.getByText("stats.revenue")).toBeInTheDocument();
+    expect(screen.queryByText("stats.sales")).not.toBeInTheDocument();
+    expect(screen.getByText("$150.00")).toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -31,6 +31,7 @@ const storeEn = {
       users: "Users",
       products: "Products",
       sales: "Sales",
+      revenue: "Revenue",
     },
   },
   ...usersEn,

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -31,6 +31,7 @@ const storeEs = {
       users: "Usuarios",
       products: "Productos",
       sales: "Ventas",
+      revenue: "Ingresos",
     },
   },
   ...usersEs,


### PR DESCRIPTION
## Changes:

- Show net revenue (paid minus refunded) instead of a raw order count on the Home dashboard's Sales tile, visible only to users with the `reports_read` permission — other roles keep seeing the existing order count unchanged.

**Screenshots**:

<img width="850" height="324" alt="Screenshot 2026-07-29 at 12 00 23 p m" src="https://github.com/user-attachments/assets/aa028c39-aa1e-47e4-836f-90b5c84d244e" />

<img width="848" height="316" alt="Screenshot 2026-07-29 at 11 59 58 a m" src="https://github.com/user-attachments/assets/28516a25-1a8d-4602-9cd7-759d339fc0f4" />
