### PR TITLE
Feature/wallet backend reconfiguration

### DIFF
--- a/client/src/components/pages/Onboarding/WalletBackendStep.jsx
+++ b/client/src/components/pages/Onboarding/WalletBackendStep.jsx
@@ -6,7 +6,7 @@ import { Card, CardBody, Input } from "@heroui/react";
 import { Zap, Server } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-const NWC_URI_REGEX = /^nostr\+walletconnect:\/\/[0-9a-f]{64}\?/;
+import { NWC_URI_REGEX } from "@/lib/nwcUri";
 
 export function WalletBackendStep({ data, onChange }) {
   const walletBackendTranslations = useTranslations();
@@ -29,32 +29,34 @@ export function WalletBackendStep({ data, onChange }) {
   return (
     <div>
       <h2 className="text-xl md:text-2xl font-bold text-green-900 mb-2">{walletBackendTranslations("stepWallet.title")}</h2>
-      <p className="text-gray-500 mb-6">{walletBackendTranslations("stepWallet.subtitle")}</p>
+      <p className="text-gray-500 mb-4 md:mb-8">{walletBackendTranslations("stepWallet.subtitle")}</p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <Card
+          shadow="none"
           isPressable
           onPress={() => handleSelect("phoenixd")}
-          className={`border-2 transition-colors cursor-pointer ${!isNwc ? "border-green-700 bg-green-50" : "border-gray-200"}`}
+          className={`border border-gray-200 rounded-lg hover:bg-green-200 ${!isNwc ? "bg-green-100 border-green-300" : ""}`}
         >
           <CardBody className="flex flex-col items-center gap-3 py-6">
-            <Server className={`w-8 h-8 ${!isNwc ? "text-green-700" : "text-gray-400"}`} />
+            <Server className="w-8 h-8 text-green-800" />
             <div className="text-center">
-              <p className={`font-semibold ${!isNwc ? "text-green-900" : "text-gray-700"}`}>phoenixd</p>
+              <p className="font-semibold text-green-900">phoenixd</p>
               <p className="text-xs text-gray-500 mt-1">{walletBackendTranslations("stepWallet.phoenixdDescription")}</p>
             </div>
           </CardBody>
         </Card>
 
         <Card
+          shadow="none"
           isPressable
           onPress={() => handleSelect("nwc")}
-          className={`border-2 transition-colors cursor-pointer ${isNwc ? "border-green-700 bg-green-50" : "border-gray-200"}`}
+          className={`border border-gray-200 rounded-lg hover:bg-green-200 ${isNwc ? "bg-green-100 border-green-300" : ""}`}
         >
           <CardBody className="flex flex-col items-center gap-3 py-6">
-            <Zap className={`w-8 h-8 ${isNwc ? "text-green-700" : "text-gray-400"}`} />
+            <Zap className="w-8 h-8 text-green-800" />
             <div className="text-center">
-              <p className={`font-semibold ${isNwc ? "text-green-900" : "text-gray-700"}`}>
+              <p className="font-semibold text-green-900">
                 {walletBackendTranslations("stepWallet.nwcName")}
               </p>
               <p className="text-xs text-gray-500 mt-1">{walletBackendTranslations("stepWallet.nwcDescription")}</p>

--- a/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCard.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCard.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+
+import { useTranslations } from "next-intl";
+
+import { NwcConnectionCardLocked } from "./NwcConnectionCardLocked";
+import { NwcConnectionCardUnlocked } from "./NwcConnectionCardUnlocked";
+
+export function NwcConnectionCard() {
+  const nwcConnectionTranslations = useTranslations();
+  const [showAccess, setShowAccess] = useState(false);
+
+  const handleHide = () => setShowAccess(false);
+
+  if (showAccess) {
+    return (
+      <NwcConnectionCardUnlocked
+        onHide={handleHide}
+        nwcConnectionTranslations={nwcConnectionTranslations}
+      />
+    );
+  }
+
+  return (
+    <NwcConnectionCardLocked
+      onReveal={() => setShowAccess(true)}
+      nwcConnectionTranslations={nwcConnectionTranslations}
+    />
+  );
+}

--- a/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardLocked.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardLocked.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button, Card, CardBody, CardFooter, CardHeader } from "@heroui/react";
+
+export function NwcConnectionCardLocked({ onReveal, nwcConnectionTranslations }) {
+  return (
+    <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+      <CardHeader className="flex flex-col items-start pb-0">
+        <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
+          {nwcConnectionTranslations("nwcConnection.title")}
+        </h2>
+      </CardHeader>
+
+      <CardBody>
+        <p className="text-sm text-gray-500">
+          {nwcConnectionTranslations("nwcConnection.description")}
+        </p>
+      </CardBody>
+
+      <CardFooter>
+        <Button
+          color="primary"
+          className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+          onPress={onReveal}
+        >
+          {nwcConnectionTranslations("nwcConnection.manageButton")}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardUnlocked.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardUnlocked.jsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+
+import { addToast, Button, Card, CardBody, CardHeader, Input } from "@heroui/react";
+
+import { NWC_URI_REGEX } from "@/lib/nwcUri";
+import { updateNwcUri } from "@/services/walletService";
+import WalletGuard from "@components/auth/WalletGuard";
+
+import { getNwcConnectionErrorDescription } from "./utils/nwcConnectionErrors";
+
+export function NwcConnectionCardUnlocked({ onHide, nwcConnectionTranslations }) {
+  const [nwcUri, setNwcUri] = useState("");
+  const [uriError, setUriError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleUriChange = (value) => {
+    setNwcUri(value);
+    setUriError("");
+  };
+
+  const handleSubmit = async () => {
+    if (!NWC_URI_REGEX.test(nwcUri)) {
+      setUriError(nwcConnectionTranslations("nwcConnection.uriInvalid"));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await updateNwcUri(nwcUri);
+      addToast({ color: "success", description: nwcConnectionTranslations("nwcConnection.success") });
+      setNwcUri("");
+    } catch (error) {
+      addToast({
+        color: "danger",
+        description: getNwcConnectionErrorDescription(nwcConnectionTranslations, error),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <WalletGuard
+      onCancel={onHide}
+      title={nwcConnectionTranslations("nwcConnection.modalTitle")}
+      passwordLabel={nwcConnectionTranslations("nwcConnection.passwordLabel")}
+      confirmText={nwcConnectionTranslations("nwcConnection.confirmButton")}
+      cancelText={nwcConnectionTranslations("nwcConnection.cancelButton")}
+    >
+      <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+        <CardHeader className="flex flex-col items-start">
+          <h2 className="text-2xl font-semibold text-green-900">
+            {nwcConnectionTranslations("nwcConnection.title")}
+          </h2>
+        </CardHeader>
+
+        <CardBody>
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-gray-500">
+              {nwcConnectionTranslations("nwcConnection.description")}
+            </p>
+
+            <Input
+              label={nwcConnectionTranslations("nwcConnection.uriLabel")}
+              placeholder="nostr+walletconnect://..."
+              value={nwcUri}
+              onValueChange={handleUriChange}
+              isInvalid={!!uriError}
+              errorMessage={uriError}
+              classNames={{ input: "font-mono text-xs" }}
+            />
+
+            <div className="flex gap-2">
+              <Button
+                color="primary"
+                className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+                isDisabled={!nwcUri || submitting}
+                isLoading={submitting}
+                onPress={handleSubmit}
+              >
+                {nwcConnectionTranslations("nwcConnection.submitButton")}
+              </Button>
+              <Button
+                variant="bordered"
+                isDisabled={submitting}
+                onPress={onHide}
+                className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium border border-border text-foreground hover:bg-muted transition-colors"
+              >
+                {nwcConnectionTranslations("nwcConnection.hideButton")}
+              </Button>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
+    </WalletGuard>
+  );
+}

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { NwcConnectionCard } from "../NwcConnectionCard";
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Button: ({ onPress, children, ...props }) => (
+    <button type="button" onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  CardFooter: ({ children }) => <div>{children}</div>,
+  Input: ({ label, value, onValueChange, errorMessage }) => (
+    <div>
+      <label htmlFor="nwc-uri-input">{label}</label>
+      <input id="nwc-uri-input" value={value} onChange={(event) => onValueChange(event.target.value)} />
+      {errorMessage && <span>{errorMessage}</span>}
+    </div>
+  ),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
+jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children, onCancel }) {
+  return (
+    <div data-testid="wallet-guard">
+      <button type="button" data-testid="guard-cancel" onClick={onCancel}>cancel</button>
+      {children}
+    </div>
+  );
+},
+);
+
+describe("NwcConnectionCard", () => {
+  describe("Initial (locked) state", () => {
+    it("renders the locked card by default", () => {
+      render(<NwcConnectionCard />);
+      expect(screen.getByText("nwcConnection.manageButton")).toBeInTheDocument();
+    });
+
+    it("does not render the WalletGuard before reveal", () => {
+      render(<NwcConnectionCard />);
+      expect(screen.queryByTestId("wallet-guard")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Transition to unlocked state", () => {
+    it("renders WalletGuard after the manage button is clicked", () => {
+      render(<NwcConnectionCard />);
+      fireEvent.click(screen.getByText("nwcConnection.manageButton"));
+      expect(screen.getByTestId("wallet-guard")).toBeInTheDocument();
+    });
+
+    it("hides the locked card after the manage button is clicked", () => {
+      render(<NwcConnectionCard />);
+      fireEvent.click(screen.getByText("nwcConnection.manageButton"));
+      expect(screen.queryByText("nwcConnection.manageButton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Hide (return to locked state)", () => {
+    it("returns to locked state when WalletGuard cancel is pressed", () => {
+      render(<NwcConnectionCard />);
+      fireEvent.click(screen.getByText("nwcConnection.manageButton"));
+      fireEvent.click(screen.getByTestId("guard-cancel"));
+      expect(screen.getByText("nwcConnection.manageButton")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardLocked.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardLocked.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { NwcConnectionCardLocked } from "../NwcConnectionCardLocked";
+
+jest.mock("@heroui/react", () => ({
+  Button: ({ onPress, children, ...props }) => (
+    <button type="button" onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  CardFooter: ({ children }) => <div>{children}</div>,
+}));
+
+const translate = (key) => key;
+
+function renderLocked(props = {}) {
+  return render(<NwcConnectionCardLocked nwcConnectionTranslations={translate} onReveal={jest.fn()} {...props} />);
+}
+
+describe("NwcConnectionCardLocked", () => {
+  describe("Rendering", () => {
+    it("renders the title", () => {
+      renderLocked();
+      expect(screen.getByText("nwcConnection.title")).toBeInTheDocument();
+    });
+
+    it("renders the description", () => {
+      renderLocked();
+      expect(screen.getByText("nwcConnection.description")).toBeInTheDocument();
+    });
+
+    it("renders the manage button", () => {
+      renderLocked();
+      expect(screen.getByText("nwcConnection.manageButton")).toBeInTheDocument();
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onReveal when the manage button is pressed", () => {
+      const onReveal = jest.fn();
+      renderLocked({ onReveal });
+      fireEvent.click(screen.getByText("nwcConnection.manageButton"));
+      expect(onReveal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
@@ -1,0 +1,196 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import * as walletService from "@/services/walletService";
+
+import { NwcConnectionCardUnlocked } from "../NwcConnectionCardUnlocked";
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Button: ({ onPress, children, isDisabled, ...props }) => (
+    <button type="button" disabled={isDisabled} onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  Input: ({ label, value, onValueChange, errorMessage }) => (
+    <div>
+      <label htmlFor="nwc-uri-input">{label}</label>
+      <input id="nwc-uri-input" value={value} onChange={(event) => onValueChange(event.target.value)} />
+      {errorMessage && <span>{errorMessage}</span>}
+    </div>
+  ),
+}));
+
+jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children, onCancel, title, passwordLabel, confirmText, cancelText }) {
+  return (
+    <div>
+      <span data-testid="guard-title">{title}</span>
+      <span data-testid="guard-password-label">{passwordLabel}</span>
+      <span data-testid="guard-confirm-text">{confirmText}</span>
+      <button type="button" data-testid="guard-cancel" onClick={onCancel}>{cancelText}</button>
+      {children}
+    </div>
+  );
+},
+);
+
+jest.mock("@/services/walletService");
+
+const translate = (key) => key;
+const validNwcUri = `nostr+walletconnect://${"a".repeat(64)}?relay=wss%3A%2F%2Frelay.example.com&secret=${"b".repeat(64)}`;
+
+function renderUnlocked(props = {}) {
+  return render(<NwcConnectionCardUnlocked nwcConnectionTranslations={translate} onHide={jest.fn()} {...props} />);
+}
+
+describe("NwcConnectionCardUnlocked", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("WalletGuard props", () => {
+    it("passes the modal title to WalletGuard", () => {
+      renderUnlocked();
+      expect(screen.getByTestId("guard-title").textContent).toBe("nwcConnection.modalTitle");
+    });
+
+    it("passes the password label to WalletGuard", () => {
+      renderUnlocked();
+      expect(screen.getByTestId("guard-password-label").textContent).toBe("nwcConnection.passwordLabel");
+    });
+
+    it("passes the confirm text to WalletGuard", () => {
+      renderUnlocked();
+      expect(screen.getByTestId("guard-confirm-text").textContent).toBe("nwcConnection.confirmButton");
+    });
+  });
+
+  describe("Rendering", () => {
+    it("renders the URI input", () => {
+      renderUnlocked();
+      expect(screen.getByLabelText("nwcConnection.uriLabel")).toBeInTheDocument();
+    });
+
+    it("renders the submit and hide buttons", () => {
+      renderUnlocked();
+      expect(screen.getByText("nwcConnection.submitButton")).toBeInTheDocument();
+      expect(screen.getByText("nwcConnection.hideButton")).toBeInTheDocument();
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onHide when the hide button is pressed", () => {
+      const onHide = jest.fn();
+      renderUnlocked({ onHide });
+      fireEvent.click(screen.getByText("nwcConnection.hideButton"));
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards onHide as onCancel to WalletGuard", () => {
+      const onHide = jest.fn();
+      renderUnlocked({ onHide });
+      fireEvent.click(screen.getByTestId("guard-cancel"));
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows a validation error and does not submit when the URI format is invalid", async () => {
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: "not-a-valid-uri" } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(screen.getByText("nwcConnection.uriInvalid")).toBeInTheDocument();
+      expect(walletService.updateNwcUri).not.toHaveBeenCalled();
+    });
+
+    it("submits a valid URI and shows a success toast", async () => {
+      walletService.updateNwcUri.mockResolvedValue({ message: "NWC backend reconfigured" });
+      const { addToast } = require("@heroui/react");
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: validNwcUri } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(walletService.updateNwcUri).toHaveBeenCalledWith(validNwcUri);
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "success", description: "nwcConnection.success" }),
+      );
+    });
+
+    it("shows a translated error toast when the connection fails", async () => {
+      const connectionError = new Error("Could not connect");
+      connectionError.code = "nwc_connection_failed";
+      walletService.updateNwcUri.mockRejectedValue(connectionError);
+      const { addToast } = require("@heroui/react");
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: validNwcUri } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "nwcConnection.errors.connectionFailed" }),
+      );
+    });
+
+    it("shows a translated error toast when reconfiguring fails", async () => {
+      const reconfigureError = new Error("Could not reconfigure");
+      reconfigureError.code = "nwc_reconfigure_failed";
+      walletService.updateNwcUri.mockRejectedValue(reconfigureError);
+      const { addToast } = require("@heroui/react");
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: validNwcUri } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "nwcConnection.errors.connectionFailed" }),
+      );
+    });
+
+    it("shows a translated error toast when switching providers is not supported", async () => {
+      const providerSwitchError = new Error("Not supported");
+      providerSwitchError.code = "provider_switch_not_supported";
+      walletService.updateNwcUri.mockRejectedValue(providerSwitchError);
+      const { addToast } = require("@heroui/react");
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: validNwcUri } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "nwcConnection.errors.providerSwitchNotSupported" }),
+      );
+    });
+
+    it("shows the generic unknown error message when the error has no recognized code", async () => {
+      walletService.updateNwcUri.mockRejectedValue(new Error("boom"));
+      const { addToast } = require("@heroui/react");
+      renderUnlocked();
+      const uriInput = screen.getByLabelText("nwcConnection.uriLabel");
+
+      fireEvent.change(uriInput, { target: { value: validNwcUri } });
+      await act(async () => {
+        fireEvent.click(screen.getByText("nwcConnection.submitButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "boom" }),
+      );
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/NwcConnection/locales/en.js
+++ b/client/src/components/pages/Store/Settings/NwcConnection/locales/en.js
@@ -1,0 +1,23 @@
+const nwcConnectionEn = {
+  nwcConnection: {
+    title: "NWC Connection",
+    description: "Re-enter the connection URI if your NWC wallet stopped working.",
+    manageButton: "Manage connection",
+    modalTitle: "Confirm Wallet access",
+    passwordLabel: "Wallet password",
+    confirmButton: "Enter",
+    cancelButton: "Cancel",
+    uriLabel: "NWC connection URI",
+    uriInvalid: "Invalid NWC URI format",
+    submitButton: "Save",
+    hideButton: "Close",
+    success: "NWC connection updated successfully",
+    errors: {
+      connectionFailed: "Could not connect to the wallet with that URI — check that it's correct and the wallet is reachable",
+      providerSwitchNotSupported: "Switching Lightning providers is not available here yet",
+      unknown: "Could not update the NWC connection",
+    },
+  },
+};
+
+export default nwcConnectionEn;

--- a/client/src/components/pages/Store/Settings/NwcConnection/locales/es.js
+++ b/client/src/components/pages/Store/Settings/NwcConnection/locales/es.js
@@ -1,0 +1,23 @@
+const nwcConnectionEs = {
+  nwcConnection: {
+    title: "Conexión NWC",
+    description: "Vuelve a introducir la URI de conexión si tu wallet NWC dejó de funcionar.",
+    manageButton: "Administrar conexión",
+    modalTitle: "Confirmar acceso a Wallet",
+    passwordLabel: "Contraseña de wallet",
+    confirmButton: "Entrar",
+    cancelButton: "Cancelar",
+    uriLabel: "URI de conexión NWC",
+    uriInvalid: "Formato de URI de NWC inválido",
+    submitButton: "Guardar",
+    hideButton: "Cerrar",
+    success: "Conexión NWC actualizada correctamente",
+    errors: {
+      connectionFailed: "No se pudo conectar con la wallet usando esa URI — revisa que sea correcta y que la wallet esté disponible",
+      providerSwitchNotSupported: "Cambiar de proveedor de Lightning todavía no está disponible desde acá",
+      unknown: "No se pudo actualizar la conexión NWC",
+    },
+  },
+};
+
+export default nwcConnectionEs;

--- a/client/src/components/pages/Store/Settings/NwcConnection/utils/nwcConnectionErrors.js
+++ b/client/src/components/pages/Store/Settings/NwcConnection/utils/nwcConnectionErrors.js
@@ -1,0 +1,16 @@
+export const NWC_CONNECTION_ERROR_TRANSLATIONS = {
+  nwc_connection_failed: "nwcConnection.errors.connectionFailed",
+  nwc_reconfigure_failed: "nwcConnection.errors.connectionFailed",
+  provider_switch_not_supported: "nwcConnection.errors.providerSwitchNotSupported",
+};
+
+export function getNwcConnectionErrorDescription(translate, nwcConnectionError) {
+  const translationKey = NWC_CONNECTION_ERROR_TRANSLATIONS[nwcConnectionError?.code];
+  if (translationKey) {
+    return translate(translationKey);
+  }
+  if (nwcConnectionError?.message) {
+    return nwcConnectionError.message;
+  }
+  return translate("nwcConnection.errors.unknown");
+}

--- a/client/src/components/pages/Store/Settings/Seed/Seed.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/Seed.jsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { useTour } from "@/hooks/tour/useTour";
-import { getInfo, getSeed } from "@/services/walletService";
+import { getSeed } from "@/services/walletService";
 
 import { SeedCardLocked } from "./SeedCardLocked";
 import { SeedCardUnlocked } from "./SeedCardUnlocked";
@@ -15,19 +15,10 @@ const SEED_SETTINGS_TOUR_KEY = "ambrosia:tour:seed-settings";
 export const SEED_SEEN_KEY = "ambrosia:tour:seed-seen";
 
 export function Seed() {
-  const t = useTranslations("settings");
-  const tTour = useTranslations("seedTour");
+  const seedTranslations = useTranslations("settings");
+  const seedTourTranslations = useTranslations("seedTour");
   const [showAccess, setShowAccess] = useState(false);
   const [seed, setSeed] = useState(null);
-  const [seedSupported, setSeedSupported] = useState(true);
-
-  useEffect(() => {
-    getInfo()
-      .then((info) => {
-        if (info?.version === "NWC") setSeedSupported(false);
-      })
-      .catch(() => {});
-  }, []);
 
   useTour({
     key: SEED_SETTINGS_TOUR_KEY,
@@ -48,11 +39,11 @@ export function Seed() {
         {
           element: "#settings-seed-card",
           popover: {
-            title: tTour("settingsTitle"),
-            description: tTour.raw("settingsDescription"),
+            title: seedTourTranslations("settingsTitle"),
+            description: seedTourTranslations.raw("settingsDescription"),
             side: "bottom",
             align: "start",
-            nextBtnText: tTour("settingsButton"),
+            nextBtnText: seedTourTranslations("settingsButton"),
             showButtons: ["next"],
           },
         },
@@ -68,10 +59,12 @@ export function Seed() {
     try {
       const seedText = await getSeed();
       setSeed(seedText);
-    } catch {
+    } catch (error) {
       addToast({
-        title: t("cardSeed.errorTitle"),
-        description: t("cardSeed.errorDescription"),
+        title: seedTranslations("cardSeed.errorTitle"),
+        description: error?.code === "unsupported_operation"
+          ? seedTranslations("cardSeed.notAvailableNwc")
+          : seedTranslations("cardSeed.errorDescription"),
         color: "danger",
       });
       setShowAccess(false);
@@ -89,7 +82,7 @@ export function Seed() {
         seed={seed}
         onAuthorized={handleAuthorized}
         onHide={handleHide}
-        t={t}
+        seedCardTranslations={seedTranslations}
       />
     );
   }
@@ -97,8 +90,7 @@ export function Seed() {
   return (
     <SeedCardLocked
       onReveal={() => setShowAccess(true)}
-      disabled={!seedSupported}
-      seedCardTranslations={t}
+      seedCardTranslations={seedTranslations}
     />
   );
 }

--- a/client/src/components/pages/Store/Settings/Seed/SeedCardLocked.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/SeedCardLocked.jsx
@@ -3,7 +3,7 @@
 import { Button, Card, CardBody, CardFooter, CardHeader } from "@heroui/react";
 import { AlertTriangle } from "lucide-react";
 
-export function SeedCardLocked({ onReveal, disabled, seedCardTranslations }) {
+export function SeedCardLocked({ onReveal, seedCardTranslations }) {
   return (
     <Card id="settings-seed-card" shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
@@ -14,40 +14,27 @@ export function SeedCardLocked({ onReveal, disabled, seedCardTranslations }) {
 
       <CardBody>
         <div className="flex flex-col max-w-2xl space-y-4">
-          {disabled ? (
-            <div className="flex items-start gap-2 bg-gray-50 border border-gray-200 rounded-lg p-3">
-              <AlertTriangle className="w-5 h-5 text-gray-400 shrink-0 mt-0.5" />
-              <p className="text-sm text-gray-500">
-                {seedCardTranslations("cardSeed.notAvailableNwc")}
-              </p>
-            </div>
-          ) : (
-            <>
-              <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3">
-                <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
-                <p className="text-sm text-amber-800">
-                  {seedCardTranslations("cardSeed.warning")}
-                </p>
-              </div>
-              <p className="text-sm text-gray-500">
-                {seedCardTranslations("cardSeed.description")}
-              </p>
-            </>
-          )}
+          <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3">
+            <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-800">
+              {seedCardTranslations("cardSeed.warning")}
+            </p>
+          </div>
+          <p className="text-sm text-gray-500">
+            {seedCardTranslations("cardSeed.description")}
+          </p>
         </div>
       </CardBody>
 
-      {!disabled && (
-        <CardFooter>
-          <Button
-            color="primary"
-            className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
-            onPress={onReveal}
-          >
-            {seedCardTranslations("cardSeed.revealButton")}
-          </Button>
-        </CardFooter>
-      )}
+      <CardFooter>
+        <Button
+          color="primary"
+          className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+          onPress={onReveal}
+        >
+          {seedCardTranslations("cardSeed.revealButton")}
+        </Button>
+      </CardFooter>
     </Card>
   );
 }

--- a/client/src/components/pages/Store/Settings/Seed/SeedCardUnlocked.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/SeedCardUnlocked.jsx
@@ -5,22 +5,22 @@ import { AlertTriangle, PenLine } from "lucide-react";
 
 import WalletGuard from "@components/auth/WalletGuard";
 
-export function SeedCardUnlocked({ seed, onAuthorized, onHide, t }) {
+export function SeedCardUnlocked({ seed, onAuthorized, onHide, seedCardTranslations }) {
   const words = seed ? seed.split(" ").filter(Boolean) : [];
 
   return (
     <WalletGuard
       onAuthorized={onAuthorized}
       onCancel={onHide}
-      title={t("cardSeed.modalTitle")}
-      passwordLabel={t("cardSeed.passwordLabel")}
-      confirmText={t("cardSeed.confirmButton")}
-      cancelText={t("cardSeed.cancelButton")}
+      title={seedCardTranslations("cardSeed.modalTitle")}
+      passwordLabel={seedCardTranslations("cardSeed.passwordLabel")}
+      confirmText={seedCardTranslations("cardSeed.confirmButton")}
+      cancelText={seedCardTranslations("cardSeed.cancelButton")}
     >
       <Card shadow="none" className="rounded-lg p-6 shadow-lg">
         <CardHeader className="flex flex-col items-start pb-0">
           <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
-            {t("cardSeed.title")}
+            {seedCardTranslations("cardSeed.title")}
           </h2>
         </CardHeader>
 
@@ -29,19 +29,19 @@ export function SeedCardUnlocked({ seed, onAuthorized, onHide, t }) {
             <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3">
               <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
               <p className="text-sm text-amber-800">
-                {t("cardSeed.warning")}
+                {seedCardTranslations("cardSeed.warning")}
               </p>
             </div>
 
             {seed ? (
               <div className="space-y-4">
                 <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-2">
-                  {words.map((word, idx) => (
+                  {words.map((word, wordIndex) => (
                     <div
-                      key={idx}
+                      key={wordIndex}
                       className="flex items-center gap-1.5 bg-gray-50 border border-gray-200 rounded px-2 py-2 sm:px-3"
                     >
-                      <span className="text-xs text-gray-400 w-5 shrink-0">{idx + 1}.</span>
+                      <span className="text-xs text-gray-400 w-5 shrink-0">{wordIndex + 1}.</span>
                       <span className="font-mono text-xs sm:text-sm text-green-900 font-medium truncate">{word}</span>
                     </div>
                   ))}
@@ -49,7 +49,7 @@ export function SeedCardUnlocked({ seed, onAuthorized, onHide, t }) {
                 <div className="flex items-start gap-2 bg-green-50 border border-green-200 rounded-lg p-3">
                   <PenLine className="w-5 h-5 text-green-700 shrink-0 mt-0.5" />
                   <p className="text-sm text-green-800 font-medium">
-                    {t("cardSeed.paperNote")}
+                    {seedCardTranslations("cardSeed.paperNote")}
                   </p>
                 </div>
                 <div>
@@ -58,7 +58,7 @@ export function SeedCardUnlocked({ seed, onAuthorized, onHide, t }) {
                     onPress={onHide}
                     className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium border border-border text-foreground hover:bg-muted transition-colors"
                   >
-                    {t("cardSeed.hideButton")}
+                    {seedCardTranslations("cardSeed.hideButton")}
                   </Button>
                 </div>
               </div>

--- a/client/src/components/pages/Store/Settings/Seed/__tests__/Seed.test.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/__tests__/Seed.test.jsx
@@ -126,6 +126,23 @@ describe("Seed", () => {
 
       expect(screen.getByText("cardSeed.revealButton")).toBeInTheDocument();
     });
+
+    it("shows the NWC-specific message when getSeed fails with an unsupported_operation code", async () => {
+      const { addToast } = require("@heroui/react");
+      const nwcError = new Error("Seed export is not available with NWC backend");
+      nwcError.code = "unsupported_operation";
+      jest.spyOn(walletService, "getSeed").mockRejectedValue(nwcError);
+      render(<Seed />);
+      fireEvent.click(screen.getByText("cardSeed.revealButton"));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("guard-confirm"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "cardSeed.notAvailableNwc" }),
+      );
+    });
   });
 
   describe("Hide (return to locked state)", () => {

--- a/client/src/components/pages/Store/Settings/Seed/__tests__/SeedCardUnlocked.test.jsx
+++ b/client/src/components/pages/Store/Settings/Seed/__tests__/SeedCardUnlocked.test.jsx
@@ -30,7 +30,7 @@ jest.mock("lucide-react", () => ({
   PenLine: () => <svg data-testid="icon-pen" />,
 }));
 
-const t = (key) => key;
+const translate = (key) => key;
 const SEED = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
 function renderUnlocked(props = {}) {
@@ -39,7 +39,7 @@ function renderUnlocked(props = {}) {
       seed={null}
       onAuthorized={jest.fn()}
       onHide={jest.fn()}
-      t={t}
+      seedCardTranslations={translate}
       {...props}
     />,
   );

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -10,6 +10,7 @@ import { Display } from "./Display";
 import { InstallPWA } from "./InstallPWA";
 import { Language } from "./Language";
 import { LightningCard } from "./Lightning/LightningCard";
+import { NwcConnectionCard } from "./NwcConnection/NwcConnectionCard";
 import { Printers } from "./Printers";
 import { Seed } from "./Seed";
 import { StoreInfo } from "./StoreInfo";
@@ -30,6 +31,7 @@ export function Settings() {
           <Language />
           <Display />
           <Seed />
+          <NwcConnectionCard />
           <Tutorials />
         </div>
 

--- a/client/src/components/pages/Store/Settings/locales/en.js
+++ b/client/src/components/pages/Store/Settings/locales/en.js
@@ -1,4 +1,5 @@
 import lightningEn from "../Lightning/locales/en";
+import nwcConnectionEn from "../NwcConnection/locales/en";
 import printersEn from "../Printers/locales/en";
 import seedEn from "../Seed/locales/en";
 import storeInfoEn from "../StoreInfo/locales/en";
@@ -42,6 +43,7 @@ const settingsEn = {
     ...tutorialsEn,
   },
   ...lightningEn,
+  ...nwcConnectionEn,
 };
 
 export default settingsEn;

--- a/client/src/components/pages/Store/Settings/locales/es.js
+++ b/client/src/components/pages/Store/Settings/locales/es.js
@@ -1,4 +1,5 @@
 import lightningEs from "../Lightning/locales/es";
+import nwcConnectionEs from "../NwcConnection/locales/es";
 import printersEs from "../Printers/locales/es";
 import seedEs from "../Seed/locales/es";
 import storeInfoEs from "../StoreInfo/locales/es";
@@ -42,6 +43,7 @@ const settingsEs = {
     ...tutorialsEs,
   },
   ...lightningEs,
+  ...nwcConnectionEs,
 };
 
 export default settingsEs;

--- a/client/src/lib/nwcUri.js
+++ b/client/src/lib/nwcUri.js
@@ -1,0 +1,1 @@
+export const NWC_URI_REGEX = /^nostr\+walletconnect:\/\/[0-9a-f]{64}\?/;

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -318,6 +318,21 @@ describe("walletService", () => {
 
       expect(httpClient).toHaveBeenCalledWith("/wallet/seed");
     });
+
+    it("throws with the server code when the backend does not support seed export", async () => {
+      httpClient.mockResolvedValue(makeResponse(501, false));
+      parseJsonResponse.mockResolvedValue({
+        message: "Seed export is not available with NWC backend",
+        code: "unsupported_operation",
+        source: "ambrosia",
+      });
+
+      await expect(getSeed()).rejects.toMatchObject({
+        message: "Seed export is not available with NWC backend",
+        status: 501,
+        code: "unsupported_operation",
+      });
+    });
   });
 
   describe("closeChannel", () => {

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -193,13 +193,36 @@ export async function getOutgoingTransactions() {
   return transactions ? transactions : [];
 }
 
+export async function updateNwcUri(nwcUri) {
+  const response = await httpClient("/wallet/updatenwcuri", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ nwcUri: nwcUri.trim() }),
+  });
+  const body = await parseJsonResponse(response, null);
+  if (!response.ok) {
+    throw createWalletServiceError(body?.message, {
+      status: response.status,
+      code: body?.code,
+      source: body?.source,
+    });
+  }
+  return body;
+}
+
 export async function getSeed() {
   const response = await httpClient("/wallet/seed");
+  const body = await parseJsonResponse(response, null);
   if (!response.ok) {
-    const body = await parseJsonResponse(response, {});
-    throw new Error(body?.message || "Seed not available");
+    throw createWalletServiceError(body?.message || "Seed not available", {
+      status: response.status,
+      code: body?.code,
+      source: body?.source,
+    });
   }
-  return await parseJsonResponse(response, null);
+  return body;
 }
 
 export async function closeChannel(channelId, address, feerateSatByte) {

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -31,6 +31,7 @@ import pos.ambrosia.config.InjectLogs
 import pos.ambrosia.config.ListValueSource
 import pos.ambrosia.config.SeedGenerator
 import pos.ambrosia.config.readConfValues
+import pos.ambrosia.config.replaceConfFileProperty
 import pos.ambrosia.config.writeConfValues
 import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.services.VapidKeyService
@@ -344,30 +345,9 @@ class Ambrosia : CliktCommand() {
         readConfValues(confFile)[key] ?: throw IllegalStateException("$key not found in ambrosia.conf")
 
     private fun ensurePhoenixWebhookConfigured(url: String) {
-        val file = File(phoenixConfFile.toString())
-        file.parentFile?.mkdirs()
-        val existingLines = if (file.exists()) file.readLines() else emptyList()
-        val updatedLines = mutableListOf<String>()
-        var replaced = false
-
-        existingLines.forEach { line ->
-            if (line.trimStart().startsWith("webhook=")) {
-                if (!replaced) {
-                    updatedLines.add("webhook=$url")
-                    replaced = true
-                }
-            } else {
-                updatedLines.add(line)
-            }
-        }
-
-        if (!replaced) {
-            updatedLines.add("webhook=$url")
-        }
-
-        if (existingLines != updatedLines) {
-            file.writeText(updatedLines.joinToString(separator = "\n", postfix = "\n"))
-            logger.info("Updated phoenix webhook entry to webhook=$url in ${file.absolutePath}")
+        File(phoenixConfFile.toString()).parentFile?.mkdirs()
+        if (replaceConfFileProperty(phoenixConfFile, "webhook", url)) {
+            logger.info("Updated phoenix webhook entry to webhook=$url in $phoenixConfFile")
         }
     }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -129,7 +129,7 @@ fun Application.handler() {
         }
         exception<NwcConnectionException> { call, cause ->
             logger.error("NWC relay connection error: ${cause.message}")
-            call.respond(HttpStatusCode.ServiceUnavailable, Message("NWC wallet relay is unavailable"))
+            call.respondWalletError(HttpStatusCode.ServiceUnavailable, "NWC wallet relay is unavailable", cause.code, cause.source)
         }
         exception<NwcServiceException> { call, cause ->
             logger.error("NWC service error: ${cause.message}")

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -17,9 +17,15 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import kotlinx.io.files.Path
+import pos.ambrosia.config.replaceConfFileProperty
+import pos.ambrosia.datadir
+import pos.ambrosia.logger
 import pos.ambrosia.models.IncomingPaymentWithRate
+import pos.ambrosia.models.Message
 import pos.ambrosia.models.OutgoingPaymentWithRate
 import pos.ambrosia.models.RolePassword
+import pos.ambrosia.models.UpdateNwcUriRequest
 import pos.ambrosia.models.WalletAuthResponse
 import pos.ambrosia.models.WalletInvoiceRate
 import pos.ambrosia.models.phoenix.CloseChannelRequest
@@ -41,6 +47,8 @@ import pos.ambrosia.services.WalletAdminNotificationService
 import pos.ambrosia.services.WalletRateService
 import pos.ambrosia.utils.Bolt11Decoder
 import pos.ambrosia.utils.InvalidCredentialsException
+import pos.ambrosia.utils.NwcConnectionException
+import pos.ambrosia.utils.UnsupportedBackendOperationException
 import pos.ambrosia.utils.authenticateAdmin
 import pos.ambrosia.utils.getCurrentUser
 
@@ -129,6 +137,27 @@ fun Route.wallet(
         }
     }
     authenticate("auth-jwt-wallet") {
+        post("/updatenwcuri") {
+            val updateNwcUriRequest = call.receive<UpdateNwcUriRequest>()
+            val trimmedNwcUri = updateNwcUriRequest.nwcUri.trim()
+            if (trimmedNwcUri.isBlank()) {
+                call.respond(HttpStatusCode.BadRequest, Message("Missing nwcUri"))
+                return@post
+            }
+            if (!ActiveLightningBackend.isNwcActive()) {
+                throw UnsupportedBackendOperationException(
+                    message = "Switching Lightning backend providers is not supported yet",
+                    code = "provider_switch_not_supported",
+                )
+            }
+            try {
+                ActiveLightningBackend.reinitializeNwcBackend(trimmedNwcUri, call.application)
+            } catch (exception: Exception) {
+                throw NwcConnectionException(code = "nwc_reconfigure_failed")
+            }
+            replaceConfFileProperty(Path(datadir, "ambrosia.conf"), "nwc-uri", trimmedNwcUri)
+            call.respond(HttpStatusCode.OK, Message("NWC backend reconfigured"))
+        }
         post("/createinvoice") {
             val createInvoiceRequest = call.receive<CreateInvoiceRequest>()
             val invoice = ActiveLightningBackend.createInvoice(createInvoiceRequest)

--- a/server/app/src/main/kotlin/pos/ambrosia/config/ConfigFile.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/config/ConfigFile.kt
@@ -43,3 +43,35 @@ fun writeConfValues(
             .trimEnd() + "\n",
     )
 }
+
+fun replaceConfFileProperty(
+    confFile: Path,
+    key: String,
+    value: String,
+): Boolean {
+    val file = File(confFile.toString())
+    val existingLines = if (file.exists()) file.readLines() else emptyList()
+    val updatedLines = mutableListOf<String>()
+    var replaced = false
+
+    existingLines.forEach { line ->
+        if (line.trimStart().startsWith("$key=")) {
+            if (!replaced) {
+                updatedLines.add("$key=$value")
+                replaced = true
+            }
+        } else {
+            updatedLines.add(line)
+        }
+    }
+
+    if (!replaced) {
+        updatedLines.add("$key=$value")
+    }
+
+    val fileChanged = existingLines != updatedLines
+    if (fileChanged) {
+        file.writeText(updatedLines.joinToString(separator = "\n", postfix = "\n"))
+    }
+    return fileChanged
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -72,6 +72,11 @@ data class WalletAuthResponse(
 )
 
 @Serializable
+data class UpdateNwcUriRequest(
+    val nwcUri: String,
+)
+
+@Serializable
 data class User(
     val id: String? = null,
     val name: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
@@ -29,6 +29,8 @@ object ActiveLightningBackend : LightningBackend, PaymentVerifier {
         backendReference.set(backend)
     }
 
+    fun isNwcActive(): Boolean = backendReference.get() is NwcService
+
     fun closeActive() {
         backendReference
             .getAndSet(null)

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
@@ -50,6 +50,8 @@ class PrintTicketException(
 
 class NwcConnectionException(
     message: String = "Unable to connect to NWC relay",
+    val code: String = "nwc_connection_failed",
+    val source: String = "ambrosia",
 ) : RuntimeException(message)
 
 class NwcServiceException(

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ActiveLightningBackendTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ActiveLightningBackendTest.kt
@@ -1,11 +1,17 @@
 package pos.ambrosia.utest
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
+import org.mockito.kotlin.mock
+import pos.ambrosia.nwc.NwcClientPort
 import pos.ambrosia.services.ActiveLightningBackend
+import pos.ambrosia.services.NwcService
 import pos.ambrosia.services.PaymentVerifier
 import pos.ambrosia.utils.FakeLightningBackend
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ActiveLightningBackendTest {
@@ -44,5 +50,21 @@ class ActiveLightningBackendTest {
 
             assertTrue(backend.closed)
         }
+    }
+
+    @Test
+    fun `isNwcActive returns false when the active backend is not NwcService`() {
+        ActiveLightningBackend.set(FakeLightningBackend("phoenixd"))
+
+        assertFalse(ActiveLightningBackend.isNwcActive())
+    }
+
+    @Test
+    fun `isNwcActive returns true when the active backend is NwcService`() {
+        val mockClient: NwcClientPort = mock()
+        val nwcService = NwcService(mockClient, "walletPubkey", CoroutineScope(SupervisorJob()))
+        ActiveLightningBackend.set(nwcService)
+
+        assertTrue(ActiveLightningBackend.isNwcActive())
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ConfigFileTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ConfigFileTest.kt
@@ -2,12 +2,25 @@ package pos.ambrosia.utest
 
 import kotlinx.io.files.Path
 import pos.ambrosia.config.readConfValues
+import pos.ambrosia.config.replaceConfFileProperty
 import pos.ambrosia.config.writeConfValues
 import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ConfigFileTest {
+    private fun tempConfFile(initialContent: String? = null): Path {
+        val tempDir = Files.createTempDirectory("configFileTest")
+        val confFile = Path(tempDir.toString(), "test.conf")
+        if (initialContent != null) {
+            File(confFile.toString()).writeText(initialContent)
+        }
+        return confFile
+    }
+
     @Test
     fun `writeConfValues replaces target keys and preserves unrelated lines`() {
         val confFile = File.createTempFile("ambrosia-test", ".conf")
@@ -45,5 +58,55 @@ class ConfigFileTest {
         } finally {
             confFile.delete()
         }
+    }
+
+    @Test
+    fun `replaceConfFileProperty adds the key when the file does not exist yet`() {
+        val confFile = tempConfFile()
+
+        val wroteFile = replaceConfFileProperty(confFile, "nwc-uri", "nostr+walletconnect://abc")
+
+        assertTrue(wroteFile)
+        assertEquals("nwc-uri=nostr+walletconnect://abc\n", File(confFile.toString()).readText())
+    }
+
+    @Test
+    fun `replaceConfFileProperty replaces the existing value for the key`() {
+        val confFile = tempConfFile("nwc-uri=old-uri\n")
+
+        val wroteFile = replaceConfFileProperty(confFile, "nwc-uri", "new-uri")
+
+        assertTrue(wroteFile)
+        assertEquals("nwc-uri=new-uri\n", File(confFile.toString()).readText())
+    }
+
+    @Test
+    fun `replaceConfFileProperty drops duplicate lines and keeps only one replaced occurrence`() {
+        val confFile = tempConfFile("nwc-uri=old-uri-1\nnwc-uri=old-uri-2\n")
+
+        replaceConfFileProperty(confFile, "nwc-uri", "new-uri")
+
+        assertEquals("nwc-uri=new-uri\n", File(confFile.toString()).readText())
+    }
+
+    @Test
+    fun `replaceConfFileProperty preserves unrelated lines`() {
+        val confFile = tempConfFile("secret=abc\nnwc-uri=old-uri\nhttp-bind-port=9154\n")
+
+        replaceConfFileProperty(confFile, "nwc-uri", "new-uri")
+
+        assertEquals(
+            "secret=abc\nnwc-uri=new-uri\nhttp-bind-port=9154\n",
+            File(confFile.toString()).readText(),
+        )
+    }
+
+    @Test
+    fun `replaceConfFileProperty returns false and does not rewrite the file when the value is unchanged`() {
+        val confFile = tempConfFile("nwc-uri=same-uri\n")
+
+        val wroteFile = replaceConfFileProperty(confFile, "nwc-uri", "same-uri")
+
+        assertFalse(wroteFile)
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/HandlerNwcExceptionTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/HandlerNwcExceptionTest.kt
@@ -43,7 +43,10 @@ class HandlerNwcExceptionTest {
         val response = responseForThrowing(NwcConnectionException("relay socket reset by peer"))
 
         assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
-        assertEquals("""{"message":"NWC wallet relay is unavailable"}""", response.body)
+        assertEquals(
+            """{"message":"NWC wallet relay is unavailable","code":"nwc_connection_failed","source":"ambrosia"}""",
+            response.body,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Changes:

- Add server-side support to safely rewrite a single property in a conf file, and use it to reconfigure the NWC connection URI without touching other config values
- Propagate translatable error codes when the NWC relay connection fails, and add a way to check whether NWC is the currently active Lightning backend
- Add an authenticated (wallet-password-gated) endpoint to reconfigure the NWC connection URI after initial setup
- Add wallet-service support for the new endpoint and propagate structured error codes from getSeed
- Add a wallet-password-gated NWC Connection card in Settings to update the connection URI, and render it there
- Extract the shared NWC URI regex constant and align WalletBackendStep's styling with the rest of the onboarding wizard
- Stop relying on an unauthenticated getInfo check in the Seed card and show the correct message when the seed is unavailable under NWC

**Screenshots**:

<img width="513" height="214" alt="Screenshot 2026-08-03 at 8 57 25 p m" src="https://github.com/user-attachments/assets/bab6929f-2212-414d-9b40-d96704a75d18" />

<img width="515" height="297" alt="Screenshot 2026-08-03 at 8 58 01 p m" src="https://github.com/user-attachments/assets/add48462-a85d-4edb-89c6-4cd61c656267" />
