### PR TITLE
Fix/close channel disabled phoenixd

### DIFF
--- a/client/src/components/pages/Store/Wallet/NodeInfo/ChannelCard.jsx
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/ChannelCard.jsx
@@ -17,7 +17,7 @@ const CLOSING_STATES = {
 function ChannelStateLabel({ state }) {
   const walletTranslations = useTranslations("wallet");
 
-  if (state === CHANNEL_STATE_NORMAL) {
+  if (state?.toUpperCase() === CHANNEL_STATE_NORMAL) {
     return (
       <div className="flex items-center space-x-1 mt-1">
         <span className="w-2 h-2 rounded-full bg-green-500" />
@@ -44,7 +44,7 @@ function ChannelStateLabel({ state }) {
 
 export function ChannelCard({ channel, index, onClose }) {
   const walletTranslations = useTranslations("wallet");
-  const isNormal = channel.state === CHANNEL_STATE_NORMAL;
+  const isNormal = channel.state?.toUpperCase() === CHANNEL_STATE_NORMAL;
 
   return (
     <Card className="border" shadow="none">


### PR DESCRIPTION
## Changes:

- Compare channel state case-insensitively in `ChannelCard.jsx` so the Close Channel button and NORMAL state label work correctly with real phoenixd channels, matching the case-insensitive comparison already used in `NodeSummary.jsx`