### PR TITLE
Fix/wallet node unavailable hang

### DIFF
--- a/client/src/components/pages/Store/Wallet/NodeInfo/locales/en.js
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/locales/en.js
@@ -14,7 +14,7 @@ const nodeInfoEn = {
     inboundLiquidity: "Inbound Liquidity:",
     fetchInfoError: "Error fetching wallet information",
     getInfoErrorDescription: "Could not load wallet information",
-    nodeUnavailable: "Lightning node is not available. Make sure phoenixd is running.",
+    nodeUnavailable: "Could not connect to your Lightning wallet. Please try again in a moment.",
     noChannels: "No active Lightning channels",
     stateShuttingDown: "Closing — settling pending payments",
     stateNegotiating: "Closing — finalizing closing transaction",

--- a/client/src/components/pages/Store/Wallet/NodeInfo/locales/es.js
+++ b/client/src/components/pages/Store/Wallet/NodeInfo/locales/es.js
@@ -14,7 +14,7 @@ const nodeInfoEs = {
     inboundLiquidity: "Liquidez Entrante:",
     fetchInfoError: "Error al obtener la información de la wallet",
     getInfoErrorDescription: "No se pudo cargar la información de la wallet",
-    nodeUnavailable: "El nodo Lightning no está disponible. Verifica que phoenixd esté corriendo.",
+    nodeUnavailable: "No se pudo conectar con tu wallet Lightning. Intentá de nuevo en un momento.",
     noChannels: "No hay canales Lightning activos",
     stateShuttingDown: "Cerrando — liquidando pagos pendientes",
     stateNegotiating: "Cerrando — finalizando la transacción de cierre",

--- a/client/src/components/pages/Store/Wallet/StoreWallet.jsx
+++ b/client/src/components/pages/Store/Wallet/StoreWallet.jsx
@@ -29,6 +29,7 @@ export function StoreWallet() {
   const { currency } = useCurrency();
   const { currentRate } = useBitcoinPrice({ currencyAcronym: currency.acronym });
   const [info, setInfo] = useState(null);
+  const [infoLoading, setInfoLoading] = useState(true);
   const [balance, setBalance] = useState(null);
   const [transactions, setTransactions] = useState([]);
   const [error, setError] = useState("");
@@ -41,6 +42,7 @@ export function StoreWallet() {
 
   const fetchInfo = useCallback(async () => {
     try {
+      setInfoLoading(true);
       const [infoResponse, balanceResponse] = await Promise.all([getInfo(), getBalance()]);
       setInfo(infoResponse);
       setBalance(balanceResponse);
@@ -54,6 +56,8 @@ export function StoreWallet() {
         variant: "solid",
         color: "danger",
       });
+    } finally {
+      setInfoLoading(false);
     }
   }, [walletTranslations]);
 
@@ -62,15 +66,11 @@ export function StoreWallet() {
       try {
         setLoading(true);
         setTransactions([]);
-        let incoming = [];
-        let outgoing = [];
 
-        if (filter === "incoming" || filter === "all") {
-          incoming = await getIncomingTransactions();
-        }
-        if (filter === "outgoing" || filter === "all") {
-          outgoing = await getOutgoingTransactions();
-        }
+        const [incoming, outgoing] = await Promise.all([
+          filter === "incoming" || filter === "all" ? getIncomingTransactions() : [],
+          filter === "outgoing" || filter === "all" ? getOutgoingTransactions() : [],
+        ]);
 
         const allTx = [...incoming, ...outgoing].sort(
           (a, b) => b.completedAt - a.completedAt,
@@ -119,7 +119,7 @@ export function StoreWallet() {
     return () => off?.();
   }, [onPayment, invoiceActions]);
 
-  if (!info) {
+  if (infoLoading) {
     return (
       <Card className="w-full max-w-md shadow-2xl border-0 bg-white">
         <CardBody className="flex flex-col items-center justify-center py-12">

--- a/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
@@ -65,6 +65,24 @@ function renderStoreWallet() {
   );
 }
 
+async function authenticateAndWait() {
+  await act(async () => {
+    renderStoreWallet();
+  });
+
+  const passwordInput = screen.getByLabelText("access.passwordLabel");
+  const confirmButton = screen.getByText("access.confirmText");
+
+  await userEvent.type(passwordInput, "password123");
+  await act(async () => {
+    fireEvent.click(confirmButton);
+  });
+
+  await waitFor(() => {
+    expect(walletService.getInfo).toHaveBeenCalled();
+  });
+}
+
 const originalWarn = console.warn;
 const originalError = console.error;
 
@@ -253,24 +271,6 @@ describe("StoreWallet Component", () => {
   });
 
   describe("Wallet Content After Authentication", () => {
-    async function authenticateAndWait() {
-      await act(async () => {
-        renderStoreWallet();
-      });
-
-      const passwordInput = screen.getByLabelText("access.passwordLabel");
-      const confirmButton = screen.getByText("access.confirmText");
-
-      await userEvent.type(passwordInput, "password123");
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
-
-      await waitFor(() => {
-        expect(walletService.getInfo).toHaveBeenCalled();
-      });
-    }
-
     it("fetches and displays node info after authentication", async () => {
       await authenticateAndWait();
 
@@ -293,6 +293,23 @@ describe("StoreWallet Component", () => {
       await waitFor(() => {
         expect(walletService.getIncomingTransactions).toHaveBeenCalled();
         expect(walletService.getOutgoingTransactions).toHaveBeenCalled();
+      });
+    });
+
+    it("fetches incoming and outgoing transactions concurrently, not sequentially", async () => {
+      let resolveIncoming;
+      jest.spyOn(walletService, "getIncomingTransactions").mockImplementation(
+        () => new Promise((resolve) => { resolveIncoming = resolve; }),
+      );
+
+      await authenticateAndWait();
+
+      await waitFor(() => {
+        expect(walletService.getOutgoingTransactions).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        resolveIncoming(mockIncomingTransactions);
       });
     });
 
@@ -320,45 +337,29 @@ describe("StoreWallet Component", () => {
   });
 
   describe("Error Handling", () => {
-    it("handles phoenixd connection error gracefully", async () => {
+    it("clears the loading spinner and shows NodeError when node info fails to load", async () => {
       jest.spyOn(walletService, "getInfo").mockRejectedValue(new Error("Connection failed"));
 
-      await act(async () => {
-        renderStoreWallet();
-      });
-
-      const passwordInput = screen.getByLabelText("access.passwordLabel");
-      const confirmButton = screen.getByText("access.confirmText");
-
-      await userEvent.type(passwordInput, "password123");
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
+      await authenticateAndWait();
 
       await waitFor(() => {
-        expect(walletService.getInfo).toHaveBeenCalled();
+        expect(screen.getByText("nodeInfo.fetchInfoError")).toBeInTheDocument();
       });
+
+      expect(screen.queryByText("loadingMessage")).not.toBeInTheDocument();
     });
 
-    it("handles transaction fetch error", async () => {
+    it("falls back to the empty transactions state when the transaction fetch fails", async () => {
       jest.spyOn(walletService, "getIncomingTransactions").mockRejectedValue(
         new Error("Failed to fetch"),
       );
 
-      await act(async () => {
-        renderStoreWallet();
-      });
+      await authenticateAndWait();
 
-      const passwordInput = screen.getByLabelText("access.passwordLabel");
-      const confirmButton = screen.getByText("access.confirmText");
-
-      await userEvent.type(passwordInput, "password123");
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
+      await userEvent.click(screen.getByText("payments.history.tabTitle"));
 
       await waitFor(() => {
-        expect(walletService.getIncomingTransactions).toHaveBeenCalled();
+        expect(screen.getByText("payments.history.noTx")).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
## Changes:

- Fix `StoreWallet.jsx` so the `/store/wallet` page no longer hangs on the "Loading wallet info..." spinner when the active Lightning backend (NWC or phoenixd) fails to respond — a new `infoLoading` flag (cleared in `fetchInfo`'s `finally`) replaces the old `if (!info)` render gate, which never released on error and left `NodeError` permanently unreachable
- Parallelize `fetchTransactions`'s incoming/outgoing fetches with `Promise.all` instead of awaiting them sequentially, halving the worst-case wait under NWC's per-request timeout
- Generalize the `nodeInfo.nodeUnavailable` message (`NodeInfo/locales/en.js`/`es.js`) to no longer assume phoenixd specifically, since the error card is now reachable for both backends
- Update `StoreWallet.test.jsx`: strengthen the error-handling tests to assert the actual resulting UI (`NodeError` text, spinner gone, transactions empty-state fallback) instead of only checking that a mock was called, and add a regression test covering the new concurrent transaction fetch

**Screenshots**:

<img width="1476" height="406" alt="imagen" src="https://github.com/user-attachments/assets/06c37f64-29ac-4c81-8dfb-bd4c726a550d" />
