### PR TITLE
Chore/admin auth test fixture

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -63,7 +63,6 @@ public val logger = LoggerFactory.getLogger("Server")
 class Api {
     fun Application.module() {
         AppConfig.loadConfig() // Load the configuration
-        val config = environment.config // Configure the application
         handler() // Install exception handlers
         install(ContentNegotiation) { json() }
         install(CORS) {
@@ -79,73 +78,7 @@ class Api {
             timeout = 15.seconds
         }
 
-        install(Authentication) {
-            jwt("auth-jwt") {
-                authHeader { call ->
-                    try {
-                        val token = call.request.cookies["accessToken"]
-                        if (token != null) {
-                            HttpAuthHeader.Single("Bearer", token)
-                        } else {
-                            null
-                        }
-                    } catch (cause: Throwable) {
-                        null
-                    }
-                }
-                verifier(
-                    JWT
-                        .require(Algorithm.HMAC256(config.property("secret").getString()))
-                        .withIssuer(config.property("jwt.issuer").getString())
-                        .withAudience(config.property("jwt.audience").getString())
-                        .withClaim("realm", "Ambrosia-Server")
-                        .build(),
-                )
-                validate { credential ->
-                    if (credential.payload.getClaim("userId").asString() != "") {
-                        JWTPrincipal(credential.payload)
-                    } else {
-                        null
-                    }
-                }
-                challenge { _, _ -> throw UnauthorizedApiException() }
-            }
-
-            jwt("auth-jwt-wallet") {
-                authHeader { call ->
-                    try {
-                        val token = call.request.cookies["walletAccessToken"]
-                        if (token != null) {
-                            HttpAuthHeader.Single("Bearer", token)
-                        } else {
-                            null
-                        }
-                    } catch (cause: Throwable) {
-                        null
-                    }
-                }
-                verifier(
-                    JWT
-                        .require(Algorithm.HMAC256(config.property("secret").getString()))
-                        .withIssuer(config.property("jwt.issuer").getString())
-                        .withAudience(config.property("jwt.audience").getString())
-                        .withClaim("realm", "Ambrosia-Server")
-                        .build(),
-                )
-                validate { credential ->
-                    val scope = credential.payload.getClaim("scope").asString()
-                    val userId = credential.payload.getClaim("userId").asString()
-                    val walletAccessToken = request.cookies["walletAccessToken"]
-                    val tokenService = TokenService(application.environment)
-                    val isValidWalletSession =
-                        scope == "wallet_access" &&
-                            userId.isNotEmpty() &&
-                            walletAccessToken != null &&
-                            tokenService.isWalletTokenValid(userId, walletAccessToken)
-                    if (isValidWalletSession) JWTPrincipal(credential.payload) else null
-                }
-            }
-        }
+        configureAuthentication()
         configureRouting()
         configureAuth()
         configureAdminNotifications()
@@ -180,5 +113,77 @@ class Api {
         }
         configurePaymentWebsocket()
         configureHealth()
+    }
+}
+
+fun Application.configureAuthentication() {
+    val applicationConfig = environment.config
+
+    install(Authentication) {
+        jwt("auth-jwt") {
+            authHeader { call ->
+                try {
+                    val token = call.request.cookies["accessToken"]
+                    if (token != null) {
+                        HttpAuthHeader.Single("Bearer", token)
+                    } else {
+                        null
+                    }
+                } catch (cause: Throwable) {
+                    null
+                }
+            }
+            verifier(
+                JWT
+                    .require(Algorithm.HMAC256(applicationConfig.property("secret").getString()))
+                    .withIssuer(applicationConfig.property("jwt.issuer").getString())
+                    .withAudience(applicationConfig.property("jwt.audience").getString())
+                    .withClaim("realm", "Ambrosia-Server")
+                    .build(),
+            )
+            validate { credential ->
+                if (credential.payload.getClaim("userId").asString() != "") {
+                    JWTPrincipal(credential.payload)
+                } else {
+                    null
+                }
+            }
+            challenge { _, _ -> throw UnauthorizedApiException() }
+        }
+
+        jwt("auth-jwt-wallet") {
+            authHeader { call ->
+                try {
+                    val token = call.request.cookies["walletAccessToken"]
+                    if (token != null) {
+                        HttpAuthHeader.Single("Bearer", token)
+                    } else {
+                        null
+                    }
+                } catch (cause: Throwable) {
+                    null
+                }
+            }
+            verifier(
+                JWT
+                    .require(Algorithm.HMAC256(applicationConfig.property("secret").getString()))
+                    .withIssuer(applicationConfig.property("jwt.issuer").getString())
+                    .withAudience(applicationConfig.property("jwt.audience").getString())
+                    .withClaim("realm", "Ambrosia-Server")
+                    .build(),
+            )
+            validate { credential ->
+                val scope = credential.payload.getClaim("scope").asString()
+                val userId = credential.payload.getClaim("userId").asString()
+                val walletAccessToken = request.cookies["walletAccessToken"]
+                val tokenService = TokenService(application.environment)
+                val isValidWalletSession =
+                    scope == "wallet_access" &&
+                        userId.isNotEmpty() &&
+                        walletAccessToken != null &&
+                        tokenService.isWalletTokenValid(userId, walletAccessToken)
+                if (isValidWalletSession) JWTPrincipal(credential.payload) else null
+            }
+        }
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/AdminAuthTestFixtureTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/AdminAuthTestFixtureTest.kt
@@ -1,0 +1,82 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.handler
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.authenticateAdmin
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installNonAdminAuth
+import pos.ambrosia.utils.withAuthCookies
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AdminAuthTestFixtureTest {
+    private lateinit var databaseFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    private fun adminOnlyRouteStatus(
+        attachCookies: Boolean = true,
+        installAuth: ApplicationTestBuilder.() -> AuthCookies,
+    ): HttpStatusCode {
+        lateinit var capturedAdminOnlyRouteStatus: HttpStatusCode
+        testApplication {
+            val authCookies = installAuth()
+            application {
+                this@application.install(ContentNegotiation) { json() }
+                handler()
+                routing {
+                    authenticateAdmin {
+                        get("/admin-only") { call.respond(HttpStatusCode.OK) }
+                    }
+                }
+            }
+
+            val adminOnlyRouteResponse = client.get("/admin-only") { if (attachCookies) withAuthCookies(authCookies) }
+            capturedAdminOnlyRouteStatus = adminOnlyRouteResponse.status
+        }
+        return capturedAdminOnlyRouteStatus
+    }
+
+    @Test
+    fun `request without auth cookies is rejected as unauthorized`() {
+        val actualStatus = adminOnlyRouteStatus(attachCookies = false) { installAdminAuth() }
+
+        assertEquals(HttpStatusCode.Unauthorized, actualStatus)
+    }
+
+    @Test
+    fun `request with real admin cookies reaches the protected route`() {
+        val actualStatus = adminOnlyRouteStatus { installAdminAuth() }
+
+        assertEquals(HttpStatusCode.OK, actualStatus)
+    }
+
+    @Test
+    fun `request with real non-admin cookies is rejected as forbidden`() {
+        val actualStatus = adminOnlyRouteStatus { installNonAdminAuth() }
+
+        assertEquals(HttpStatusCode.Forbidden, actualStatus)
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
@@ -1,0 +1,75 @@
+package pos.ambrosia.utils
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.applicationEnvironment
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.configureAuthentication
+import pos.ambrosia.models.AuthResponse
+import pos.ambrosia.services.TokenService
+
+private const val TEST_SECRET = "admin-auth-test-fixture-secret"
+private const val TEST_ISSUER = "admin-auth-test-fixture-issuer"
+private const val TEST_AUDIENCE = "admin-auth-test-fixture-audience"
+
+data class AuthCookies(
+    val accessToken: String,
+    val refreshToken: String,
+)
+
+fun ApplicationTestBuilder.installAdminAuth(
+    roleName: String = "admin-test-role",
+    userName: String = "admin-test-user",
+): AuthCookies = installAuth(roleName, userName, isAdmin = true)
+
+fun ApplicationTestBuilder.installNonAdminAuth(
+    roleName: String = "non-admin-test-role",
+    userName: String = "non-admin-test-user",
+): AuthCookies = installAuth(roleName, userName, isAdmin = false)
+
+private fun ApplicationTestBuilder.installAuth(
+    roleName: String,
+    userName: String,
+    isAdmin: Boolean,
+): AuthCookies {
+    val testApplicationConfig =
+        MapApplicationConfig(
+            "secret" to TEST_SECRET,
+            "jwt.issuer" to TEST_ISSUER,
+            "jwt.audience" to TEST_AUDIENCE,
+        )
+
+    environment {
+        config = testApplicationConfig
+    }
+    application {
+        configureAuthentication()
+    }
+
+    val roleId = ExposedTestDb.seedRole(roleName, isAdmin = isAdmin)
+    val userId = ExposedTestDb.seedUser(userName, roleId)
+
+    val tokenService = TokenService(applicationEnvironment { config = testApplicationConfig })
+    val seededUser =
+        AuthResponse(
+            id = userId,
+            name = userName,
+            roleId = roleId,
+            role = roleName,
+            isAdmin = isAdmin,
+        )
+
+    return AuthCookies(
+        accessToken = tokenService.generateAccessToken(seededUser),
+        refreshToken = tokenService.generateRefreshToken(seededUser),
+    )
+}
+
+fun HttpRequestBuilder.withAuthCookies(cookies: AuthCookies) {
+    header(
+        HttpHeaders.Cookie,
+        "accessToken=${cookies.accessToken}; refreshToken=${cookies.refreshToken}",
+    )
+}


### PR DESCRIPTION
## Changes:

- Extract the inline `install(Authentication) { ... }` block from `Api().module()` into a top-level `configureAuthentication()` function in `Api.kt`, matching the pattern of its other `configureXxx()` neighbors, so it can be reused by test code without duplicating the auth setup
- Add `AdminAuthTestFixture.kt`, a reusable test helper that seeds a real admin (or non-admin) user via `ExposedTestDb`, generates real `accessToken`/`refreshToken` JWTs via `TokenService`, and installs `configureAuthentication()` on a `testApplication`, enabling end-to-end tests of routes protected by `authenticateAdmin`
- Add `AdminAuthTestFixtureTest.kt` validating the fixture against a minimal `authenticateAdmin`-protected route: unauthenticated requests get 401, non-admin requests get 403, and real admin requests reach the route