### PR TITLE
Feature/nwc lud16 display

### DIFF
--- a/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/NodeSummary.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Wallet, Layers, Globe, Zap } from "lucide-react";
+import { Wallet, Layers, Globe, Zap, AtSign } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { formatFiat, formatSats } from "../utils/formatters";
@@ -58,6 +58,13 @@ export function NodeSummary({ info, totalBalance, currentRate, currencyAcronym, 
             value={info.blockHeight}
           />
         </>
+      )}
+      {isNwcBackend && info.lud16 && (
+        <StatCard
+          icon={AtSign}
+          label={walletTranslations("nodeInfo.lightningAddress")}
+          value={info.lud16}
+        />
       )}
     </div>
   );

--- a/client/src/components/pages/Store/Wallet/NodeInfo/__tests__/NodeInfo.test.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/__tests__/NodeInfo.test.jsx
@@ -153,6 +153,25 @@ describe("NodeInfo Component", () => {
       expect(screen.getByText("nodeInfo.channels")).toBeInTheDocument();
       expect(screen.getByText("nodeInfo.block")).toBeInTheDocument();
     });
+
+    it("shows the lightning address card when lud16 is present", () => {
+      renderNodeInfo({ ...mockNwcNodeInfo, lud16: "wallet@example.com" });
+
+      expect(screen.getByText("nodeInfo.lightningAddress")).toBeInTheDocument();
+      expect(screen.getByText("wallet@example.com")).toBeInTheDocument();
+    });
+
+    it("hides the lightning address card when lud16 is absent", () => {
+      renderNodeInfo(mockNwcNodeInfo);
+
+      expect(screen.queryByText("nodeInfo.lightningAddress")).not.toBeInTheDocument();
+    });
+
+    it("hides the lightning address card for non-NWC backends even if lud16 is present", () => {
+      renderNodeInfo({ ...mockNodeInfo, lud16: "wallet@example.com" });
+
+      expect(screen.queryByText("nodeInfo.lightningAddress")).not.toBeInTheDocument();
+    });
   });
 
   describe("Channel Details", () => {

--- a/client/src/components/pages/Store/Wallet/NodeInfo/locales/en.js
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/locales/en.js
@@ -5,6 +5,7 @@ const nodeInfoEn = {
     network: "Network",
     channels: "Channels",
     block: "Block",
+    lightningAddress: "Lightning Address",
     subtitle: "Lightning Channels",
     channel: "Channel #",
     sats: "sats",

--- a/client/src/components/pages/Store/Wallet/NodeInfo/locales/es.js
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/locales/es.js
@@ -5,6 +5,7 @@ const nodeInfoEs = {
     network: "Red",
     channels: "Canales",
     block: "Bloque",
+    lightningAddress: "Dirección Lightning",
     subtitle: "Canales Lightning",
     channel: "Canal #",
     sats: "sats",

--- a/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/PhoenixModels.kt
@@ -118,6 +118,7 @@ data class NodeInfo(
     val chain: String,
     val blockHeight: Int?,
     val version: String,
+    val lud16: String? = null,
 )
 
 @Serializable data class PhoenixBalance(

--- a/server/app/src/main/kotlin/pos/ambrosia/services/NwcService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/NwcService.kt
@@ -47,6 +47,7 @@ class NwcService(
     private val walletPubkeyHex: String,
     private val scope: CoroutineScope,
     private val onIncomingPaymentReceived: (PaymentNotification) -> Unit = {},
+    private val lud16: String? = null,
 ) : LightningBackend {
     private data class PendingInvoice(
         val paymentRequest: String,
@@ -166,6 +167,7 @@ class NwcService(
             chain = chain,
             blockHeight = info.blockHeight,
             version = "NWC",
+            lud16 = lud16,
         )
     }
 
@@ -297,7 +299,8 @@ class NwcService(
             val nwcClient = NwcClient(connectionInfo, httpClient)
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-            val service = NwcService(nwcClient, connectionInfo.walletPubkeyHex, scope, onIncomingPaymentReceived)
+            val service =
+                NwcService(nwcClient, connectionInfo.walletPubkeyHex, scope, onIncomingPaymentReceived, connectionInfo.lud16)
 
             scope.launch {
                 connectAndMarkReady(nwcClient, service)

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/NwcServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/NwcServiceTest.kt
@@ -33,6 +33,7 @@ class NwcServiceTest {
     private val mockClient: NwcClientPort = mock()
     private val walletPubkey = "b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4"
     private val service = NwcService(mockClient, walletPubkey, CoroutineScope(SupervisorJob())).also { it.markReady() }
+    private val defaultNip47Info = Nip47Info(pubkey = null, network = "mainnet")
 
     @Test
     fun `createInvoice returns paymentHash and bolt11 from NWC client`() =
@@ -99,7 +100,7 @@ class NwcServiceTest {
     @Test
     fun `getNodeInfo uses wallet pubkey as fallback when NWC omits it`() =
         runBlocking {
-            whenever(mockClient.getInfo()).thenReturn(Nip47Info(pubkey = null, network = "mainnet"))
+            whenever(mockClient.getInfo()).thenReturn(defaultNip47Info)
 
             assertEquals(walletPubkey, service.getNodeInfo().nodeId)
         }
@@ -116,7 +117,7 @@ class NwcServiceTest {
     @Test
     fun `getNodeInfo returns empty channel list`() =
         runBlocking {
-            whenever(mockClient.getInfo()).thenReturn(Nip47Info(pubkey = null, network = "mainnet"))
+            whenever(mockClient.getInfo()).thenReturn(defaultNip47Info)
 
             assertEquals(emptyList(), service.getNodeInfo().channels)
         }
@@ -130,9 +131,28 @@ class NwcServiceTest {
         }
 
     @Test
+    fun `getNodeInfo includes lud16 when the service was constructed with one`() =
+        runBlocking {
+            val serviceWithLud16 =
+                NwcService(mockClient, walletPubkey, CoroutineScope(SupervisorJob()), lud16 = "wallet@example.com")
+                    .also { it.markReady() }
+            whenever(mockClient.getInfo()).thenReturn(defaultNip47Info)
+
+            assertEquals("wallet@example.com", serviceWithLud16.getNodeInfo().lud16)
+        }
+
+    @Test
+    fun `getNodeInfo omits lud16 when the service was constructed without one`() =
+        runBlocking {
+            whenever(mockClient.getInfo()).thenReturn(defaultNip47Info)
+
+            assertEquals(null, service.getNodeInfo().lud16)
+        }
+
+    @Test
     fun `getNodeInfo does not make a redundant get_balance round-trip`() =
         runBlocking<Unit> {
-            whenever(mockClient.getInfo()).thenReturn(Nip47Info(pubkey = null, network = "mainnet"))
+            whenever(mockClient.getInfo()).thenReturn(defaultNip47Info)
 
             service.getNodeInfo()
 
@@ -443,9 +463,9 @@ class NwcServiceTest {
     fun `close cancels coroutine scope and closes underlying NWC client`() {
         val client: NwcClientPort = mock()
         val scope = CoroutineScope(SupervisorJob())
-        val svc = NwcService(client, walletPubkey, scope).also { it.markReady() }
+        val serviceToClose = NwcService(client, walletPubkey, scope).also { it.markReady() }
 
-        svc.close()
+        serviceToClose.close()
 
         verify(client).close()
         assertEquals(false, scope.isActive)


### PR DESCRIPTION
## Changes:

- Expose the connected NWC wallet's `lud16` (Lightning Address) through `NodeInfo`, extracted from the connection URI at `NwcService` construction time.
- Show the Lightning Address as a stat card in `Store/Wallet` when the active backend is NWC and the connection URI provided one.

**Screenshots**:

<img width="581" height="295" alt="Screenshot 2026-08-04 at 5 37 54 p m" src="https://github.com/user-attachments/assets/74874c7d-3406-40fa-a7ad-9aeae487a237" />
