### PR TITLE
Chore/nwc test coverage

### DIFF
--- a/server/app/src/test/kotlin/pos/ambrosia/utest/NostrRelayTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/NostrRelayTest.kt
@@ -1,0 +1,37 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import pos.ambrosia.nwc.NostrRelay
+import pos.ambrosia.utils.NwcConnectionException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+private fun firstConnectionAttemptFailsEntirely(): Boolean {
+    var onDisconnectInvoked = false
+    testApplication {
+        val client = createClient { install(WebSockets) }
+        val relay = NostrRelay(url = "/no-such-relay", httpClient = client)
+        val relayScope = CoroutineScope(Dispatchers.Default + Job())
+        try {
+            assertFailsWith<NwcConnectionException> {
+                relay.connect(relayScope, onDisconnect = { onDisconnectInvoked = true })
+            }
+        } finally {
+            relayScope.cancel()
+        }
+    }
+    return onDisconnectInvoked
+}
+
+class NostrRelayTest {
+    @Test
+    fun `onDisconnect is not invoked when the very first connection attempt fails entirely`() {
+        assertFalse(firstConnectionAttemptFailsEntirely())
+    }
+}

--- a/server/e2e_tests_py/ambrosia/test_server.py
+++ b/server/e2e_tests_py/ambrosia/test_server.py
@@ -29,15 +29,29 @@ class AmbrosiaTestServer:
     # Server configuration constants (matching TestServer.kt)
     SERVER_PORT = 9154
     SERVER_HOST = "127.0.0.1"
-    HEALTH_CHECK_URL = f"http://{SERVER_HOST}:{SERVER_PORT}/"
+    DEFAULT_DATADIR = "/tmp/ambrosia-test-data"
+    DEFAULT_EXTRA_ARGS = (
+        "--phoenixd-url=http://localhost:9740 "
+        "--phoenixd-password=test-password "
+        "--phoenixd-webhook-secret=test-webhook-secret"
+    )
 
     # Timeout settings
     STARTUP_TIMEOUT = 30  # seconds
     HEALTH_CHECK_INTERVAL = 1  # seconds
 
-    def __init__(self):
+    def __init__(
+        self,
+        port: int = SERVER_PORT,
+        extra_args: str = DEFAULT_EXTRA_ARGS,
+        datadir: str = DEFAULT_DATADIR,
+    ):
         self.server_process: subprocess.Popen | None = None
-        self.server_url = f"http://{self.SERVER_HOST}:{self.SERVER_PORT}"
+        self.port = port
+        self.extra_args = extra_args
+        self.datadir = datadir
+        self.server_url = f"http://{self.SERVER_HOST}:{self.port}"
+        self.health_check_url = f"{self.server_url}/"
         self._gradle_dir = Path(__file__).parent.parent.parent
 
     def start_server(self) -> None:
@@ -48,23 +62,21 @@ class AmbrosiaTestServer:
 
         logger.info(f"Starting server from directory: {self._gradle_dir}")
 
-        # Change to the app directory and run gradlew with Phoenix configuration
+        # Change to the app directory and run gradlew with the configured backend.
+        # Note: All application arguments must be in a single quoted string after --args
+        # Use shorter access token expiration (5 seconds) for faster E2E testing
         cmd = [
             "./gradlew",
             "run",
             "--no-daemon",
-            # Note: All application arguments must be in a single quoted string after --args
-            # Use shorter access token expiration (5 seconds) for faster E2E testing
-            "--args=--phoenixd-url=http://localhost:9740 "
-            "--phoenixd-password=test-password "
-            "--phoenixd-webhook-secret=test-webhook-secret "
+            f"--args=--http-bind-port={self.port} {self.extra_args} "
             "--jwt-access-token-expiration 5",
         ]
 
         logger.info(f"Starting server with command: {' '.join(cmd)}")
 
         env = os.environ.copy()
-        env["AMBROSIA_DATADIR"] = "/tmp/ambrosia-test-data"
+        env["AMBROSIA_DATADIR"] = self.datadir
 
         try:
             self.server_process = subprocess.Popen(
@@ -126,7 +138,7 @@ class AmbrosiaTestServer:
         while time.time() - start_time < timeout:
             try:
                 # Check if server is responding
-                response = httpx.get(self.HEALTH_CHECK_URL, timeout=5.0)
+                response = httpx.get(self.health_check_url, timeout=5.0)
                 if response.status_code == 200:
                     logger.info("Server is ready and responding")
                     return

--- a/server/e2e_tests_py/tests/test_nwc_backend_e2e.py
+++ b/server/e2e_tests_py/tests/test_nwc_backend_e2e.py
@@ -1,0 +1,117 @@
+"""End-to-end tests for the NWC (Nostr Wallet Connect) Lightning backend.
+
+Boots a second, independent Ambrosia instance with --nwc-uri instead of
+--phoenixd-url and confirms the real HTTP routing layer behaves correctly
+under it.
+"""
+
+import logging
+
+import pytest
+
+from ambrosia.api_utils import assert_status_code
+from ambrosia.auth_utils import DEFAULT_TEST_USER, login_user
+from ambrosia.http_client import AmbrosiaHttpClient
+from ambrosia.test_server import AmbrosiaTestServer
+
+logger = logging.getLogger(__name__)
+
+NWC_SERVER_PORT = 9165
+NWC_SERVER_SSL_PORT = 9455
+NWC_SERVER_DATADIR = "/tmp/ambrosia-test-data-nwc"
+WALLET_PASSWORD = "password123"
+
+# Real secp256k1 pubkey (openssl ecparam -name secp256k1) — parsed synchronously as a BIP-340 x-only point at server startup, so arbitrary hex here can crash the boot.
+NWC_URI = (
+    "nostr+walletconnect://"
+    "7bf8c2495f3342c80e0cbdd0d306e19d0c44762c773195289c3a77d76bf70bdb"
+    "?relay=ws://127.0.0.1:19999"
+    "&secret=ef99a279c64d8f63f87103577ad699aef0e83253925cfad4446b4f254eba7652"
+)
+NWC_EXTRA_ARGS = (
+    f"--nwc-uri={NWC_URI} "
+    f"--ssl-bind-port={NWC_SERVER_SSL_PORT} "
+    "--phoenixd-password=test-password "
+    "--phoenixd-webhook-secret=test-webhook-secret"
+)
+
+
+@pytest.fixture(scope="module")
+def nwc_server():
+    """Boots a second Ambrosia instance configured with --nwc-uri."""
+    server = AmbrosiaTestServer(
+        port=NWC_SERVER_PORT,
+        extra_args=NWC_EXTRA_ARGS,
+        datadir=NWC_SERVER_DATADIR,
+    )
+    server.start_server()
+    yield server
+    server.stop_server()
+
+
+@pytest.fixture
+async def nwc_wallet_client(nwc_server: AmbrosiaTestServer):
+    """Authenticated admin client, with wallet access unlocked, for the NWC server."""
+    async with AmbrosiaHttpClient(nwc_server.server_url) as client:
+        setup_response = await client.post(
+            "/initial-setup",
+            json={
+                "businessType": "store",
+                "userName": DEFAULT_TEST_USER["name"],
+                "userPassword": WALLET_PASSWORD,
+                "userPin": DEFAULT_TEST_USER["pin"],
+                "businessName": "Test Store (NWC)",
+                "businessAddress": "123 Test St",
+                "businessPhone": "1234567890",
+                "businessEmail": "test-nwc@example.com",
+                "businessCurrency": "USD",
+            },
+        )
+        if setup_response.status_code not in (201, 409):
+            pytest.fail(
+                f"Initial setup on the NWC server failed with "
+                f"{setup_response.status_code}: {setup_response.text}"
+            )
+
+        await login_user(client)
+
+        wallet_auth_response = await client.post(
+            "/wallet/auth", json={"password": WALLET_PASSWORD}
+        )
+        assert_status_code(
+            wallet_auth_response, 200, "Failed to authenticate wallet access"
+        )
+
+        yield client
+
+
+class TestNwcBackend:
+    """Confirms the real HTTP routing layer behaves correctly under NWC."""
+
+    @pytest.mark.asyncio
+    async def test_getinfo_fails_when_the_relay_is_unreachable(
+        self, nwc_wallet_client: AmbrosiaHttpClient
+    ):
+        """Unlike closeChannel below, getNodeInfo needs a live NIP-47 round-trip, so this 503 is the correct outcome here, not a bug."""
+        response = await nwc_wallet_client.get("/wallet/getinfo")
+
+        assert_status_code(response, 503, "Expected the NWC relay to be unreachable")
+        assert response.json()["code"] == "nwc_connection_failed"
+        logger.info("✓ /wallet/getinfo fails with the NWC-specific connection error")
+
+    @pytest.mark.asyncio
+    async def test_close_channel_returns_unsupported_operation(
+        self, nwc_wallet_client: AmbrosiaHttpClient
+    ):
+        response = await nwc_wallet_client.post(
+            "/wallet/closechannel",
+            json={
+                "channelId": "not-a-real-channel",
+                "address": "bcrt1qnotarealaddress",
+                "feerateSatByte": 1,
+            },
+        )
+
+        assert_status_code(response, 501, "closeChannel should be rejected under NWC")
+        assert response.json()["code"] == "unsupported_operation"
+        logger.info("✓ closeChannel is rejected as unsupported under NWC")


### PR DESCRIPTION
## Changes:

- Add a regression test for `NostrRelay.connect()` confirming `onDisconnect` is not invoked when the very first connection attempt fails entirely.
- Parameterize `AmbrosiaTestServer` (port, extra CLI args, data directory) and add an E2E scenario that boots a second instance with `--nwc-uri` to confirm the NWC backend is correctly wired through real HTTP routing (`/wallet/getinfo` connection failure, `/wallet/closechannel` unsupported-operation rejection).