### PR TITLE
Fix/electron skip phoenixd under nwc

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -6,7 +6,7 @@ const AutoUpdater = require('./services/AutoUpdater');
 const { readConfig, writeConfig } = require('./services/ConfigurationBootstrap');
 const ServiceManager = require('./services/ServiceManager');
 const logger = require('./utils/logger');
-const { getPhoenixDataDirectory } = require('./utils/resourcePaths');
+const { getDataDirectory, getPhoenixDataDirectory } = require('./utils/resourcePaths');
 
 // To prevent multiple instances of the application
 const gotTheLock = app.requestSingleInstanceLock();
@@ -366,7 +366,7 @@ app.whenReady().then(async () => {
     // Track service startup progress
     updateSplash(null, 0, 'Initializing...');
 
-    serviceManager.on('service:started', ({ service, port }) => {
+    serviceManager.on('service:started', ({ service, port, skipped }) => {
       logger.log(`[Electron] Service started: ${service} on port ${port}`);
 
       // Update progress based on service
@@ -375,7 +375,7 @@ app.whenReady().then(async () => {
 
       if (service === 'phoenixd') {
         progress = 33;
-        message = 'Lightning Network ready';
+        message = skipped ? 'NWC wallet configured' : 'Lightning Network ready';
         completeSplashStep('phoenixd');
         updateSplash('backend', progress, 'Starting Backend...');
       } else if (service === 'backend') {
@@ -411,7 +411,13 @@ app.whenReady().then(async () => {
       updateSplash(null, 33, 'Development mode');
       updateSplash('nextjs', 66, 'Starting Frontend...');
     } else {
-      updateSplash('phoenixd', 10, 'Starting Lightning Network...');
+      const ambrosiaConfigPath = path.join(getDataDirectory(), 'ambrosia.conf');
+      const nwcUriConfigured = Boolean(readConfig(ambrosiaConfigPath)['nwc-uri']);
+      updateSplash(
+        'phoenixd',
+        10,
+        nwcUriConfigured ? 'Connecting to NWC wallet...' : 'Starting Lightning Network...',
+      );
     }
 
     const url = await serviceManager.startAll();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,7 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-const logger = require('./utils/logger');
-
 const SEND_CHANNELS = ['ping', 'restart-server'];
 
 const INVOKE_CHANNELS = [
@@ -75,4 +73,4 @@ contextBridge.exposeInMainWorld('electron', {
   },
 });
 
-logger.log('[Preload] Electron APIs exposed successfully');
+console.log('[Preload] Electron APIs exposed successfully');

--- a/electron/services/ServiceManager.js
+++ b/electron/services/ServiceManager.js
@@ -66,19 +66,27 @@ class ServiceManager extends EventEmitter {
 
       logger.log('[ServiceManager] Production mode: starting all bundled services');
 
-      // Step 1: Check if phoenixd is already running on default port
-      logger.log('[ServiceManager] Step 1: Checking for existing Phoenixd...');
-      const phoenixdAlreadyRunning = await isPhoenixdRunning(DEFAULT_PORTS.phoenixd);
+      const nwcUriConfigured = Boolean(this.configs.ambrosia['nwc-uri']);
 
-      if (phoenixdAlreadyRunning) {
-        logger.log(`[ServiceManager] Phoenixd already running on port ${DEFAULT_PORTS.phoenixd}, reusing...`);
-        this.ports.phoenixd = DEFAULT_PORTS.phoenixd;
+      // Step 1: Start Phoenixd, unless NWC is the configured Lightning backend
+      if (nwcUriConfigured) {
+        logger.log('[ServiceManager] Step 1: NWC is the configured backend, skipping Phoenixd startup');
         this.externalServices.phoenixd = true;
+        this.emit('service:started', { service: 'phoenixd', port: this.ports.phoenixd, skipped: true });
       } else {
-        logger.log('[ServiceManager] Starting Phoenixd...');
-        await this.phoenixdService.start(this.ports.phoenixd, phoenixConfig);
+        logger.log('[ServiceManager] Step 1: Checking for existing Phoenixd...');
+        const phoenixdAlreadyRunning = await isPhoenixdRunning(DEFAULT_PORTS.phoenixd);
+
+        if (phoenixdAlreadyRunning) {
+          logger.log(`[ServiceManager] Phoenixd already running on port ${DEFAULT_PORTS.phoenixd}, reusing...`);
+          this.ports.phoenixd = DEFAULT_PORTS.phoenixd;
+          this.externalServices.phoenixd = true;
+        } else {
+          logger.log('[ServiceManager] Starting Phoenixd...');
+          await this.phoenixdService.start(this.ports.phoenixd, phoenixConfig);
+        }
+        this.emit('service:started', { service: 'phoenixd', port: this.ports.phoenixd });
       }
-      this.emit('service:started', { service: 'phoenixd', port: this.ports.phoenixd });
 
       // Step 2: Check if backend is already running on default port
       logger.log('[ServiceManager] Step 2: Checking for existing Backend...');

--- a/server/app/src/main/kotlin/pos/ambrosia/config/AppConfig.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/config/AppConfig.kt
@@ -27,16 +27,18 @@ object AppConfig {
             FileInputStream(configFile).use { fis ->
                 properties.load(fis)
             }
-        } catch (e: Exception) {
+        } catch (exception: Exception) {
             logger.error("Error loading configuration from {}", configFile)
         }
 
-        try {
-            FileInputStream(phoenixConfFile).use { fis ->
-                phoenixProperties.load(fis)
+        if (properties.getProperty("nwc-uri").isNullOrBlank()) {
+            try {
+                FileInputStream(phoenixConfFile).use { fis ->
+                    phoenixProperties.load(fis)
+                }
+            } catch (exception: Exception) {
+                logger.error("Error loading Phoenix configuration from {}", phoenixConfFile)
             }
-        } catch (e: Exception) {
-            logger.error("Error loading Phoenix configuration from {}", phoenixConfFile)
         }
     }
 
@@ -46,7 +48,7 @@ object AppConfig {
 
         try {
             seed = seedFile.readText()
-        } catch (e: Exception) {
+        } catch (exception: Exception) {
             logger.error("Error loading Phoenix seed from {}", seedFile)
         }
         return seed


### PR DESCRIPTION
## Changes:

- Skip starting `phoenixd` in the Electron app when NWC is the configured Lightning backend, instead of always starting it regardless of the user's onboarding choice. The splash screen still reports the step as complete (with an NWC-specific message) so its progress sequence isn't disrupted.
- Skip loading `phoenix.conf` on the server when NWC is configured, avoiding a misleading error log on every boot of a deployment that never has that file.